### PR TITLE
Add lori integration layer

### DIFF
--- a/.github/workflows/breakage-against-ponyc-latest.yml
+++ b/.github/workflows/breakage-against-ponyc-latest.yml
@@ -13,11 +13,11 @@ jobs:
     name: Test against ponyc main
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/ponylang/shared-docker-ci-standard-builder:nightly
+      image: ghcr.io/ponylang/shared-docker-ci-standard-builder-with-libressl-4.2.0:release
     steps:
       - uses: actions/checkout@v4.1.1
       - name: Test
-        run: make test config=debug
+        run: make test ssl=libressl config=debug
       - name: Send alert on failure
         if: ${{ failure() }}
         uses: zulip/github-actions-zulip/send-message@e4c8f27c732ba9bd98ac6be0583096dea82feea5

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -39,8 +39,8 @@ jobs:
     name: Test against recent ponyc release
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/ponylang/shared-docker-ci-standard-builder:release
+      image: ghcr.io/ponylang/shared-docker-ci-standard-builder-with-libressl-4.2.0:release
     steps:
       - uses: actions/checkout@v4.1.1
       - name: Test
-        run: make test config=debug
+        run: make test ssl=libressl config=debug

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,20 @@ else
 	PONYC = $(COMPILE_WITH) --debug
 endif
 
