### PR TITLE
Add HTTP request parser

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,4 +40,10 @@ No release notes until after the first release. This project is pre-1.0 and hasn
   - `status.pony` — HTTP status codes (`Status` interface, 35 standard primitives)
   - `headers.pony` — Case-insensitive header collection (`Headers` class)
   - `_response_serializer.pony` — Response wire-format serializer (package-private)
+  - `_mort.pony` — Runtime enforcement primitives (`_IllegalState`, `_Unreachable`)
+  - `parse_error.pony` — Parse error types (`ParseError` union, 8 error primitives)
+  - `_parser_config.pony` — Parser size limit configuration
+  - `_request_parser_notify.pony` — Parser callback trait (synchronous `ref` methods)
+  - `_parser_state.pony` — Parser state machine (state interface, 6 state classes, `_BufferScan`)
+  - `_request_parser.pony` — Request parser class (entry point, buffer management)
 - `examples/` — example programs

--- a/http_server/_mort.pony
+++ b/http_server/_mort.pony
@@ -1,0 +1,35 @@
+use @exit[None](status: U8)
+use @fprintf[I32](stream: Pointer[U8] tag, fmt: Pointer[U8] tag, ...)
+use @pony_os_stderr[Pointer[U8]]()
+
+primitive _IllegalState
+  """
+  To be used to exit early if we called a function that shouldn't be possible
+  in our current state.
+  """
+  fun apply(loc: SourceLoc = __loc) =>
+    @fprintf(
+      @pony_os_stderr(),
+      ("An illegal state was encountered in %s at line %s\n" +
+       "Please open an issue at " +
+       "https://github.com/ponylang/lori_http_server/issues")
+       .cstring(),
+      loc.file().cstring(),
+      loc.line().string().cstring())
+    @exit(1)
+
+primitive _Unreachable
+  """
+  To be used in places that the compiler can't prove is unreachable but we are
+  certain is unreachable and if we reach it, we'd be silently hiding a bug.
+  """
+  fun apply(loc: SourceLoc = __loc) =>
+    @fprintf(
+      @pony_os_stderr(),
+      ("The unreachable was reached in %s at line %s\n" +
+       "Please open an issue at " +
+       "https://github.com/ponylang/lori_http_server/issues")
+       .cstring(),
+      loc.file().cstring(),
+      loc.line().string().cstring())
+    @exit(1)

