### PR TITLE
Add HTTP data types and response serialization

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,16 @@ Built on lori (v0.8.1). Lori provides raw TCP I/O with a connection-actor model:
 
 See [Discussion #2](https://github.com/ponylang/lori_http_server/discussions/2) for the phased implementation plan.
 
+## Release Notes
+
+No release notes until after the first release. This project is pre-1.0 and hasn't been released yet — there are no users to notify of changes.
+
 ## File Layout
 
 - `http_server/` — main package source
+  - `method.pony` — HTTP method types (`Method` interface, 9 primitives, `Methods` parse/enumerate)
+  - `version.pony` — HTTP version types (`HTTP10`, `HTTP11`, `Version` closed union)
+  - `status.pony` — HTTP status codes (`Status` interface, 35 standard primitives)
+  - `headers.pony` — Case-insensitive header collection (`Headers` class)
+  - `_response_serializer.pony` — Response wire-format serializer (package-private)
 - `examples/` — example programs

--- a/http_server/_response_serializer.pony
+++ b/http_server/_response_serializer.pony
@@ -1,0 +1,51 @@
+primitive _ResponseSerializer
+  """
+  Serialize HTTP response components into wire format bytes.
+
+  Produces the standard HTTP/1.x response format:
+  ```
+  HTTP/1.1 200 OK\r\n
+  header-name: value\r\n
+  \r\n
+  <body bytes>
+  ```
+  """
+
+  fun apply(
+    status: Status,
+    headers: Headers val,
+    body: (ByteSeq | None) = None,
+    version: Version = HTTP11)
+    : Array[U8] iso^
+  =>
+    """Serialize a response to wire format bytes."""
+    recover iso
+      let buf = Array[U8]
+
+      // Status line: "HTTP/1.1 200 OK\r\n"
+      buf.>append(version.string())
+        .>push(' ')
+        .>append(status.code().string())
+        .>push(' ')
+        .>append(status.reason())
+        .>append("\r\n")
+
+      // Headers
+      for (name, value) in headers.values() do
+        buf.>append(name)
+          .>append(": ")
+          .>append(value)
+          .>append("\r\n")
+      end
+
+      // Blank line separating headers from body
+      buf.append("\r\n")
+
+      // Body
+      match body
+      | let b: String val => buf.append(b)
+      | let b: Array[U8] val => buf.append(b)
+      end
+
+      buf
+    end

--- a/http_server/_test.pony
+++ b/http_server/_test.pony
@@ -1,8 +1,26 @@
 use "pony_test"
+use "pony_check"
 
 actor \nodoc\ Main is TestList
   new create(env: Env) =>
     PonyTest(env, this)
 
   fun tag tests(test: PonyTest) =>
-    None
+    // Method tests
+    test(Property1UnitTest[String val](_PropertyValidMethodParsesCorrectly))
+    test(Property1UnitTest[String val](_PropertyInvalidMethodReturnsNone))
+    test(Property1UnitTest[(String val, Bool)](
+      _PropertyMethodParseBoundary))
+
+    // Headers tests
+    test(Property1UnitTest[(String val, String val)](
+      _PropertyHeadersCaseInsensitive))
+    test(Property1UnitTest[(String val, String val, String val)](
+      _PropertyHeadersSetReplaces))
+    test(Property1UnitTest[(String val, String val, String val)](
+      _PropertyHeadersAddPreserves))
+
+    // Response serializer tests
+    test(Property1UnitTest[_ResponseInput](
+      _PropertyResponseWireFormat))
+    test(_TestResponseSerializerKnownGood)

--- a/http_server/_test_headers.pony
+++ b/http_server/_test_headers.pony
@@ -1,0 +1,99 @@
+use "pony_check"
+
+class \nodoc\ iso _PropertyHeadersCaseInsensitive
+  is Property1[(String val, String val)]
+  """
+  Adding a header and retrieving it with a different case variant returns
+  the same value.
+  """
+  fun name(): String => "headers/case_insensitive"
+
+  fun gen(): Generator[(String val, String val)] =>
+    Generators.zip2[String val, String val](
+      Generators.ascii_letters(1, 20),
+      Generators.ascii_printable(1, 50))
+
+  fun ref property(
+    arg1: (String val, String val),
+    ph: PropertyHelper)
+  =>
+    (let header_name, let value) = arg1
+    let headers = Headers
+    headers.add(header_name, value)
+
+    // Retrieve with different case variants
+    ph.assert_eq[String val](value, _get_or_empty(headers, header_name.upper()))
+    ph.assert_eq[String val](value, _get_or_empty(headers, header_name.lower()))
+
+  fun _get_or_empty(headers: Headers box, header_name: String): String val =>
+    match headers.get(header_name)
+    | let v: String val => v
+    else
+      ""
+    end
+
+class \nodoc\ iso _PropertyHeadersSetReplaces
+  is Property1[(String val, String val, String val)]
+  """
+  Calling `set()` twice for the same name keeps only the second value.
+  """
+  fun name(): String => "headers/set_replaces"
+
+  fun gen(): Generator[(String val, String val, String val)] =>
+    Generators.zip3[String val, String val, String val](
+      Generators.ascii_letters(1, 20),
+      Generators.ascii_printable(1, 50),
+      Generators.ascii_printable(1, 50))
+
+  fun ref property(
+    arg1: (String val, String val, String val),
+    ph: PropertyHelper)
+  =>
+    (let header_name, let v1, let v2) = arg1
+    let headers = Headers
+    headers.set(header_name, v1)
+    headers.set(header_name, v2)
+
+    ph.assert_eq[USize](1, headers.size())
+    ph.assert_eq[String val](v2, _get_or_empty(headers, header_name))
+
+  fun _get_or_empty(headers: Headers box, header_name: String): String val =>
+    match headers.get(header_name)
+    | let v: String val => v
+    else
+      ""
+    end
+
+class \nodoc\ iso _PropertyHeadersAddPreserves
+  is Property1[(String val, String val, String val)]
+  """
+  Calling `add()` twice for the same name keeps both values. `get()` returns
+  the first, and `size()` reflects both entries.
+  """
+  fun name(): String => "headers/add_preserves"
+
+  fun gen(): Generator[(String val, String val, String val)] =>
+    Generators.zip3[String val, String val, String val](
+      Generators.ascii_letters(1, 20),
+      Generators.ascii_printable(1, 50),
+      Generators.ascii_printable(1, 50))
+
+  fun ref property(
+    arg1: (String val, String val, String val),
+    ph: PropertyHelper)
+  =>
+    (let header_name, let v1, let v2) = arg1
+    let headers = Headers
+    headers.add(header_name, v1)
+    headers.add(header_name, v2)
+
+    ph.assert_eq[USize](2, headers.size())
+    // get() returns the first value added
+    ph.assert_eq[String val](v1, _get_or_empty(headers, header_name))
+
+  fun _get_or_empty(headers: Headers box, header_name: String): String val =>
+    match headers.get(header_name)
+    | let v: String val => v
+    else
+      ""
+    end

--- a/http_server/_test_method.pony
+++ b/http_server/_test_method.pony
@@ -1,0 +1,94 @@
+use "pony_check"
+
+class \nodoc\ iso _PropertyValidMethodParsesCorrectly is Property1[String val]
+  fun name(): String => "method/valid_parse"
+
+  fun gen(): Generator[String val] =>
+    Generators.one_of[String val](
+      ["GET"; "HEAD"; "POST"; "PUT"; "DELETE"
+       "CONNECT"; "OPTIONS"; "TRACE"; "PATCH"])
+
+  fun ref property(arg1: String val, ph: PropertyHelper) =>
+    match Methods.parse(arg1)
+    | let m: Method =>
+      ph.assert_eq[String val](arg1, m.string())
+    else
+      ph.fail("valid method string should parse: " + arg1)
+    end
+
+class \nodoc\ iso _PropertyInvalidMethodReturnsNone is Property1[String val]
+  fun name(): String => "method/invalid_returns_none"
+
+  fun gen(): Generator[String val] =>
+    Generators.frequency[String val]([
+      as WeightedGenerator[String val]:
+      // empty string
+      (1, Generators.unit[String val](""))
+      // wrong case
+      (1, Generators.one_of[String val](
+        ["get"; "head"; "post"; "put"; "delete"
+         "connect"; "options"; "trace"; "patch"]))
+      // valid method with extra chars appended
+      (1, Generators.one_of[String val](
+        ["GETX"; "POSTY"; "PUTS"; "DELETES"
+         "HEADS"; "CONNECTX"; "OPTIONS!"; "TRACES"; "PATCHX"]))
+      // truncated valid methods
+      (1, Generators.one_of[String val](
+        ["GE"; "HEA"; "POS"; "PU"; "DELET"
+         "CONNEC"; "OPTION"; "TRAC"; "PATC"]))
+      // numeric strings
+      (1, Generators.ascii_numeric(1, 10))
+      // random ASCII (vanishingly small chance of being a valid method)
+      (2, Generators.ascii(1, 20))
+    ])
+
+  fun ref property(arg1: String val, ph: PropertyHelper) =>
+    ph.assert_true(
+      Methods.parse(arg1) is None,
+      "invalid method string should not parse: " + arg1)
+
+class \nodoc\ iso _PropertyMethodParseBoundary
+  is Property1[(String val, Bool)]
+  fun name(): String => "method/parse_boundary"
+
+  fun gen(): Generator[(String val, Bool)] =>
+    let valid_gen: Generator[(String val, Bool)] =
+      Generators.one_of[String val](
+        ["GET"; "HEAD"; "POST"; "PUT"; "DELETE"
+         "CONNECT"; "OPTIONS"; "TRACE"; "PATCH"])
+        .map[( String val, Bool)]({(s) => (s, true) })
+
+    let invalid_gen: Generator[(String val, Bool)] =
+      Generators.frequency[String val]([
+        as WeightedGenerator[String val]:
+        (1, Generators.unit[String val](""))
+        (1, Generators.one_of[String val](
+          ["get"; "head"; "post"; "put"; "delete"
+           "connect"; "options"; "trace"; "patch"]))
+        (1, Generators.one_of[String val](
+          ["GETX"; "POSTY"; "PUTS"; "DELETES"]))
+        (1, Generators.ascii_numeric(1, 10))
+        (2, Generators.ascii(1, 20))
+      ]).map[(String val, Bool)]({(s) => (s, false) })
+
+    Generators.frequency[(String val, Bool)]([
+      as WeightedGenerator[(String val, Bool)]:
+      (1, valid_gen)
+      (1, invalid_gen)
+    ])
+
+  fun ref property(arg1: (String val, Bool), ph: PropertyHelper) =>
+    (let input, let should_parse) = arg1
+    let result = Methods.parse(input)
+    if should_parse then
+      match result
+      | let m: Method =>
+        ph.assert_eq[String val](input, m.string())
+      else
+        ph.fail("expected parse success for: " + input)
+      end
+    else
+      ph.assert_true(
+        result is None,
+        "expected parse failure for: " + input)
+    end

--- a/http_server/_test_response_serializer.pony
+++ b/http_server/_test_response_serializer.pony
@@ -1,0 +1,163 @@
+use "pony_check"
+use "pony_test"
+
+class val _ResponseInput is Stringable
+  """Test input: indices and sizes that the property uses to build a response."""
+  let status_idx: USize
+  let num_headers: USize
+  let body_size: USize
+
+  new val create(si: USize, nh: USize, bs: USize) =>
+    status_idx = si
+    num_headers = nh
+    body_size = bs
+
+  fun string(): String iso^ =>
+    recover iso
+      String.>append("ResponseInput(status_idx=")
+        .>append(status_idx.string())
+        .>append(", num_headers=")
+        .>append(num_headers.string())
+        .>append(", body_size=")
+        .>append(body_size.string())
+        .>append(")")
+    end
+
+class \nodoc\ iso _PropertyResponseWireFormat is Property1[_ResponseInput]
+  """
+  Serialized responses have valid HTTP wire format structure: status line,
+  headers with `: ` separator, blank line, then body.
+  """
+  fun name(): String => "response_serializer/wire_format"
+
+  fun gen(): Generator[_ResponseInput] =>
+    Generators.map3[USize, USize, USize, _ResponseInput](
+      Generators.usize(0, 5),
+      Generators.usize(0, 5),
+      Generators.usize(0, 100),
+      {(si, nh, bs) => _ResponseInput(si, nh, bs) })
+
+  fun ref property(arg1: _ResponseInput, ph: PropertyHelper) =>
+    let statuses: Array[Status val] val =
+      [StatusOK; StatusCreated; StatusNoContent
+       StatusBadRequest; StatusNotFound
+       StatusInternalServerError]
+
+    let status = try
+      statuses(arg1.status_idx % statuses.size())?
+    else
+      StatusOK
+    end
+
+    let headers = recover val
+      let h = Headers
+      var i: USize = 0
+      while i < arg1.num_headers do
+        h.add("header-" + i.string(), "value-" + i.string())
+        i = i + 1
+      end
+      h
+    end
+
+    let body: (ByteSeq | None) = if arg1.body_size > 0 then
+      recover val
+        let arr = Array[U8](arg1.body_size)
+        var i: USize = 0
+        while i < arg1.body_size do
+          arr.push('X')
+          i = i + 1
+        end
+        arr
+      end
+    else
+      None
+    end
+
+    let result: Array[U8] val = _ResponseSerializer(status, headers, body)
+    let output = String.from_array(result)
+
+    // Verify status line starts with HTTP/1.1
+    ph.assert_true(
+      output.contains("HTTP/1.1 "),
+      "output should contain HTTP/1.1")
+
+    // Verify status code and reason appear
+    let code_str: String val = status.code().string()
+    ph.assert_true(
+      output.contains(code_str),
+      "output should contain status code " + code_str)
+    ph.assert_true(
+      output.contains(status.reason()),
+      "output should contain reason phrase " + status.reason())
+
+    // Verify header/body separator exists
+    ph.assert_true(
+      output.contains("\r\n\r\n"),
+      "output should contain blank line separator")
+
+    // Verify each header appears in output
+    var i: USize = 0
+    while i < arg1.num_headers do
+      let expected_header: String val =
+        "header-" + i.string() + ": " + "value-" + i.string() + "\r\n"
+      ph.assert_true(
+        output.contains(expected_header),
+        "output should contain header: " + expected_header)
+      i = i + 1
+    end
+
+    // Verify body size
+    let sep_pos = try
+      output.find("\r\n\r\n")?
+    else
+      ph.fail("no header/body separator found")
+      return
+    end
+    let body_start = sep_pos + 4
+    let actual_body_size = output.size() - body_start.usize()
+    ph.assert_eq[USize](arg1.body_size, actual_body_size, "body size mismatch")
+
+class \nodoc\ iso _TestResponseSerializerKnownGood is UnitTest
+  """
+  Verify exact byte output for known HTTP responses.
+  """
+  fun name(): String => "response_serializer/known_good"
+
+  fun apply(h: TestHelper) =>
+    _test_200_no_headers_no_body(h)
+    _test_200_with_header_and_body(h)
+    _test_404_no_body(h)
+
+  fun _test_200_no_headers_no_body(h: TestHelper) =>
+    let headers = recover val Headers end
+    let result: Array[U8] val = _ResponseSerializer(StatusOK, headers)
+    let expected = "HTTP/1.1 200 OK\r\n\r\n"
+    h.assert_eq[String val](
+      expected,
+      String.from_array(result),
+      "200 OK, no headers, no body")
+
+  fun _test_200_with_header_and_body(h: TestHelper) =>
+    let headers = recover val
+      let hd = Headers
+      hd.set("content-type", "text/plain")
+      hd
+    end
+    let body: Array[U8] val = "Hello, World!".array()
+    let result: Array[U8] val =
+      _ResponseSerializer(StatusOK, headers, body)
+    let expected =
+      "HTTP/1.1 200 OK\r\ncontent-type: text/plain\r\n\r\nHello, World!"
+    h.assert_eq[String val](
+      expected,
+      String.from_array(result),
+      "200 OK with Content-Type and body")
+
+  fun _test_404_no_body(h: TestHelper) =>
+    let headers = recover val Headers end
+    let result: Array[U8] val = _ResponseSerializer(StatusNotFound, headers)
+    let expected = "HTTP/1.1 404 Not Found\r\n\r\n"
+    h.assert_eq[String val](
+      expected,
+      String.from_array(result),
+      "404 Not Found, no body")

--- a/http_server/headers.pony
+++ b/http_server/headers.pony
@@ -1,0 +1,64 @@
+class Headers
+  """
+  A collection of HTTP headers with case-insensitive name lookup.
+
+  Names are lowercased on storage. Use `set()` to replace all values for a
+  name, or `add()` to append an additional value (appropriate for multi-value
+  headers like Set-Cookie).
+  """
+  embed _headers: Array[(String, String)]
+
+  new create() =>
+    """Create an empty header collection."""
+    _headers = Array[(String, String)]
+
+  fun ref set(name: String, value: String) =>
+    """
+    Set a header, removing any existing entries with the same name.
+
+    After this call, `get(name)` returns `value` and there is exactly one
+    entry for this name.
+    """
+    let lower_name: String val = name.lower()
+    var i: USize = 0
+    while i < _headers.size() do
+      try
+        if _headers(i)?._1 == lower_name then
+          _headers.delete(i)?
+        else
+          i = i + 1
+        end
+      else
+        i = i + 1
+      end
+    end
+    _headers.push((lower_name, value))
+
+  fun ref add(name: String, value: String) =>
+    """
+    Add a header entry without removing existing entries with the same name.
+
+    This is appropriate for headers that can appear multiple times
+    (e.g., Set-Cookie). Use `set()` when you want to replace.
+    """
+    _headers.push((name.lower(), value))
+
+  fun get(name: String): (String | None) =>
+    """
+    Get the first value for the given header name (case-insensitive).
+
+    Returns `None` if no header with that name exists.
+    """
+    let lower_name: String val = name.lower()
+    for (n, v) in _headers.values() do
+      if n == lower_name then return v end
+    end
+    None
+
+  fun size(): USize =>
+    """Return the number of header entries."""
+    _headers.size()
+
+  fun values(): ArrayValues[(String, String), this->Array[(String, String)]] =>
+    """Iterate over all header entries as (name, value) pairs."""
+    _headers.values()

--- a/http_server/method.pony
+++ b/http_server/method.pony
@@ -1,0 +1,70 @@
+interface val Method is (Equatable[Method] & Stringable)
+  """An HTTP request method (RFC 7231)."""
+
+primitive GET is Method
+  """HTTP GET method."""
+  fun string(): String iso^ => "GET".clone()
+  fun eq(that: Method): Bool => that is this
+
+primitive HEAD is Method
+  """HTTP HEAD method."""
+  fun string(): String iso^ => "HEAD".clone()
+  fun eq(that: Method): Bool => that is this
+
+primitive POST is Method
+  """HTTP POST method."""
+  fun string(): String iso^ => "POST".clone()
+  fun eq(that: Method): Bool => that is this
+
+primitive PUT is Method
+  """HTTP PUT method."""
+  fun string(): String iso^ => "PUT".clone()
+  fun eq(that: Method): Bool => that is this
+
+primitive DELETE is Method
+  """HTTP DELETE method."""
+  fun string(): String iso^ => "DELETE".clone()
+  fun eq(that: Method): Bool => that is this
+
+primitive CONNECT is Method
+  """HTTP CONNECT method."""
+  fun string(): String iso^ => "CONNECT".clone()
+  fun eq(that: Method): Bool => that is this
+
+primitive OPTIONS is Method
+  """HTTP OPTIONS method."""
+  fun string(): String iso^ => "OPTIONS".clone()
+  fun eq(that: Method): Bool => that is this
+
+primitive TRACE is Method
+  """HTTP TRACE method."""
+  fun string(): String iso^ => "TRACE".clone()
+  fun eq(that: Method): Bool => that is this
+
+primitive PATCH is Method
+  """HTTP PATCH method."""
+  fun string(): String iso^ => "PATCH".clone()
+  fun eq(that: Method): Bool => that is this
+
+primitive Methods
+  """Parse HTTP method strings and enumerate known methods."""
+
+  fun parse(data: String): (Method | None) =>
+    """Parse a string into an HTTP method, or None if not recognized."""
+    match data
+    | "GET" => GET
+    | "HEAD" => HEAD
+    | "POST" => POST
+    | "PUT" => PUT
+    | "DELETE" => DELETE
+    | "CONNECT" => CONNECT
+    | "OPTIONS" => OPTIONS
+    | "TRACE" => TRACE
+    | "PATCH" => PATCH
+    else
+      None
+    end
+
+  fun valid(): Array[Method] val =>
+    """Return all standard HTTP methods."""
+    [GET; HEAD; POST; PUT; DELETE; CONNECT; OPTIONS; TRACE; PATCH]

--- a/http_server/status.pony
+++ b/http_server/status.pony
@@ -1,0 +1,224 @@
+interface val Status is Stringable
+  """An HTTP response status code with numeric code and reason phrase."""
+  fun code(): U16
+  fun reason(): String val
+
+// --- 1xx Informational ---
+
+primitive StatusContinue is Status
+  """100 Continue."""
+  fun code(): U16 => 100
+  fun reason(): String val => "Continue"
+  fun string(): String iso^ => "100 Continue".clone()
+
+primitive StatusSwitchingProtocols is Status
+  """101 Switching Protocols."""
+  fun code(): U16 => 101
+  fun reason(): String val => "Switching Protocols"
+  fun string(): String iso^ => "101 Switching Protocols".clone()
+
+// --- 2xx Success ---
+
+primitive StatusOK is Status
+  """200 OK."""
+  fun code(): U16 => 200
+  fun reason(): String val => "OK"
+  fun string(): String iso^ => "200 OK".clone()
+
+primitive StatusCreated is Status
+  """201 Created."""
+  fun code(): U16 => 201
+  fun reason(): String val => "Created"
+  fun string(): String iso^ => "201 Created".clone()
+
+primitive StatusAccepted is Status
+  """202 Accepted."""
+  fun code(): U16 => 202
+  fun reason(): String val => "Accepted"
+  fun string(): String iso^ => "202 Accepted".clone()
+
+primitive StatusNoContent is Status
+  """204 No Content."""
+  fun code(): U16 => 204
+  fun reason(): String val => "No Content"
+  fun string(): String iso^ => "204 No Content".clone()
+
+primitive StatusPartialContent is Status
+  """206 Partial Content."""
+  fun code(): U16 => 206
+  fun reason(): String val => "Partial Content"
+  fun string(): String iso^ => "206 Partial Content".clone()
+
+// --- 3xx Redirection ---
+
+primitive StatusMovedPermanently is Status
+  """301 Moved Permanently."""
+  fun code(): U16 => 301
+  fun reason(): String val => "Moved Permanently"
+  fun string(): String iso^ => "301 Moved Permanently".clone()
+
+primitive StatusFound is Status
+  """302 Found."""
+  fun code(): U16 => 302
+  fun reason(): String val => "Found"
+  fun string(): String iso^ => "302 Found".clone()
+
+primitive StatusSeeOther is Status
+  """303 See Other."""
+  fun code(): U16 => 303
+  fun reason(): String val => "See Other"
+  fun string(): String iso^ => "303 See Other".clone()
+
+primitive StatusNotModified is Status
+  """304 Not Modified."""
+  fun code(): U16 => 304
+  fun reason(): String val => "Not Modified"
+  fun string(): String iso^ => "304 Not Modified".clone()
+
+primitive StatusTemporaryRedirect is Status
+  """307 Temporary Redirect."""
+  fun code(): U16 => 307
+  fun reason(): String val => "Temporary Redirect"
+  fun string(): String iso^ => "307 Temporary Redirect".clone()
+
+primitive StatusPermanentRedirect is Status
+  """308 Permanent Redirect."""
+  fun code(): U16 => 308
+  fun reason(): String val => "Permanent Redirect"
+  fun string(): String iso^ => "308 Permanent Redirect".clone()
+
+// --- 4xx Client Error ---
+
+primitive StatusBadRequest is Status
+  """400 Bad Request."""
+  fun code(): U16 => 400
+  fun reason(): String val => "Bad Request"
+  fun string(): String iso^ => "400 Bad Request".clone()
+
+primitive StatusUnauthorized is Status
+  """401 Unauthorized."""
+  fun code(): U16 => 401
+  fun reason(): String val => "Unauthorized"
+  fun string(): String iso^ => "401 Unauthorized".clone()
+
+primitive StatusForbidden is Status
+  """403 Forbidden."""
+  fun code(): U16 => 403
+  fun reason(): String val => "Forbidden"
+  fun string(): String iso^ => "403 Forbidden".clone()
+
+primitive StatusNotFound is Status
+  """404 Not Found."""
+  fun code(): U16 => 404
+  fun reason(): String val => "Not Found"
+  fun string(): String iso^ => "404 Not Found".clone()
+
+primitive StatusMethodNotAllowed is Status
+  """405 Method Not Allowed."""
+  fun code(): U16 => 405
+  fun reason(): String val => "Method Not Allowed"
+  fun string(): String iso^ => "405 Method Not Allowed".clone()
+
+primitive StatusNotAcceptable is Status
+  """406 Not Acceptable."""
+  fun code(): U16 => 406
+  fun reason(): String val => "Not Acceptable"
+  fun string(): String iso^ => "406 Not Acceptable".clone()
+
+primitive StatusRequestTimeout is Status
+  """408 Request Timeout."""
+  fun code(): U16 => 408
+  fun reason(): String val => "Request Timeout"
+  fun string(): String iso^ => "408 Request Timeout".clone()
+
+primitive StatusConflict is Status
+  """409 Conflict."""
+  fun code(): U16 => 409
+  fun reason(): String val => "Conflict"
+  fun string(): String iso^ => "409 Conflict".clone()
+
+primitive StatusGone is Status
+  """410 Gone."""
+  fun code(): U16 => 410
+  fun reason(): String val => "Gone"
+  fun string(): String iso^ => "410 Gone".clone()
+
+primitive StatusLengthRequired is Status
+  """411 Length Required."""
+  fun code(): U16 => 411
+  fun reason(): String val => "Length Required"
+  fun string(): String iso^ => "411 Length Required".clone()
+
+primitive StatusPayloadTooLarge is Status
+  """413 Payload Too Large."""
+  fun code(): U16 => 413
+  fun reason(): String val => "Payload Too Large"
+  fun string(): String iso^ => "413 Payload Too Large".clone()
+
+primitive StatusURITooLong is Status
+  """414 URI Too Long."""
+  fun code(): U16 => 414
+  fun reason(): String val => "URI Too Long"
+  fun string(): String iso^ => "414 URI Too Long".clone()
+
+primitive StatusUnsupportedMediaType is Status
+  """415 Unsupported Media Type."""
+  fun code(): U16 => 415
+  fun reason(): String val => "Unsupported Media Type"
+  fun string(): String iso^ => "415 Unsupported Media Type".clone()
+
+primitive StatusUnprocessableEntity is Status
+  """422 Unprocessable Entity."""
+  fun code(): U16 => 422
+  fun reason(): String val => "Unprocessable Entity"
+  fun string(): String iso^ => "422 Unprocessable Entity".clone()
+
+primitive StatusTooManyRequests is Status
+  """429 Too Many Requests."""
+  fun code(): U16 => 429
+  fun reason(): String val => "Too Many Requests"
+  fun string(): String iso^ => "429 Too Many Requests".clone()
+
+primitive StatusRequestHeaderFieldsTooLarge is Status
+  """431 Request Header Fields Too Large."""
+  fun code(): U16 => 431
+  fun reason(): String val => "Request Header Fields Too Large"
+  fun string(): String iso^ => "431 Request Header Fields Too Large".clone()
+
+// --- 5xx Server Error ---
+
+primitive StatusInternalServerError is Status
+  """500 Internal Server Error."""
+  fun code(): U16 => 500
+  fun reason(): String val => "Internal Server Error"
+  fun string(): String iso^ => "500 Internal Server Error".clone()
+
+primitive StatusNotImplemented is Status
+  """501 Not Implemented."""
+  fun code(): U16 => 501
+  fun reason(): String val => "Not Implemented"
+  fun string(): String iso^ => "501 Not Implemented".clone()
+
+primitive StatusBadGateway is Status
+  """502 Bad Gateway."""
+  fun code(): U16 => 502
+  fun reason(): String val => "Bad Gateway"
+  fun string(): String iso^ => "502 Bad Gateway".clone()
+
+primitive StatusServiceUnavailable is Status
+  """503 Service Unavailable."""
+  fun code(): U16 => 503
+  fun reason(): String val => "Service Unavailable"
+  fun string(): String iso^ => "503 Service Unavailable".clone()
+
+primitive StatusGatewayTimeout is Status
+  """504 Gateway Timeout."""
+  fun code(): U16 => 504
+  fun reason(): String val => "Gateway Timeout"
+  fun string(): String iso^ => "504 Gateway Timeout".clone()
+
+primitive StatusHTTPVersionNotSupported is Status
+  """505 HTTP Version Not Supported."""
+  fun code(): U16 => 505
+  fun reason(): String val => "HTTP Version Not Supported"
+  fun string(): String iso^ => "505 HTTP Version Not Supported".clone()

--- a/http_server/version.pony
+++ b/http_server/version.pony
@@ -1,0 +1,14 @@
+interface val _Version is (Equatable[Version] & Stringable)
+
+primitive HTTP10 is _Version
+  """HTTP/1.0 protocol version."""
+  fun string(): String iso^ => "HTTP/1.0".clone()
+  fun eq(that: Version): Bool => that is this
+
+primitive HTTP11 is _Version
+  """HTTP/1.1 protocol version."""
+  fun string(): String iso^ => "HTTP/1.1".clone()
+  fun eq(that: Version): Bool => that is this
+
+type Version is ((HTTP10 | HTTP11) & _Version)
+  """HTTP protocol version, either HTTP/1.0 or HTTP/1.1."""


### PR DESCRIPTION
Phase 1 of the HTTP server implementation plan (Discussion #2). Foundational value types that the rest of the library operates on — plain classes and primitives, no actors, no lori dependency.

Components:
- **Method** interface with 9 standard HTTP method primitives and `Methods.parse()` for string-to-method conversion
- **Version** closed union (`HTTP10`, `HTTP11`) for exhaustive matching
- **Status** interface with 35 standard status code primitives (1xx–5xx), open for custom codes
- **Headers** class with case-insensitive storage (lowercased on write), `set()` (replace) and `add()` (append) semantics
- **Response serializer** (package-private) producing HTTP/1.x wire format bytes

Property-based tests using PonyCheck cover method parsing (valid/invalid/mixed generator triad), header case-insensitivity and set/add semantics, and response wire format structure. Example-based tests verify exact byte output for known-good responses.

Design: #2