+ifeq (,$(filter $(MAKECMDGOALS),clean docs TAGS))
+  ifeq ($(ssl), 3.0.x)
+          SSL = -Dopenssl_3.0.x
+  else ifeq ($(ssl), 1.1.x)
+          SSL = -Dopenssl_1.1.x
+  else ifeq ($(ssl), libressl)
+          SSL = -Dlibressl
+  else
+    $(error Unknown SSL version "$(ssl)". Must set using 'ssl=FOO')
+  endif
+endif
+
+PONYC := $(PONYC) $(SSL)
+
 SOURCE_FILES := $(shell find $(SRC_DIR) -name *.pony)
 EXAMPLES := $(notdir $(shell find $(EXAMPLES_DIR)/* -type d))
 EXAMPLES_SOURCE_FILES := $(shell find $(EXAMPLES_DIR) -name *.pony)

--- a/corral.json
+++ b/corral.json
@@ -12,7 +12,7 @@
   },
   "deps": [
     {
-      "locator": "github.com/ponylang/lori",
+      "locator": "github.com/ponylang/lori.git",
       "version": "0.8.1"
     }
   ]

--- a/examples/basic/main.pony
+++ b/examples/basic/main.pony
@@ -1,5 +1,33 @@
-use "../../http_server"
+"""
+Basic HTTP server that responds to every request with "Hello, World!".
+
+Demonstrates the core API: `Server`, `HandlerFactory`, `Handler`, and
+`Responder`.
+"""
+use http_server = "../../http_server"
+use lori = "lori"
 
 actor Main
   new create(env: Env) =>
-    env.out.print("HTTP server example")
+    let auth = lori.TCPListenAuth(env.root)
+    http_server.Server(auth, "localhost", "8080", _HelloFactory)
+    env.out.print("HTTP server listening on localhost:8080")
+
+class val _HelloFactory is http_server.HandlerFactory
+  fun apply(responder: http_server.Responder): http_server.Handler ref^ =>
+    _HelloHandler(responder)
+
+class ref _HelloHandler is http_server.Handler
+  let _responder: http_server.Responder
+
+  new ref create(responder: http_server.Responder) =>
+    _responder = responder
+
+  fun ref request_complete() =>
+    let headers = recover val
+      let h = http_server.Headers
+      h.set("content-type", "text/plain")
+      h.set("content-length", "13")
+      h
+    end
+    _responder.respond(http_server.StatusOK, headers, "Hello, World!")

--- a/http_server/_connection.pony
+++ b/http_server/_connection.pony
@@ -1,0 +1,94 @@
+use lori = "lori"
+
+actor _Connection is
+  (lori.TCPConnectionActor & lori.ServerLifecycleEventReceiver
+    & _RequestParserNotify)
+  """
+  Per-connection actor that owns TCP I/O, parsing, handler dispatch,
+  and response sending.
+
+  Implements the single-actor connection model: no actor boundaries
+  between the TCP layer and application handler. Data arrives via
+  `_on_received`, is fed to the parser, and parser callbacks are
+  forwarded to the handler synchronously.
+
+  Phase 3 lifecycle: close after every response. No keep-alive.
+  """
+  var _tcp_connection: lori.TCPConnection = lori.TCPConnection.none()
+  var _state: _ConnectionState = _Active
+  let _responder: Responder
+  let _handler: Handler
+  var _parser: (_RequestParser | None) = None
+
+  new create(
+    auth: lori.TCPServerAuth,
+    fd: U32,
+    handler_factory: HandlerFactory)
+  =>
+    // Initialize responder and handler first with placeholder connection.
+    // _parser defaults to None, so all fields are now initialized and
+    // `this` becomes `ref` — required by TCPConnection.server and
+    // _RequestParser.
+    _responder = Responder._create(_tcp_connection)
+    _handler = handler_factory(_responder)
+    _tcp_connection = lori.TCPConnection.server(auth, fd, this, this)
+    _responder._set_connection(_tcp_connection)
+    _parser = _RequestParser(this)
+
+  //
+  // TCPConnectionActor / ServerLifecycleEventReceiver
+  //
+
+  fun ref _connection(): lori.TCPConnection =>
+    _tcp_connection
+
+  fun ref _on_received(data: Array[U8] iso) =>
+    _state.on_received(this, consume data)
+
+  fun ref _on_closed() =>
+    _state.on_closed(this)
+
+  //
+  // _RequestParserNotify — forwarding parser events to handler
+  //
+
+  fun ref request_received(
+    method: Method,
+    uri: String val,
+    version: Version,
+    headers: Headers val)
+  =>
+    _responder._set_version(version)
+    _handler.request(method, uri, version, headers)
+
+  fun ref body_chunk(data: Array[U8] val) =>
+    _handler.body_chunk(data)
+
+  fun ref request_complete() =>
+    _handler.request_complete()
+    // Phase 3: always close after request completes
+    _tcp_connection.close()
+    _state = _Closed
+
+  fun ref parse_error(err: ParseError) =>
+    let response = _ResponseSerializer(
+      StatusBadRequest,
+      recover val Headers end)
+    _tcp_connection.send(consume response)
+    _tcp_connection.close()
+    _state = _Closed
+
+  //
+  // Internal methods called by state classes
+  //
+
+  fun ref _feed_parser(data: Array[U8] iso) =>
+    """Feed incoming data to the request parser."""
+    match _parser
+    | let p: _RequestParser => p.parse(consume data)
+    end
+
+  fun ref _handle_closed() =>
+    """Notify the handler that the connection has closed."""
+    _handler.closed()
+    _state = _Closed

--- a/http_server/_connection_state.pony
+++ b/http_server/_connection_state.pony
@@ -1,0 +1,38 @@
+trait ref _ConnectionState
+  """
+  Connection lifecycle state.
+
+  Dispatches lori events to the appropriate connection methods based on
+  what operations are valid in each state. Phase 3 has two states:
+  `_Active` (processing requests) and `_Closed` (all operations are
+  no-ops). Phase 4 can split `_Active` into finer-grained states for
+  keep-alive.
+  """
+
+  fun ref on_received(conn: _Connection ref, data: Array[U8] iso)
+    """Handle incoming data from the TCP connection."""
+
+  fun ref on_closed(conn: _Connection ref)
+    """Handle connection close notification."""
+
+class ref _Active is _ConnectionState
+  """
+  Connection is active — parsing requests and dispatching to the handler.
+  """
+
+  fun ref on_received(conn: _Connection ref, data: Array[U8] iso) =>
+    conn._feed_parser(consume data)
+
+  fun ref on_closed(conn: _Connection ref) =>
+    conn._handle_closed()
+
+class ref _Closed is _ConnectionState
+  """
+  Connection is closed — all operations are no-ops.
+  """
+
+  fun ref on_received(conn: _Connection ref, data: Array[U8] iso) =>
+    None
+
+  fun ref on_closed(conn: _Connection ref) =>
+    None

--- a/http_server/_test.pony
+++ b/http_server/_test.pony
@@ -1,5 +1,6 @@
 use "pony_test"
 use "pony_check"
+use lori = "lori"
 
 actor \nodoc\ Main is TestList
   new create(env: Env) =>
@@ -60,3 +61,7 @@ actor \nodoc\ Main is TestList
     test(_TestDuplicateContentLength)
     test(_TestInvalidURI)
     test(_TestDataAfterError)
+
+    // Server integration tests
+    test(_TestServerHelloWorld)
+    test(_TestServerParseError)

--- a/http_server/_test_server.pony
+++ b/http_server/_test_server.pony
@@ -1,0 +1,166 @@
+use "pony_test"
+use lori = "lori"
+
+class \nodoc\ iso _TestServerHelloWorld is UnitTest
+  """
+  Start a listener, connect a client, send a GET request,
+  verify the handler responds with 200 OK and "Hello, World!" body.
+  """
+  fun name(): String => "server/hello world"
+
+  fun apply(h: TestHelper) =>
+    h.long_test(5_000_000_000)
+    let port = "45871"
+    let listener = _TestServerListener(h, port, _TestHelloFactory)
+    h.dispose_when_done(listener)
+
+class \nodoc\ iso _TestServerParseError is UnitTest
+  """
+  Start a listener, connect a client, send garbage bytes,
+  verify the connection responds with 400 Bad Request.
+  """
+  fun name(): String => "server/parse error"
+
+  fun apply(h: TestHelper) =>
+    h.long_test(5_000_000_000)
+    let port = "45872"
+    let listener = _TestServerListener(h, port, _TestHelloFactory)
+    h.dispose_when_done(listener)
+
+// ---------------------------------------------------------------------------
+// Test handler: responds with "Hello, World!" on every request
+// ---------------------------------------------------------------------------
+
+class \nodoc\ val _TestHelloFactory is HandlerFactory
+  fun apply(responder: Responder): Handler ref^ =>
+    _TestHelloHandler(responder)
+
+class \nodoc\ ref _TestHelloHandler is Handler
+  let _responder: Responder
+
+  new ref create(responder: Responder) =>
+    _responder = responder
+
+  fun ref request_complete() =>
+    let headers = recover val
+      let h = Headers
+      h.set("content-type", "text/plain")
+      h.set("content-length", "13")
+      h
+    end
+    _responder.respond(StatusOK, headers, "Hello, World!")
+
+// ---------------------------------------------------------------------------
+// Test listener: creates _Connection actors, starts test client
+// ---------------------------------------------------------------------------
+
+actor \nodoc\ _TestServerListener is lori.TCPListenerActor
+  var _tcp_listener: lori.TCPListener = lori.TCPListener.none()
+  let _server_auth: lori.TCPServerAuth
+  let _handler_factory: HandlerFactory
+  let _h: TestHelper
+  let _port: String
+
+  new create(h: TestHelper, port: String, handler_factory: HandlerFactory) =>
+    _h = h
+    _port = port
+    _handler_factory = handler_factory
+    let listen_auth = lori.TCPListenAuth(_h.env.root)
+    _server_auth = lori.TCPServerAuth(listen_auth)
+    let host = ifdef linux then "127.0.0.2" else "localhost" end
+    _tcp_listener = lori.TCPListener(listen_auth, host, port, this)
+
+  fun ref _listener(): lori.TCPListener =>
+    _tcp_listener
+
+  fun ref _on_accept(fd: U32): _Connection =>
+    _Connection(_server_auth, fd, _handler_factory)
+
+  fun ref _on_listening() =>
+    // Server is ready — start the test client based on which test is running
+    if _port == "45871" then
+      // Hello world test: send valid HTTP request
+      let request = "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n"
+      let client = _TestHTTPClient(_h, _port, request, "200 OK",
+        "Hello, World!")
+      _h.dispose_when_done(client)
+    elseif _port == "45872" then
+      // Parse error test: send garbage
+      let client = _TestHTTPClient(_h, _port, "GARBAGE DATA\r\n\r\n",
+        "400 Bad Request", None)
+      _h.dispose_when_done(client)
+    end
+
+  fun ref _on_listen_failure() =>
+    _h.fail("Listener failed to start on port " + _port)
+    _h.complete(false)
+
+// ---------------------------------------------------------------------------
+// Test client: sends request bytes, verifies response
+// ---------------------------------------------------------------------------
+
+actor \nodoc\ _TestHTTPClient is
+  (lori.TCPConnectionActor & lori.ClientLifecycleEventReceiver)
+
+  var _tcp_connection: lori.TCPConnection = lori.TCPConnection.none()
+  let _h: TestHelper
+  let _request: String val
+  let _expected_status: String val
+  let _expected_body: (String val | None)
+  var _response: String ref = String
+
+  new create(
+    h: TestHelper,
+    port: String,
+    request: String val,
+    expected_status: String val,
+    expected_body: (String val | None))
+  =>
+    _h = h
+    _request = request
+    _expected_status = expected_status
+    _expected_body = expected_body
+    let host = ifdef linux then "127.0.0.2" else "localhost" end
+    _tcp_connection = lori.TCPConnection.client(
+      lori.TCPConnectAuth(_h.env.root), host, port, "", this, this)
+
+  fun ref _connection(): lori.TCPConnection =>
+    _tcp_connection
+
+  fun ref _on_connected() =>
+    _tcp_connection.send(_request)
+
+  fun ref _on_received(data: Array[U8] iso) =>
+    _response.append(consume data)
+    // Check if we have a complete response (headers end with \r\n\r\n)
+    if _response.contains("\r\n\r\n") then
+      _verify_response()
+    end
+
+  fun ref _on_connection_failure() =>
+    _h.fail("Client connection failed")
+    _h.complete(false)
+
+  fun ref _verify_response() =>
+    let response: String val = _response.clone()
+
+    // Verify status line contains expected status
+    if not response.contains(_expected_status) then
+      _h.fail("Expected status '" + _expected_status
+        + "' not found in response:\n" + response)
+      _h.complete(false)
+      return
+    end
+
+    // Verify body if expected
+    match _expected_body
+    | let body: String val =>
+      if not response.contains(body) then
+        _h.fail("Expected body '" + body
+          + "' not found in response:\n" + response)
+        _h.complete(false)
+        return
+      end
+    end
+
+    _h.complete(true)

--- a/http_server/handler.pony
+++ b/http_server/handler.pony
@@ -1,0 +1,64 @@
+trait ref Handler
+  """
+  Application handler for HTTP requests.
+
+  All methods run synchronously inside the connection actor. The handler
+  receives a `Responder` at creation time (via `HandlerFactory`) and uses
+  it to send responses.
+
+  Only `request_complete` must be implemented — the other methods have
+  default no-op implementations for handlers that don't need them.
+  """
+
+  fun ref request(
+    method: Method,
+    uri: String val,
+    version: Version,
+    headers: Headers val)
+  =>
+    """
+    Called when the request line and all headers have been parsed.
+
+    For requests with a body, `body_chunk` calls follow. For requests
+    without a body, `request_complete` is called immediately after.
+    """
+    None
+
+  fun ref body_chunk(data: Array[U8] val) =>
+    """
+    Called for each chunk of request body data as it becomes available.
+
+    Body data is delivered incrementally — not accumulated. Not all
+    requests have bodies.
+    """
+    None
+
+  fun ref request_complete()
+    """
+    Called when the entire request (including any body) has been received.
+
+    This is typically where the handler calls `Responder.respond()` to
+    send a response. After this method returns, the connection closes
+    (Phase 3 — no keep-alive).
+    """
+
+  fun ref closed() =>
+    """
+    Called when the remote peer closes the connection before the request
+    completes.
+
+    Not called after a normal request/response cycle — once `request_complete`
+    returns, the connection transitions to a closed state before lori's close
+    notification arrives.
+    """
+    None
+
+interface val HandlerFactory
+  """
+  Creates a handler for each new connection.
+
+  The factory is `val` so it can be safely shared across connection actors.
+  Each call receives a `Responder` that the handler should store for
+  sending responses.
+  """
+  fun apply(responder: Responder): Handler ref^

--- a/http_server/http_server.pony
+++ b/http_server/http_server.pony
@@ -1,3 +1,26 @@
 """
-HTTP server for Pony.
+HTTP server for Pony, built on lori.
+
+Start a server with `Server`, passing a `HandlerFactory` that creates a
+`Handler` for each connection. Use `Responder.respond()` to send responses:
+
+```pony
+use "http_server"
+use lori = "lori"
+
+actor Main
+  new create(env: Env) =>
+    Server(lori.TCPListenAuth(env.root), "localhost", "8080", MyFactory)
+
+class val MyFactory is HandlerFactory
+  fun apply(responder: Responder): Handler ref^ =>
+    MyHandler(responder)
+
+class ref MyHandler is Handler
+  let _responder: Responder
+  new ref create(responder: Responder) => _responder = responder
+
+  fun ref request_complete() =>
+    _responder.respond(StatusOK, None, "Hello!")
+```
 """

--- a/http_server/responder.pony
+++ b/http_server/responder.pony
@@ -1,0 +1,64 @@
+use lori = "lori"
+
+class ref Responder
+  """
+  Sends an HTTP response on a connection.
+
+  The handler receives a `Responder` at creation time and calls `respond()`
+  to send a response. Only the first call to `respond()` takes effect —
+  subsequent calls are silently ignored.
+
+  Responders are created internally by the connection actor. Application
+  code should not attempt to construct them directly.
+  """
+  var _tcp_connection: lori.TCPConnection
+  var _version: Version = HTTP11
+  var _responded: Bool = false
+
+  new _create(tcp_connection: lori.TCPConnection) =>
+    """Create a responder for the given connection."""
+    _tcp_connection = tcp_connection
+
+  fun ref respond(
+    status: Status,
+    headers: (Headers val | None) = None,
+    body: (ByteSeq | None) = None)
+  =>
+    """
+    Send an HTTP response with the given status, headers, and optional body.
+
+    Only the first call takes effect. The response version matches the
+    request version (set internally by the connection actor).
+
+    Pass `None` for headers to send a response with no custom headers.
+    To include headers, create them in a `recover val` block:
+    ```pony
+    let headers = recover val
+      let h = Headers
+      h.set("Content-Type", "text/plain")
+      h
+    end
+    responder.respond(StatusOK, headers, "Hello!")
+    ```
+    """
+    if not _responded then
+      _responded = true
+      let h: Headers val = match headers
+      | let h': Headers val => h'
+      | None => recover val Headers end
+      end
+      let response = _ResponseSerializer(status, h, body, _version)
+      _tcp_connection.send(consume response)
+    end
+
+  fun responded(): Bool =>
+    """Whether a response has already been sent."""
+    _responded
+
+  fun ref _set_connection(tcp_connection: lori.TCPConnection) =>
+    """Update the TCP connection (called by the connection after init)."""
+    _tcp_connection = tcp_connection
+
+  fun ref _set_version(version: Version) =>
+    """Set the HTTP version for the response (called by the connection)."""
+    _version = version

--- a/http_server/server.pony
+++ b/http_server/server.pony
@@ -1,0 +1,46 @@
+use lori = "lori"
+
+actor Server is lori.TCPListenerActor
+  """
+  HTTP server that listens for connections and dispatches requests to
+  application handlers.
+
+  Each accepted connection creates a new `Handler` via the provided
+  `HandlerFactory`. Handlers run synchronously inside the connection
+  actor — no extra actor hops for the common case.
+
+  ```pony
+  use "http_server"
+  use lori = "lori"
+
+  actor Main
+    new create(env: Env) =>
+      let auth = lori.TCPListenAuth(env.root)
+      Server(auth, "localhost", "8080", MyHandlerFactory)
+  ```
+  """
+  var _tcp_listener: lori.TCPListener = lori.TCPListener.none()
+  let _handler_factory: HandlerFactory
+  let _server_auth: lori.TCPServerAuth
+
+  new create(
+    auth: lori.TCPListenAuth,
+    host: String,
+    port: String,
+    handler_factory: HandlerFactory)
+  =>
+    """
+    Start an HTTP server listening on the given host and port.
+
+    The `handler_factory` creates a new `Handler` for each accepted
+    connection. It must be `val` (immutable and shareable).
+    """
+    _handler_factory = handler_factory
+    _server_auth = lori.TCPServerAuth(auth)
+    _tcp_listener = lori.TCPListener(auth, host, port, this)
+
+  fun ref _listener(): lori.TCPListener =>
+    _tcp_listener
+
+  fun ref _on_accept(fd: U32): _Connection =>
+    _Connection(_server_auth, fd, _handler_factory)


### PR DESCRIPTION
Implements Phase 3 of the implementation plan: wire up lori TCP I/O to the existing request parser and response serializer.

The core addition is `_Connection`, a single actor per connection that owns TCP I/O, the request parser, handler dispatch, and response sending. `Server` is a thin listener wrapper that creates `_Connection` actors on accept. Application code implements `Handler` (synchronous `ref` callbacks) and `HandlerFactory` (creates a handler per connection).

`Responder` wraps response serialization and TCP send with a once-only guard. Connection lifecycle uses the same trait-based state machine pattern as the parser (`_Active` / `_Closed`).

Phase 3 is close-after-every-response (no keep-alive). Two integration tests verify end-to-end request/response and parse error handling. The basic example is updated to a working HTTP server.

Also adds the `ssl` option to the Makefile (matching lori's pattern) and fixes the corral locator to use `.git` suffix.

Design: #2