--- a/http_server/_parser_config.pony
+++ b/http_server/_parser_config.pony
@@ -1,0 +1,21 @@
+class val _ParserConfig
+  """
+  Configuration for HTTP request parser size limits.
+
+  All limits are in bytes. Requests exceeding any limit produce a parse error.
+  """
+  let max_request_line_size: USize
+  let max_header_size: USize
+  let max_chunk_header_size: USize
+  let max_body_size: USize
+
+  new val create(
+    max_request_line_size': USize = 8192,
+    max_header_size': USize = 8192,
+    max_chunk_header_size': USize = 128,
+    max_body_size': USize = 1_048_576)
+  =>
+    max_request_line_size = max_request_line_size'
+    max_header_size = max_header_size'
+    max_chunk_header_size = max_chunk_header_size'
+    max_body_size = max_body_size'

--- a/http_server/_parser_state.pony
+++ b/http_server/_parser_state.pony
@@ -1,0 +1,570 @@
+primitive _ParseContinue
+  """More data may be parseable in the current buffer."""
+
+primitive _ParseNeedMore
+  """Need more data from the network before parsing can continue."""
+
+type _ParseResult is (_ParseContinue | _ParseNeedMore | ParseError)
+  """Result of a single parse step."""
+
+interface ref _ParserState
+  """
+  A state in the HTTP request parser state machine.
+
+  Each state is a class that owns its per-state data (buffers,
+  accumulators). State transitions are explicit assignments to
+  `p.state`. Per-state data is automatically cleaned up when
+  the state transitions out.
+  """
+  fun ref parse(p: _RequestParser ref): _ParseResult
+
+// ---------------------------------------------------------------------------
+// Buffer scanning utilities
+// ---------------------------------------------------------------------------
+
+primitive _BufferScan
+  """Byte-level scanning utilities for the parser buffer."""
+
+  fun find_crlf(buf: Array[U8] box, from: USize = 0): (USize | None) =>
+    """
+    Find the position of \\r\\n in buf starting from `from`.
+    Returns the index of \\r, or None if not found.
+    """
+    if buf.size() < (from + 2) then return None end
+    var i = from
+    let limit = buf.size() - 1
+    try
+      while i < limit do
+        if (buf(i)? == '\r') and (buf(i + 1)? == '\n') then
+          return i
+        end
+        i = i + 1
+      end
+    else
+      _Unreachable()
+    end
+    None
+
+  fun find_byte(
+    buf: Array[U8] box,
+    byte: U8,
+    from: USize,
+    to: USize = USize.max_value())
+    : (USize | None)
+  =>
+    """Find the first occurrence of `byte` in buf[from, to)."""
+    var i = from
+    let limit = to.min(buf.size())
+    try
+      while i < limit do
+        if buf(i)? == byte then return i end
+        i = i + 1
+      end
+    else
+      _Unreachable()
+    end
+    None
+
+// ---------------------------------------------------------------------------
+// Parser states
+// ---------------------------------------------------------------------------
+
+class _ExpectRequestLine is _ParserState
+  """
+  Initial state: waiting for a complete HTTP request line.
+
+  Format: METHOD SP request-target SP HTTP-version CRLF
+  """
+  fun ref parse(p: _RequestParser ref): _ParseResult =>
+    let available = p.buf.size() - p.pos
+
+    // Check for CRLF marking end of request line
+    match _BufferScan.find_crlf(p.buf, p.pos)
+    | let crlf: USize =>
+      let line_len = crlf - p.pos
+      if line_len > p.config.max_request_line_size then
+        return TooLarge
+      end
+
+      // Find first space: separates method from URI
+      let method_end = match _BufferScan.find_byte(p.buf, ' ', p.pos, crlf)
+        | let i: USize => i
+        | None => return UnknownMethod
+        end
+
+      // Parse method
+      let method_str: String val = p.extract_string(p.pos, method_end)
+      let method = match Methods.parse(method_str)
+        | let m: Method => m
+        | None => return UnknownMethod
+        end
+
+      // Skip space(s) after method
+      var uri_start = method_end + 1
+      try
+        while (uri_start < crlf) and (p.buf(uri_start)? == ' ') do
+          uri_start = uri_start + 1
+        end
+      else
+        _Unreachable()
+      end
+
+      // Find second space: separates URI from version
+      let uri_end = match _BufferScan.find_byte(p.buf, ' ', uri_start, crlf)
+        | let i: USize => i
+        | None => return InvalidVersion
+        end
+
+      // Extract and validate URI
+      if uri_end == uri_start then
+        return InvalidURI
+      end
+
+      let uri: String val = p.extract_string(uri_start, uri_end)
+
+      // Validate URI: no control characters (< 0x21 or > 0x7E)
+      try
+        var i: USize = 0
+        while i < uri.size() do
+          let ch = uri(i)?
+          if (ch < 0x21) or (ch > 0x7E) then
+            return InvalidURI
+          end
+          i = i + 1
+        end
+      else
+        _Unreachable()
+      end
+
+      // Skip space(s) before version
+      var ver_start = uri_end + 1
+      try
+        while (ver_start < crlf) and (p.buf(ver_start)? == ' ') do
+          ver_start = ver_start + 1
+        end
+      else
+        _Unreachable()
+      end
+
+      // Parse version: must be exactly "HTTP/1.0" or "HTTP/1.1"
+      let ver_len = crlf - ver_start
+      if ver_len != 8 then
+        return InvalidVersion
+      end
+
+      let version = try
+        if (p.buf(ver_start)? == 'H')
+          and (p.buf(ver_start + 1)? == 'T')
+          and (p.buf(ver_start + 2)? == 'T')
+          and (p.buf(ver_start + 3)? == 'P')
+          and (p.buf(ver_start + 4)? == '/')
+          and (p.buf(ver_start + 5)? == '1')
+          and (p.buf(ver_start + 6)? == '.')
+        then
+          let minor = p.buf(ver_start + 7)?
+          if minor == '1' then
+            HTTP11
+          elseif minor == '0' then
+            HTTP10
+          else
+            return InvalidVersion
+          end
+        else
+          return InvalidVersion
+        end
+      else
+        _Unreachable()
+        return InvalidVersion
+      end
+
+      // Advance past the request line (including CRLF)
+      p.pos = crlf + 2
+
+      // Transition to header parsing
+      p.state = _ExpectHeaders(method, uri, version, p.config)
+      _ParseContinue
+
+    | None =>
+      // No complete line yet — check size limit
+      if available > p.config.max_request_line_size then
+        TooLarge
+      else
+        _ParseNeedMore
+      end
+    end
+
+class _ExpectHeaders is _ParserState
+  """
+  Parsing HTTP headers after the request line.
+
+  Loops through header lines until an empty line (CRLF) marks the end
+  of headers. Tracks Content-Length and Transfer-Encoding for body handling.
+  """
+  let _method: Method
+  let _uri: String val
+  let _version: Version
+  let _config: _ParserConfig
+  var _headers: Headers iso = recover iso Headers end
+  var _content_length: (USize | None) = None
+  var _chunked: Bool = false
+  var _total_header_bytes: USize = 0
+
+  new create(
+    method: Method,
+    uri: String val,
+    version: Version,
+    config: _ParserConfig)
+  =>
+    _method = method
+    _uri = uri
+    _version = version
+    _config = config
+
+  fun ref parse(p: _RequestParser ref): _ParseResult =>
+    // Loop through header lines
+    while true do
+      match _BufferScan.find_crlf(p.buf, p.pos)
+      | let crlf: USize =>
+        if crlf == p.pos then
+          // Empty line: end of headers
+          p.pos = crlf + 2
+
+          // Destructive read: swap out headers as val, replace with empty
+          let headers: Headers val =
+            (_headers = recover iso Headers end)
+
+          // Deliver the request metadata
+          p.handler.request_received(_method, _uri, _version, headers)
+
+          // Determine body handling: Transfer-Encoding takes precedence
+          // over Content-Length per RFC 7230 §3.3.3
+          if _chunked then
+            p.state = _ExpectChunkHeader(0, _config)
+            return _ParseContinue
+          end
+
+          match _content_length
+          | let cl: USize if cl > 0 =>
+            if cl > _config.max_body_size then
+              return BodyTooLarge
+            end
+            p.state = _ExpectFixedBody(cl)
+            return _ParseContinue
+          else
+            // No body (no Content-Length, Content-Length: 0, or None)
+            p.handler.request_complete()
+            p.state = _ExpectRequestLine
+            return _ParseContinue
+          end
+        end
+
+        // Track header size
+        let line_len = (crlf - p.pos) + 2
+        _total_header_bytes = _total_header_bytes + line_len
+        if _total_header_bytes > _config.max_header_size then
+          return TooLarge
+        end
+
+        // Check for obs-fold (continuation line): reject per RFC 7230
+        try
+          let first_byte = p.buf(p.pos)?
+          if (first_byte == ' ') or (first_byte == '\t') then
+            return MalformedHeaders
+          end
+        else
+          _Unreachable()
+        end
+
+        // Find colon separator
+        let colon_pos = match _BufferScan.find_byte(p.buf, ':', p.pos, crlf)
+          | let i: USize => i
+          | None => return MalformedHeaders
+          end
+
+        // Header name must not be empty
+        if colon_pos == p.pos then
+          return MalformedHeaders
+        end
+
+        // Extract header name (lowercasing happens in Headers.add)
+        let name: String val = p.extract_string(p.pos, colon_pos)
+
+        // Extract header value, skipping optional whitespace (OWS)
+        var val_start = colon_pos + 1
+        try
+          while val_start < crlf do
+            let ch = p.buf(val_start)?
+            if (ch != ' ') and (ch != '\t') then break end
+            val_start = val_start + 1
+          end
+        else
+          _Unreachable()
+        end
+
+        // Trim trailing OWS from value
+        var val_end = crlf
+        try
+          while val_end > val_start do
+            let ch = p.buf(val_end - 1)?
+            if (ch != ' ') and (ch != '\t') then break end
+            val_end = val_end - 1
+          end
+        else
+          _Unreachable()
+        end
+
+        let value: String val = p.extract_string(val_start, val_end)
+
+        // Detect special headers
+        let lower_name: String val = name.lower()
+        if lower_name == "content-length" then
+          match _parse_content_length(value)
+          | let cl: USize =>
+            match _content_length
+            | let existing: USize =>
+              if existing != cl then
+                return InvalidContentLength
+              end
+            | None =>
+              _content_length = cl
+            end
+          | InvalidContentLength => return InvalidContentLength
+          end
+        elseif lower_name == "transfer-encoding" then
+          if value.lower().contains("chunked") then
+            _chunked = true
+          end
+        end
+
+        _headers.add(name, value)
+
+        // Advance past this header line
+        p.pos = crlf + 2
+      | None =>
+        // No complete line yet — check size limit
+        let pending = p.buf.size() - p.pos
+        if (pending + _total_header_bytes) > _config.max_header_size then
+          return TooLarge
+        end
+        return _ParseNeedMore
+      end
+    end
+    _Unreachable()
+    _ParseNeedMore
+
+  fun _parse_content_length(value: String val)
+    : (USize | InvalidContentLength)
+  =>
+    """Parse a Content-Length value as a non-negative integer."""
+    if value.size() == 0 then
+      return InvalidContentLength
+    end
+    try
+      var i: USize = 0
+      while i < value.size() do
+        let ch = value(i)?
+        if (ch < '0') or (ch > '9') then
+          return InvalidContentLength
+        end
+        i = i + 1
+      end
+      value.read_int[USize]()?._1
+    else
+      InvalidContentLength
+    end
+
+class _ExpectFixedBody is _ParserState
+  """
+  Reading a fixed-length request body (Content-Length).
+
+  Delivers body data incrementally as it becomes available in the buffer.
+  """
+  var _remaining: USize
+
+  new create(remaining: USize) =>
+    _remaining = remaining
+
+  fun ref parse(p: _RequestParser ref): _ParseResult =>
+    let available = (p.buf.size() - p.pos).min(_remaining)
+    if available > 0 then
+      let chunk: Array[U8] val =
+        p.extract_bytes(p.pos, p.pos + available)
+      p.handler.body_chunk(chunk)
+      p.pos = p.pos + available
+      _remaining = _remaining - available
+    end
+
+    if _remaining == 0 then
+      p.handler.request_complete()
+      p.state = _ExpectRequestLine
+      _ParseContinue
+    else
+      _ParseNeedMore
+    end
+
+class _ExpectChunkHeader is _ParserState
+  """
+  Expecting a chunk size line in chunked transfer encoding.
+
+  Format: chunk-size [ chunk-ext ] CRLF
+  """
+  var _total_body_received: USize
+  let _config: _ParserConfig
+
+  new create(total_body_received: USize, config: _ParserConfig) =>
+    _total_body_received = total_body_received
+    _config = config
+
+  fun ref parse(p: _RequestParser ref): _ParseResult =>
+    match _BufferScan.find_crlf(p.buf, p.pos)
+    | let crlf: USize =>
+      let line_len = crlf - p.pos
+      if line_len > _config.max_chunk_header_size then
+        return InvalidChunk
+      end
+      if line_len == 0 then
+        return InvalidChunk
+      end
+
+      // Find optional chunk extension (semicolon)
+      let size_end = match _BufferScan.find_byte(p.buf, ';', p.pos, crlf)
+        | let i: USize => i
+        | None => crlf
+        end
+
+      // Parse hex chunk size — must consume entire string
+      let size_str: String val = p.extract_string(p.pos, size_end)
+      let chunk_size = try
+        (let cs, let consumed) = size_str.read_int[USize](0, 16)?
+        if consumed.usize() != size_str.size() then
+          return InvalidChunk
+        end
+        cs
+      else
+        return InvalidChunk
+      end
+
+      p.pos = crlf + 2
+
+      if chunk_size == 0 then
+        // Last chunk — expect trailers or final CRLF
+        p.state = _ExpectChunkTrailer(0, _config)
+        _ParseContinue
+      else
+        // Check body size limit
+        if (_total_body_received + chunk_size) > _config.max_body_size then
+          return BodyTooLarge
+        end
+        p.state = _ExpectChunkData(
+          chunk_size, _total_body_received, _config)
+        _ParseContinue
+      end
+    | None =>
+      // No complete line — check size limit
+      let pending = p.buf.size() - p.pos
+      if pending > _config.max_chunk_header_size then
+        InvalidChunk
+      else
+        _ParseNeedMore
+      end
+    end
+
+class _ExpectChunkData is _ParserState
+  """
+  Reading chunk data in chunked transfer encoding.
+
+  Delivers data incrementally, then expects CRLF after the chunk data.
+  """
+  var _remaining: USize
+  var _total_body_received: USize
+  let _config: _ParserConfig
+
+  new create(
+    remaining: USize,
+    total_body_received: USize,
+    config: _ParserConfig)
+  =>
+    _remaining = remaining
+    _total_body_received = total_body_received
+    _config = config
+
+  fun ref parse(p: _RequestParser ref): _ParseResult =>
+    if _remaining > 0 then
+      let available = (p.buf.size() - p.pos).min(_remaining)
+      if available > 0 then
+        let chunk: Array[U8] val =
+          p.extract_bytes(p.pos, p.pos + available)
+        p.handler.body_chunk(chunk)
+        p.pos = p.pos + available
+        _remaining = _remaining - available
+        _total_body_received = _total_body_received + available
+      end
+      if _remaining > 0 then
+        return _ParseNeedMore
+      end
+    end
+
+    // Chunk data consumed — expect CRLF
+    let bytes_available = p.buf.size() - p.pos
+    if bytes_available < 2 then
+      return _ParseNeedMore
+    end
+
+    try
+      if (p.buf(p.pos)? == '\r') and (p.buf(p.pos + 1)? == '\n') then
+        p.pos = p.pos + 2
+        p.state = _ExpectChunkHeader(_total_body_received, _config)
+        _ParseContinue
+      else
+        InvalidChunk
+      end
+    else
+      _Unreachable()
+      InvalidChunk
+    end
+
+class _ExpectChunkTrailer is _ParserState
+  """
+  Reading optional trailer headers after the last (zero-size) chunk.
+
+  Trailers are skipped (not delivered to the handler). The request is
+  complete when an empty line is found.
+  """
+  var _total_trailer_bytes: USize
+  let _config: _ParserConfig
+
+  new create(total_trailer_bytes: USize, config: _ParserConfig) =>
+    _total_trailer_bytes = total_trailer_bytes
+    _config = config
+
+  fun ref parse(p: _RequestParser ref): _ParseResult =>
+    while true do
+      match _BufferScan.find_crlf(p.buf, p.pos)
+      | let crlf: USize =>
+        if crlf == p.pos then
+          // Empty line: end of chunked message
+          p.pos = crlf + 2
+          p.handler.request_complete()
+          p.state = _ExpectRequestLine
+          return _ParseContinue
+        end
+
+        // Skip this trailer header line
+        let line_len = (crlf - p.pos) + 2
+        _total_trailer_bytes = _total_trailer_bytes + line_len
+        if _total_trailer_bytes > _config.max_header_size then
+          return TooLarge
+        end
+
+        p.pos = crlf + 2
+      | None =>
+        let pending = p.buf.size() - p.pos
+        if (pending + _total_trailer_bytes) > _config.max_header_size then
+          return TooLarge
+        end
+        return _ParseNeedMore
+      end
+    end
+    _Unreachable()
+    _ParseNeedMore
+

--- a/http_server/_request_parser.pony
+++ b/http_server/_request_parser.pony
@@ -1,0 +1,81 @@
+class _RequestParser
+  """
+  HTTP/1.1 request parser.
+
+  Data is fed in as chunks via `parse()` (matching lori's delivery model).
+  Parsed requests are delivered via the `_RequestParserNotify` callback
+  interface. The parser handles arbitrary chunk boundaries, pipelining
+  (multiple requests in one buffer), and both fixed-length and chunked
+  transfer encoding.
+
+  Fields are public so that state classes (in the same package)
+  can access them for buffer reading, position tracking, state transitions,
+  and handler callbacks.
+  """
+  var state: _ParserState = _ExpectRequestLine
+  let handler: _RequestParserNotify ref
+  let config: _ParserConfig
+  var buf: Array[U8] ref = Array[U8]
+  var pos: USize = 0
+  var _failed: Bool = false
+
+  new create(
+    handler': _RequestParserNotify ref,
+    config': _ParserConfig = _ParserConfig)
+  =>
+    handler = handler'
+    config = config'
+
+  fun ref parse(data: Array[U8] iso) =>
+    """
+    Feed data to the parser.
+
+    The parser processes as much data as possible in a single call,
+    delivering callbacks for each complete request (or request component)
+    found. Remaining partial data is buffered for the next call.
+    """
+    // Short-circuit if parser has already failed (terminal state)
+    if _failed then return end
+
+    buf.append(consume data)
+
+    // Parse loop: process data until we need more or hit an error
+    var continue_parsing = true
+    while continue_parsing do
+      match state.parse(this)
+      | _ParseContinue => None
+      | _ParseNeedMore => continue_parsing = false
+      | let err: ParseError =>
+        handler.parse_error(err)
+        _failed = true
+        continue_parsing = false
+      end
+    end
+
+    // Compact consumed data
+    if pos > 0 then
+      buf.trim_in_place(pos)
+      pos = 0
+    end
+
+  fun ref extract_bytes(from: USize, to: USize): Array[U8] iso^ =>
+    """Copy bytes from buf[from..to) into a new iso array."""
+    let len = to - from
+    let out = recover Array[U8].create(len) end
+    var i = from
+    while i < to do
+      try out.push(buf(i)?) else _Unreachable() end
+      i = i + 1
+    end
+    out
+
+  fun ref extract_string(from: USize, to: USize): String iso^ =>
+    """Copy bytes from buf[from..to) into a new iso String."""
+    let len = to - from
+    let out = recover String.create(len) end
+    var i = from
+    while i < to do
+      try out.push(buf(i)?) else _Unreachable() end
+      i = i + 1
+    end
+    out

--- a/http_server/_request_parser_notify.pony
+++ b/http_server/_request_parser_notify.pony
@@ -1,0 +1,42 @@
+trait ref _RequestParserNotify
+  """
+  Callback interface for the HTTP request parser.
+  """
+
+  fun ref request_received(
+    method: Method,
+    uri: String val,
+    version: Version,
+    headers: Headers val)
+  """
+  Called when the request line and all headers have been parsed.
+
+  For requests with a body (Content-Length or Transfer-Encoding: chunked),
+  `body_chunk` calls follow. For requests without a body,
+  `request_complete` is called immediately after.
+  """
+
+  fun ref body_chunk(data: Array[U8] val)
+  """
+  Called for each chunk of request body data as it becomes available.
+
+  Body data is delivered incrementally — not accumulated. The total body
+  size equals the Content-Length or the sum of chunked transfer chunks.
+  """
+
+  fun ref request_complete()
+  """
+  Called when the entire request (including any body) has been received.
+
+  After this call, the parser is ready to parse the next request on the
+  same connection (HTTP pipelining).
+  """
+
+  fun ref parse_error(err: ParseError)
+  """
+  Called when a parse error is encountered.
+
+  After this call, the parser enters a terminal failed state and will not
+  produce any further callbacks. The connection actor should send an
+  appropriate error response (e.g., 400 Bad Request) and close.
+  """

--- a/http_server/_test.pony
+++ b/http_server/_test.pony
@@ -24,3 +24,39 @@ actor \nodoc\ Main is TestList
     test(Property1UnitTest[_ResponseInput](
       _PropertyResponseWireFormat))
     test(_TestResponseSerializerKnownGood)
+
+    // Parser property-based tests
+    test(Property1UnitTest[(String val, String val)](
+      _PropertyValidRequestLineParsesCorrectly))
+    test(Property1UnitTest[String val](
+      _PropertyInvalidMethodRejected))
+    test(Property1UnitTest[Array[(String val, String val)] ref](
+      _PropertyHeadersRoundtrip))
+    test(Property1UnitTest[USize](
+      _PropertyFixedBodyDelivered))
+    test(Property1UnitTest[Array[USize] ref](
+      _PropertyChunkedBodyDelivered))
+    test(Property1UnitTest[(String val, Bool)](
+      _PropertyRequestLineBoundary))
+
+    // Parser example-based tests
+    test(_TestParserKnownGoodRequests)
+    test(_TestIncrementalByteByByte)
+    test(_TestPipelining)
+    test(_TestPipeliningWithBody)
+    test(_TestPipeliningChunked)
+    test(_TestSizeLimitRequestLine)
+    test(_TestSizeLimitHeaders)
+    test(_TestSizeLimitBody)
+    test(_TestInvalidContentLength)
+    test(_TestInvalidChunkSize)
+    test(_TestMissingCRLFAfterChunk)
+    test(_TestChunkedWithTrailers)
+    test(_TestHTTP10Version)
+    test(_TestInvalidVersion)
+    test(_TestNoBody)
+    test(_TestContentLengthZero)
+    test(_TestContentLengthAndChunked)
+    test(_TestDuplicateContentLength)
+    test(_TestInvalidURI)
+    test(_TestDataAfterError)

--- a/http_server/_test_request_parser.pony
+++ b/http_server/_test_request_parser.pony
@@ -1,0 +1,857 @@
+use "format"
+use "pony_check"
+use "pony_test"
+
+// ---------------------------------------------------------------------------
+// Test helper: recording implementation of _RequestParserNotify
+// ---------------------------------------------------------------------------
+
+class \nodoc\ _TestParserNotify is _RequestParserNotify
+  embed requests: Array[(Method, String val, Version, Headers val)] =
+    Array[(Method, String val, Version, Headers val)]
+  embed body_chunks: Array[Array[U8] val] = Array[Array[U8] val]
+  var completed: USize = 0
+  embed errors: Array[ParseError] = Array[ParseError]
+
+  fun ref request_received(
+    method: Method,
+    uri: String val,
+    version: Version,
+    headers: Headers val)
+  =>
+    requests.push((method, uri, version, headers))
+
+  fun ref body_chunk(data: Array[U8] val) =>
+    body_chunks.push(data)
+
+  fun ref request_complete() =>
+    completed = completed + 1
+
+  fun ref parse_error(err: ParseError) =>
+    errors.push(err)
+
+  fun ref collected_body_string(): String val =>
+    """Concatenate all body chunks into a single string."""
+    let out = String
+    for chunk in body_chunks.values() do
+      out.append(chunk)
+    end
+    out.clone()
+
+// ---------------------------------------------------------------------------
+// Property-based tests
+// ---------------------------------------------------------------------------
+
+class \nodoc\ iso _PropertyValidRequestLineParsesCorrectly
+  is Property1[(String val, String val)]
+  """
+  Valid (method, path) pairs serialized as HTTP/1.1 request lines parse
+  correctly, delivering request_received with matching values and then
+  request_complete.
+  """
+  fun name(): String => "parser/valid_request_line"
+
+  fun gen(): Generator[(String val, String val)] =>
+    // Generate (method_string, path)
+    let method_gen = Generators.one_of[String val](
+      ["GET"; "HEAD"; "POST"; "PUT"; "DELETE"
+       "CONNECT"; "OPTIONS"; "TRACE"; "PATCH"])
+    let path_gen = Generators.map2[String val, String val, String val](
+      Generators.unit[String val]("/"),
+      Generators.ascii_letters(0, 20),
+      {(slash, rest) => slash + rest })
+    Generators.zip2[String val, String val](method_gen, path_gen)
+
+  fun ref property(
+    arg1: (String val, String val),
+    ph: PropertyHelper)
+  =>
+    (let method_str, let path) = arg1
+    let raw: String val =
+      method_str + " " + path + " HTTP/1.1\r\nHost: test\r\n\r\n"
+    let notify: _TestParserNotify ref = _TestParserNotify
+    let parser = _RequestParser(notify)
+    parser.parse(recover raw.array().clone() end)
+
+    ph.assert_eq[USize](1, notify.requests.size(),
+      "should have 1 request")
+    ph.assert_eq[USize](1, notify.completed,
+      "should have 1 completion")
+    ph.assert_eq[USize](0, notify.errors.size(),
+      "should have 0 errors")
+    try
+      (let m, let u, let v, _) = notify.requests(0)?
+      ph.assert_eq[String val](method_str, m.string())
+      ph.assert_eq[String val](path, u)
+      ph.assert_true(v is HTTP11, "version should be HTTP/1.1")
+    else
+      ph.fail("could not read request")
+    end
+
+class \nodoc\ iso _PropertyInvalidMethodRejected
+  is Property1[String val]
+  """
+  Invalid method strings in request lines produce UnknownMethod errors.
+  """
+  fun name(): String => "parser/invalid_method_rejected"
+
+  fun gen(): Generator[String val] =>
+    Generators.frequency[String val]([
+      as WeightedGenerator[String val]:
+      (1, Generators.one_of[String val](
+        ["get"; "head"; "post"; "put"; "delete"
+         "connect"; "options"; "trace"; "patch"]))
+      (1, Generators.one_of[String val](
+        ["GETX"; "POSTY"; "PUTS"]))
+      (1, Generators.one_of[String val](
+        ["GE"; "POS"; "DELET"]))
+      (1, Generators.ascii_numeric(1, 10))
+    ])
+
+  fun ref property(arg1: String val, ph: PropertyHelper) =>
+    let raw: String val = arg1 + " / HTTP/1.1\r\n\r\n"
+    let notify: _TestParserNotify ref = _TestParserNotify
+    let parser = _RequestParser(notify)
+    parser.parse(recover raw.array().clone() end)
+
+    ph.assert_eq[USize](0, notify.requests.size(),
+      "should have 0 requests for: " + arg1)
+    ph.assert_eq[USize](1, notify.errors.size(),
+      "should have 1 error for: " + arg1)
+    try
+      ph.assert_true(notify.errors(0)? is UnknownMethod,
+        "error should be UnknownMethod for: " + arg1)
+    end
+
+class \nodoc\ iso _PropertyHeadersRoundtrip
+  is Property1[Array[(String val, String val)] ref]
+  """
+  Headers added to a request are correctly parsed and available in the
+  delivered Headers collection.
+  """
+  fun name(): String => "parser/headers_roundtrip"
+
+  fun gen(): Generator[Array[(String val, String val)] ref] =>
+    // Generate 1-5 header (name, value) pairs
+    let pair_gen = Generators.zip2[String val, String val](
+      Generators.ascii_letters(1, 10),
+      Generators.ascii_letters(1, 20))
+    Generators.array_of[
+      (String val, String val)](pair_gen, 1, 5)
+
+  fun ref property(
+    arg1: Array[(String val, String val)] ref,
+    ph: PropertyHelper)
+  =>
+    // Build request with headers
+    var raw: String val = "GET / HTTP/1.1\r\n"
+    for (hdr_name, hdr_value) in arg1.values() do
+      raw = raw + hdr_name + ": " + hdr_value + "\r\n"
+    end
+    raw = raw + "\r\n"
+
+    let notify: _TestParserNotify ref = _TestParserNotify
+    let parser = _RequestParser(notify)
+    parser.parse(recover raw.array().clone() end)
+
+    ph.assert_eq[USize](1, notify.requests.size(),
+      "should have 1 request")
+    try
+      (_, _, _, let headers) = notify.requests(0)?
+      // Headers.get returns first value for a case-insensitive name.
+      // Only check the first occurrence of each name to handle collisions.
+      let seen = Array[String val]
+      for (hdr_name, hdr_value) in arg1.values() do
+        let lower: String val = hdr_name.lower()
+        var already_seen = false
+        for s in seen.values() do
+          if s == lower then already_seen = true; break end
+        end
+        if not already_seen then
+          seen.push(lower)
+          match headers.get(hdr_name)
+          | let v: String val =>
+            ph.assert_eq[String val](hdr_value, v,
+              "header " + hdr_name + " mismatch")
+          | None =>
+            ph.fail("header " + hdr_name + " not found")
+          end
+        end
+      end
+    else
+      ph.fail("could not read request")
+    end
+
+class \nodoc\ iso _PropertyFixedBodyDelivered
+  is Property1[USize]
+  """
+  Requests with Content-Length have their body delivered completely via
+  body_chunk callbacks, followed by request_complete.
+  """
+  fun name(): String => "parser/fixed_body_delivered"
+
+  fun gen(): Generator[USize] =>
+    Generators.usize(1, 200)
+
+  fun ref property(arg1: USize, ph: PropertyHelper) =>
+    // Build body of the given size
+    let body = recover val
+      let b = Array[U8](arg1)
+      var i: USize = 0
+      while i < arg1 do
+        b.push('A' + (i % 26).u8())
+        i = i + 1
+      end
+      b
+    end
+
+    let raw = recover val
+      let r = String
+      r.append("POST /data HTTP/1.1\r\n")
+      r.append("Content-Length: " + arg1.string() + "\r\n")
+      r.append("\r\n")
+      r.append(body)
+      r
+    end
+
+    let notify: _TestParserNotify ref = _TestParserNotify
+    let parser = _RequestParser(notify)
+    parser.parse(recover raw.array().clone() end)
+
+    ph.assert_eq[USize](1, notify.requests.size(),
+      "should have 1 request")
+    ph.assert_eq[USize](1, notify.completed,
+      "should have 1 completion")
+    ph.assert_eq[USize](0, notify.errors.size(),
+      "should have 0 errors")
+
+    // Verify body size by summing chunks
+    var total_body: USize = 0
+    for chunk in notify.body_chunks.values() do
+      total_body = total_body + chunk.size()
+    end
+    ph.assert_eq[USize](arg1, total_body, "body size mismatch")
+
+    // Verify body content byte by byte
+    var byte_idx: USize = 0
+    for chunk in notify.body_chunks.values() do
+      try
+        var ci: USize = 0
+        while ci < chunk.size() do
+          ph.assert_eq[U8](body(byte_idx)?, chunk(ci)?,
+            "body byte mismatch at " + byte_idx.string())
+          byte_idx = byte_idx + 1
+          ci = ci + 1
+        end
+      end
+    end
+
+class \nodoc\ iso _PropertyChunkedBodyDelivered
+  is Property1[Array[USize] ref]
+  """
+  Chunked transfer encoding delivers the complete body and
+  request_complete.
+  """
+  fun name(): String => "parser/chunked_body_delivered"
+
+  fun gen(): Generator[Array[USize] ref] =>
+    // Generate 1-5 chunk sizes between 1 and 50
+    Generators.array_of[USize](Generators.usize(1, 50), 1, 5)
+
+  fun ref property(arg1: Array[USize] ref, ph: PropertyHelper) =>
+    // Build chunked request with known data
+    var total_size: USize = 0
+    var raw: String val =
+      "POST /upload HTTP/1.1\r\n" +
+      "Transfer-Encoding: chunked\r\n" +
+      "\r\n"
+
+    for size in arg1.values() do
+      let chunk_data: String val = recover val
+        let s = String(size)
+        var i: USize = 0
+        while i < size do
+          s.push('A' + (i % 26).u8())
+          i = i + 1
+        end
+        s
+      end
+      let hex_size: String val =
+        Format.int[USize](size where fmt = FormatHexBare)
+      raw = raw + hex_size + "\r\n" + chunk_data + "\r\n"
+      total_size = total_size + size
+    end
+    raw = raw + "0\r\n\r\n"
+
+    let notify: _TestParserNotify ref = _TestParserNotify
+    let parser = _RequestParser(notify)
+    parser.parse(recover raw.array().clone() end)
+
+    ph.assert_eq[USize](1, notify.requests.size(),
+      "should have 1 request")
+    ph.assert_eq[USize](1, notify.completed,
+      "should have 1 completion")
+    ph.assert_eq[USize](0, notify.errors.size(),
+      "should have 0 errors")
+
+    var total_received: USize = 0
+    for chunk in notify.body_chunks.values() do
+      total_received = total_received + chunk.size()
+    end
+    ph.assert_eq[USize](total_size, total_received,
+      "total body size mismatch")
+
+class \nodoc\ iso _PropertyRequestLineBoundary
+  is Property1[(String val, Bool)]
+  """
+  Mixed valid/invalid request lines: valid ones produce request_received,
+  invalid ones produce parse_error.
+  """
+  fun name(): String => "parser/request_line_boundary"
+
+  fun gen(): Generator[(String val, Bool)] =>
+    let valid_gen: Generator[(String val, Bool)] =
+      Generators.map2[String val, String val, (String val, Bool)](
+        Generators.one_of[String val](
+          ["GET"; "POST"; "PUT"; "DELETE"; "HEAD"]),
+        Generators.ascii_letters(1, 10),
+        {(method, path) =>
+          (method + " /" + path + " HTTP/1.1\r\nHost: x\r\n\r\n", true) })
+
+    let invalid_gen: Generator[(String val, Bool)] =
+      Generators.frequency[String val]([
+        as WeightedGenerator[String val]:
+        (1, Generators.one_of[String val](
+          ["get"; "GETX"; "POS"; "123"]))
+        (1, Generators.ascii(1, 10))
+      ]).map[(String val, Bool)](
+        {(method) =>
+          (method + " / HTTP/1.1\r\n\r\n", false) })
+
+    Generators.frequency[(String val, Bool)]([
+      as WeightedGenerator[(String val, Bool)]:
+      (1, valid_gen)
+      (1, invalid_gen)
+    ])
+
+  fun ref property(arg1: (String val, Bool), ph: PropertyHelper) =>
+    (let raw, let should_succeed) = arg1
+    let notify: _TestParserNotify ref = _TestParserNotify
+    let parser = _RequestParser(notify)
+    parser.parse(recover raw.array().clone() end)
+
+    if should_succeed then
+      ph.assert_eq[USize](1, notify.requests.size(),
+        "valid request should parse")
+      ph.assert_eq[USize](0, notify.errors.size(),
+        "valid request should have no errors")
+    else
+      ph.assert_eq[USize](1, notify.errors.size(),
+        "invalid request should produce error")
+    end
+
+// ---------------------------------------------------------------------------
+// Example-based tests
+// ---------------------------------------------------------------------------
+
+class \nodoc\ iso _TestParserKnownGoodRequests is UnitTest
+  """Verify exact callback sequences for well-known HTTP requests."""
+  fun name(): String => "parser/known_good_requests"
+
+  fun apply(h: TestHelper) =>
+    _test_simple_get(h)
+    _test_post_with_body(h)
+    _test_get_with_multiple_headers(h)
+
+  fun _test_simple_get(h: TestHelper) =>
+    let raw = "GET / HTTP/1.1\r\nHost: www.example.com\r\n\r\n"
+    let notify: _TestParserNotify ref = _TestParserNotify
+    let parser = _RequestParser(notify)
+    parser.parse(recover raw.array().clone() end)
+
+    h.assert_eq[USize](1, notify.requests.size(), "simple GET: 1 request")
+    h.assert_eq[USize](1, notify.completed, "simple GET: 1 completion")
+    try
+      (let m, let u, let v, let hdrs) = notify.requests(0)?
+      h.assert_true(m is GET, "method should be GET")
+      h.assert_eq[String val]("/", u, "URI should be /")
+      h.assert_true(v is HTTP11, "version should be HTTP/1.1")
+      h.assert_eq[String val](
+        "www.example.com",
+        match hdrs.get("Host")
+        | let s: String val => s
+        else "" end,
+        "Host header")
+    else
+      h.fail("simple GET: could not read request")
+    end
+
+  fun _test_post_with_body(h: TestHelper) =>
+    let raw: String val =
+      "POST /login HTTP/1.1\r\n" +
+      "Host: example.com\r\n" +
+      "Content-Length: 13\r\n" +
+      "\r\n" +
+      "user=testuser"
+    let notify: _TestParserNotify ref = _TestParserNotify
+    let parser = _RequestParser(notify)
+    parser.parse(recover raw.array().clone() end)
+
+    h.assert_eq[USize](1, notify.requests.size(), "POST: 1 request")
+    h.assert_eq[USize](1, notify.completed, "POST: 1 completion")
+    try
+      (let m, let u, _, _) = notify.requests(0)?
+      h.assert_true(m is POST, "method should be POST")
+      h.assert_eq[String val]("/login", u, "URI should be /login")
+    else
+      h.fail("POST: could not read request")
+    end
+    h.assert_eq[String val](
+      "user=testuser",
+      notify.collected_body_string(),
+      "POST body")
+
+  fun _test_get_with_multiple_headers(h: TestHelper) =>
+    let raw: String val =
+      "GET /page HTTP/1.1\r\n" +
+      "Host: example.com\r\n" +
+      "Accept: text/html\r\n" +
+      "Accept-Language: en\r\n" +
+      "\r\n"
+    let notify: _TestParserNotify ref = _TestParserNotify
+    let parser = _RequestParser(notify)
+    parser.parse(recover raw.array().clone() end)
+
+    h.assert_eq[USize](1, notify.requests.size())
+    try
+      (_, _, _, let hdrs) = notify.requests(0)?
+      h.assert_eq[USize](3, hdrs.size(), "should have 3 headers")
+    else
+      h.fail("could not read request")
+    end
+
+class \nodoc\ iso _TestIncrementalByteByByte is UnitTest
+  """
+  Feed a complete request one byte at a time. Verify the parser produces
+  the same result as feeding all at once.
+  """
+  fun name(): String => "parser/incremental_byte_by_byte"
+
+  fun apply(h: TestHelper) =>
+    let raw: String val =
+      "GET / HTTP/1.1\r\nHost: localhost\r\nContent-Length: 5\r\n\r\nHello"
+
+    let notify: _TestParserNotify ref = _TestParserNotify
+    let parser = _RequestParser(notify)
+
+    // Feed one byte at a time
+    var i: USize = 0
+    let arr = raw.array()
+    while i < arr.size() do
+      try
+        let byte = recover iso
+          let a = Array[U8](1)
+          a.push(arr(i)?)
+          a
+        end
+        parser.parse(consume byte)
+      end
+      i = i + 1
+    end
+
+    h.assert_eq[USize](1, notify.requests.size(), "1 request")
+    h.assert_eq[USize](1, notify.completed, "1 completion")
+    h.assert_eq[USize](0, notify.errors.size(), "0 errors")
+    h.assert_eq[String val](
+      "Hello",
+      notify.collected_body_string(),
+      "body should be Hello")
+
+class \nodoc\ iso _TestPipelining is UnitTest
+  """Two GET requests back-to-back in one buffer — both parsed in order."""
+  fun name(): String => "parser/pipelining"
+
+  fun apply(h: TestHelper) =>
+    let raw: String val =
+      "GET /first HTTP/1.1\r\nHost: test\r\n\r\n" +
+      "GET /second HTTP/1.1\r\nHost: test\r\n\r\n"
+
+    let notify: _TestParserNotify ref = _TestParserNotify
+    let parser = _RequestParser(notify)
+    parser.parse(recover raw.array().clone() end)
+
+    h.assert_eq[USize](2, notify.requests.size(), "2 requests")
+    h.assert_eq[USize](2, notify.completed, "2 completions")
+    try
+      h.assert_eq[String val]("/first", notify.requests(0)?._2)
+      h.assert_eq[String val]("/second", notify.requests(1)?._2)
+    else
+      h.fail("could not read requests")
+    end
+
+class \nodoc\ iso _TestPipeliningWithBody is UnitTest
+  """Two requests, first with Content-Length body — both parsed correctly."""
+  fun name(): String => "parser/pipelining_with_body"
+
+  fun apply(h: TestHelper) =>
+    let raw: String val =
+      "POST /data HTTP/1.1\r\nContent-Length: 3\r\n\r\nabc" +
+      "GET /next HTTP/1.1\r\nHost: test\r\n\r\n"
+
+    let notify: _TestParserNotify ref = _TestParserNotify
+    let parser = _RequestParser(notify)
+    parser.parse(recover raw.array().clone() end)
+
+    h.assert_eq[USize](2, notify.requests.size(), "2 requests")
+    h.assert_eq[USize](2, notify.completed, "2 completions")
+    try
+      (let m1, let u1, _, _) = notify.requests(0)?
+      h.assert_true(m1 is POST, "first is POST")
+      h.assert_eq[String val]("/data", u1)
+
+      (let m2, let u2, _, _) = notify.requests(1)?
+      h.assert_true(m2 is GET, "second is GET")
+      h.assert_eq[String val]("/next", u2)
+    else
+      h.fail("could not read requests")
+    end
+
+class \nodoc\ iso _TestPipeliningChunked is UnitTest
+  """Two requests, first chunked — both parsed correctly."""
+  fun name(): String => "parser/pipelining_chunked"
+
+  fun apply(h: TestHelper) =>
+    let raw: String val =
+      "POST /upload HTTP/1.1\r\n" +
+      "Transfer-Encoding: chunked\r\n\r\n" +
+      "5\r\nHello\r\n0\r\n\r\n" +
+      "GET /done HTTP/1.1\r\nHost: test\r\n\r\n"
+
+    let notify: _TestParserNotify ref = _TestParserNotify
+    let parser = _RequestParser(notify)
+    parser.parse(recover raw.array().clone() end)
+
+    h.assert_eq[USize](2, notify.requests.size(), "2 requests")
+    h.assert_eq[USize](2, notify.completed, "2 completions")
+    h.assert_eq[String val](
+      "Hello", notify.collected_body_string())
+
+class \nodoc\ iso _TestSizeLimitRequestLine is UnitTest
+  """Request line exceeding small limit → TooLarge."""
+  fun name(): String => "parser/size_limit_request_line"
+
+  fun apply(h: TestHelper) =>
+    let config = _ParserConfig(where max_request_line_size' = 16)
+    let notify: _TestParserNotify ref = _TestParserNotify
+    let parser = _RequestParser(notify, config)
+
+    // "GET /very-long-path HTTP/1.1" is longer than 16 bytes
+    let raw = "GET /very-long-path HTTP/1.1\r\n\r\n"
+    parser.parse(recover raw.array().clone() end)
+
+    h.assert_eq[USize](1, notify.errors.size(), "should have 1 error")
+    try
+      h.assert_true(notify.errors(0)? is TooLarge, "should be TooLarge")
+    end
+
+class \nodoc\ iso _TestSizeLimitHeaders is UnitTest
+  """Headers exceeding small limit → TooLarge."""
+  fun name(): String => "parser/size_limit_headers"
+
+  fun apply(h: TestHelper) =>
+    let config = _ParserConfig(where max_header_size' = 32)
+    let notify: _TestParserNotify ref = _TestParserNotify
+    let parser = _RequestParser(notify, config)
+
+    let raw: String val =
+      "GET / HTTP/1.1\r\n" +
+      "X-Very-Long-Header-Name: very-long-value-that-exceeds-limit\r\n" +
+      "\r\n"
+    parser.parse(recover raw.array().clone() end)
+
+    h.assert_eq[USize](1, notify.errors.size(), "should have 1 error")
+    try
+      h.assert_true(notify.errors(0)? is TooLarge, "should be TooLarge")
+    end
+
+class \nodoc\ iso _TestSizeLimitBody is UnitTest
+  """Content-Length or chunked body exceeding small limit → BodyTooLarge."""
+  fun name(): String => "parser/size_limit_body"
+
+  fun apply(h: TestHelper) =>
+    let config = _ParserConfig(where max_body_size' = 5)
+
+    // Fixed body: Content-Length 10 > max_body_size 5
+    let notify: _TestParserNotify ref = _TestParserNotify
+    let parser = _RequestParser(notify, config)
+    let raw: String val =
+      "POST / HTTP/1.1\r\n" +
+      "Content-Length: 10\r\n\r\n" +
+      "0123456789"
+    parser.parse(recover raw.array().clone() end)
+
+    h.assert_eq[USize](1, notify.errors.size(),
+      "fixed body: should have 1 error")
+    try
+      h.assert_true(notify.errors(0)? is BodyTooLarge,
+        "fixed body: should be BodyTooLarge")
+    end
+
+    // Chunked body: 10 bytes > max_body_size 5
+    let notify2: _TestParserNotify ref = _TestParserNotify
+    let parser2 = _RequestParser(notify2, config)
+    let raw2: String val =
+      "POST / HTTP/1.1\r\n" +
+      "Transfer-Encoding: chunked\r\n\r\n" +
+      "a\r\n0123456789\r\n0\r\n\r\n"
+    parser2.parse(recover raw2.array().clone() end)
+
+    h.assert_eq[USize](1, notify2.errors.size(),
+      "chunked body: should have 1 error")
+    try
+      h.assert_true(notify2.errors(0)? is BodyTooLarge,
+        "chunked body: should be BodyTooLarge")
+    end
+
+class \nodoc\ iso _TestInvalidContentLength is UnitTest
+  """Non-numeric Content-Length → InvalidContentLength."""
+  fun name(): String => "parser/invalid_content_length"
+
+  fun apply(h: TestHelper) =>
+    let raw = "POST / HTTP/1.1\r\nContent-Length: abc\r\n\r\n"
+    let notify: _TestParserNotify ref = _TestParserNotify
+    let parser = _RequestParser(notify)
+    parser.parse(recover raw.array().clone() end)
+
+    h.assert_eq[USize](1, notify.errors.size(), "should have 1 error")
+    try
+      h.assert_true(notify.errors(0)? is InvalidContentLength,
+        "should be InvalidContentLength")
+    end
+
+class \nodoc\ iso _TestInvalidChunkSize is UnitTest
+  """Non-hex chunk size → InvalidChunk."""
+  fun name(): String => "parser/invalid_chunk_size"
+
+  fun apply(h: TestHelper) =>
+    let raw: String val =
+      "POST / HTTP/1.1\r\n" +
+      "Transfer-Encoding: chunked\r\n\r\n" +
+      "xyz\r\n"
+    let notify: _TestParserNotify ref = _TestParserNotify
+    let parser = _RequestParser(notify)
+    parser.parse(recover raw.array().clone() end)
+
+    h.assert_eq[USize](1, notify.errors.size(), "should have 1 error")
+    try
+      h.assert_true(notify.errors(0)? is InvalidChunk,
+        "should be InvalidChunk")
+    end
+
+class \nodoc\ iso _TestMissingCRLFAfterChunk is UnitTest
+  """Wrong bytes after chunk data → InvalidChunk."""
+  fun name(): String => "parser/missing_crlf_after_chunk"
+
+  fun apply(h: TestHelper) =>
+    let raw: String val =
+      "POST / HTTP/1.1\r\n" +
+      "Transfer-Encoding: chunked\r\n\r\n" +
+      "5\r\nHelloXX"  // Missing CRLF after "Hello", has "XX" instead
+    let notify: _TestParserNotify ref = _TestParserNotify
+    let parser = _RequestParser(notify)
+    parser.parse(recover raw.array().clone() end)
+
+    h.assert_eq[USize](1, notify.errors.size(), "should have 1 error")
+    try
+      h.assert_true(notify.errors(0)? is InvalidChunk,
+        "should be InvalidChunk")
+    end
+
+class \nodoc\ iso _TestChunkedWithTrailers is UnitTest
+  """Chunked request with trailer headers → trailers skipped, completes."""
+  fun name(): String => "parser/chunked_with_trailers"
+
+  fun apply(h: TestHelper) =>
+    let raw: String val =
+      "POST / HTTP/1.1\r\n" +
+      "Transfer-Encoding: chunked\r\n\r\n" +
+      "5\r\nHello\r\n" +
+      "0\r\n" +
+      "Trailer-Header: value\r\n" +
+      "\r\n"
+    let notify: _TestParserNotify ref = _TestParserNotify
+    let parser = _RequestParser(notify)
+    parser.parse(recover raw.array().clone() end)
+
+    h.assert_eq[USize](1, notify.requests.size(), "1 request")
+    h.assert_eq[USize](1, notify.completed, "1 completion")
+    h.assert_eq[USize](0, notify.errors.size(), "0 errors")
+    h.assert_eq[String val](
+      "Hello", notify.collected_body_string())
+
+class \nodoc\ iso _TestHTTP10Version is UnitTest
+  """HTTP/1.0 request → version is HTTP10."""
+  fun name(): String => "parser/http10_version"
+
+  fun apply(h: TestHelper) =>
+    let raw = "GET / HTTP/1.0\r\nHost: test\r\n\r\n"
+    let notify: _TestParserNotify ref = _TestParserNotify
+    let parser = _RequestParser(notify)
+    parser.parse(recover raw.array().clone() end)
+
+    h.assert_eq[USize](1, notify.requests.size())
+    try
+      h.assert_true(notify.requests(0)?._3 is HTTP10,
+        "version should be HTTP/1.0")
+    end
+
+class \nodoc\ iso _TestInvalidVersion is UnitTest
+  """Bad version string → InvalidVersion."""
+  fun name(): String => "parser/invalid_version"
+
+  fun apply(h: TestHelper) =>
+    _test_version(h, "HTTP/2.0")
+    _test_version(h, "HTTP/1.2")
+    _test_version(h, "HTXP/1.1")
+    _test_version(h, "HTTP/1")
+
+  fun _test_version(h: TestHelper, ver: String val) =>
+    let raw: String val = "GET / " + ver + "\r\n\r\n"
+    let notify: _TestParserNotify ref = _TestParserNotify
+    let parser = _RequestParser(notify)
+    parser.parse(recover raw.array().clone() end)
+    h.assert_eq[USize](1, notify.errors.size(),
+      "should have 1 error for " + ver)
+    try
+      h.assert_true(notify.errors(0)? is InvalidVersion,
+        "should be InvalidVersion for " + ver)
+    end
+
+class \nodoc\ iso _TestNoBody is UnitTest
+  """
+  GET request with no Content-Length or Transfer-Encoding →
+  request_complete immediately after headers.
+  """
+  fun name(): String => "parser/no_body"
+
+  fun apply(h: TestHelper) =>
+    let raw = "GET / HTTP/1.1\r\nHost: test\r\n\r\n"
+    let notify: _TestParserNotify ref = _TestParserNotify
+    let parser = _RequestParser(notify)
+    parser.parse(recover raw.array().clone() end)
+
+    h.assert_eq[USize](1, notify.requests.size(), "1 request")
+    h.assert_eq[USize](1, notify.completed, "1 completion")
+    h.assert_eq[USize](0, notify.body_chunks.size(), "0 body chunks")
+
+class \nodoc\ iso _TestContentLengthZero is UnitTest
+  """Content-Length: 0 → request_complete immediately (no body state)."""
+  fun name(): String => "parser/content_length_zero"
+
+  fun apply(h: TestHelper) =>
+    let raw: String val =
+      "POST / HTTP/1.1\r\n" +
+      "Content-Length: 0\r\n" +
+      "\r\n"
+    let notify: _TestParserNotify ref = _TestParserNotify
+    let parser = _RequestParser(notify)
+    parser.parse(recover raw.array().clone() end)
+
+    h.assert_eq[USize](1, notify.requests.size(), "1 request")
+    h.assert_eq[USize](1, notify.completed, "1 completion")
+    h.assert_eq[USize](0, notify.body_chunks.size(), "0 body chunks")
+
+class \nodoc\ iso _TestContentLengthAndChunked is UnitTest
+  """
+  Both Content-Length and Transfer-Encoding: chunked → chunked takes
+  precedence per RFC 7230 §3.3.3.
+  """
+  fun name(): String => "parser/content_length_and_chunked"
+
+  fun apply(h: TestHelper) =>
+    let raw: String val =
+      "POST / HTTP/1.1\r\n" +
+      "Content-Length: 100\r\n" +
+      "Transfer-Encoding: chunked\r\n" +
+      "\r\n" +
+      "5\r\nHello\r\n0\r\n\r\n"
+    let notify: _TestParserNotify ref = _TestParserNotify
+    let parser = _RequestParser(notify)
+    parser.parse(recover raw.array().clone() end)
+
+    h.assert_eq[USize](1, notify.requests.size(), "1 request")
+    h.assert_eq[USize](1, notify.completed, "1 completion")
+    h.assert_eq[USize](0, notify.errors.size(), "0 errors")
+    // Body is 5 bytes (chunked), not 100 (Content-Length)
+    h.assert_eq[String val](
+      "Hello", notify.collected_body_string())
+
+class \nodoc\ iso _TestDuplicateContentLength is UnitTest
+  """Two Content-Length headers with differing values → InvalidContentLength."""
+  fun name(): String => "parser/duplicate_content_length"
+
+  fun apply(h: TestHelper) =>
+    let raw: String val =
+      "POST / HTTP/1.1\r\n" +
+      "Content-Length: 10\r\n" +
+      "Content-Length: 20\r\n" +
+      "\r\n"
+    let notify: _TestParserNotify ref = _TestParserNotify
+    let parser = _RequestParser(notify)
+    parser.parse(recover raw.array().clone() end)
+
+    h.assert_eq[USize](1, notify.errors.size(), "should have 1 error")
+    try
+      h.assert_true(notify.errors(0)? is InvalidContentLength,
+        "should be InvalidContentLength")
+    end
+
+class \nodoc\ iso _TestInvalidURI is UnitTest
+  """URI with control characters → InvalidURI."""
+  fun name(): String => "parser/invalid_uri"
+
+  fun apply(h: TestHelper) =>
+    // URI with control character (0x01) → InvalidURI
+    let raw: String val = recover val
+      let s = String
+      s.append("GET /foo")
+      s.push(0x01)
+      s.append("bar HTTP/1.1\r\n\r\n")
+      s
+    end
+    let notify: _TestParserNotify ref = _TestParserNotify
+    let parser = _RequestParser(notify)
+    parser.parse(recover raw.array().clone() end)
+
+    h.assert_eq[USize](1, notify.errors.size(),
+      "should have 1 error")
+    try
+      h.assert_true(notify.errors(0)? is InvalidURI,
+        "should be InvalidURI")
+    end
+
+class \nodoc\ iso _TestDataAfterError is UnitTest
+  """
+  Feed data after a parse error → no additional callbacks fired
+  (verifies _failed short-circuit).
+  """
+  fun name(): String => "parser/data_after_error"
+
+  fun apply(h: TestHelper) =>
+    let notify: _TestParserNotify ref = _TestParserNotify
+    let parser = _RequestParser(notify)
+
+    // Cause an error
+    let bad = "INVALID / HTTP/1.1\r\n\r\n"
+    parser.parse(recover bad.array().clone() end)
+    h.assert_eq[USize](1, notify.errors.size(), "1 error after bad request")
+
+    // Feed valid data after error
+    let good = "GET / HTTP/1.1\r\nHost: test\r\n\r\n"
+    parser.parse(recover good.array().clone() end)
+
+    // Should still have exactly 1 error and 0 requests
+    h.assert_eq[USize](1, notify.errors.size(),
+      "still 1 error after second parse")
+    h.assert_eq[USize](0, notify.requests.size(),
+      "0 requests (parser is failed)")

--- a/http_server/parse_error.pony
+++ b/http_server/parse_error.pony
@@ -1,0 +1,38 @@
+interface val _ParseError is Stringable
+
+primitive TooLarge is _ParseError
+  """Request line or headers exceed the configured size limit."""
+  fun string(): String iso^ => "TooLarge".clone()
+
+primitive UnknownMethod is _ParseError
+  """HTTP method string not recognized."""
+  fun string(): String iso^ => "UnknownMethod".clone()
+
+primitive InvalidURI is _ParseError
+  """Request URI is empty or contains spaces or control characters."""
+  fun string(): String iso^ => "InvalidURI".clone()
+
+primitive InvalidVersion is _ParseError
+  """HTTP version is not HTTP/1.0 or HTTP/1.1."""
+  fun string(): String iso^ => "InvalidVersion".clone()
+
+primitive MalformedHeaders is _ParseError
+  """Header syntax is invalid (missing colon, obs-fold continuation line)."""
+  fun string(): String iso^ => "MalformedHeaders".clone()
+
+primitive InvalidContentLength is _ParseError
+  """Content-Length is non-numeric, negative, or has conflicting values."""
+  fun string(): String iso^ => "InvalidContentLength".clone()
+
+primitive InvalidChunk is _ParseError
+  """Chunked transfer encoding error: bad chunk size or missing CRLF."""
+  fun string(): String iso^ => "InvalidChunk".clone()
+
+primitive BodyTooLarge is _ParseError
+  """Request body exceeds the configured maximum body size."""
+  fun string(): String iso^ => "BodyTooLarge".clone()
+
+type ParseError is
+  ((TooLarge | UnknownMethod | InvalidURI | InvalidVersion | MalformedHeaders
+  | InvalidContentLength | InvalidChunk | BodyTooLarge) & _ParseError)
+  """Parse error encountered during HTTP request parsing."""


### PR DESCRIPTION
Phase 2 of the implementation plan ([Discussion #2](https://github.com/ponylang/lori_http_server/discussions/2)): a plain class HTTP/1.1 request parser as a state machine.

- Data fed in as chunks matching lori's delivery model, parsed requests delivered via synchronous `ref` callbacks
- State machine uses classes-as-states (adapted from ponylang/postgres) with single-method `_ParserState` interface
- Each state class owns its per-state data, automatically cleaned up on transitions
- Handles fixed-length bodies (Content-Length), chunked transfer encoding, HTTP pipelining
- Configurable size limits (`_ParserConfig`) for request line, headers, chunk headers, and body size
- Parse errors are a typed union (`ParseError`) of 8 error primitives
- No lori dependency — testable in isolation
- 6 property-based tests + 20 example-based tests (34 total including existing)