### PR TITLE
Add connection management (Phase 4)

### DIFF
--- a/examples/basic/main.pony
+++ b/examples/basic/main.pony
@@ -1,8 +1,8 @@
 """
 Basic HTTP server that responds to every request with "Hello, World!".
 
-Demonstrates the core API: `Server`, `HandlerFactory`, `Handler`, and
-`Responder`.
+Demonstrates the core API: `Server`, `HandlerFactory`, `Handler`,
+`Responder`, `ServerConfig`, and `ServerNotify`.
 """
 use http_server = "../../http_server"
 use lori = "lori"
@@ -10,8 +10,18 @@ use lori = "lori"
 actor Main
   new create(env: Env) =>
     let auth = lori.TCPListenAuth(env.root)
-    http_server.Server(auth, "localhost", "8080", _HelloFactory)
-    env.out.print("HTTP server listening on localhost:8080")
+    let config = http_server.ServerConfig("localhost", "8080")
+    http_server.Server(auth, _HelloFactory, config, _ServerNotify(env))
+
+class val _ServerNotify is http_server.ServerNotify
+  let _env: Env
+  new val create(env: Env) => _env = env
+
+  fun listening(server: http_server.Server tag) =>
+    _env.out.print("Server listening on localhost:8080")
+
+  fun listen_failure(server: http_server.Server tag) =>
+    _env.out.print("Failed to start server")
 
 class val _HelloFactory is http_server.HandlerFactory
   fun apply(responder: http_server.Responder): http_server.Handler ref^ =>

--- a/http_server/_connection.pony
+++ b/http_server/_connection.pony
@@ -1,4 +1,25 @@
 use lori = "lori"
+use "time"
+
+primitive _KeepAliveDecision
+  """
+  Determine whether to keep a connection alive based on HTTP version
+  and the Connection header value.
+
+  HTTP/1.1 defaults to keep-alive; HTTP/1.0 defaults to close. An explicit
+  `Connection: close` or `Connection: keep-alive` header overrides the
+  default.
+  """
+
+  fun apply(version: Version, connection: (String | None)): Bool =>
+    match connection
+    | let c: String =>
+      let lower = c.lower()
+      if lower == "close" then return false end
+      if lower == "keep-alive" then return true end
+    end
+    // Default: HTTP/1.1 keeps alive, HTTP/1.0 does not
+    version is HTTP11
 
 actor _Connection is
   (lori.TCPConnectionActor & lori.ServerLifecycleEventReceiver
@@ -12,28 +33,40 @@ actor _Connection is
   `_on_received`, is fed to the parser, and parser callbacks are
   forwarded to the handler synchronously.
 
-  Phase 3 lifecycle: close after every response. No keep-alive.
+  Connections are persistent by default (HTTP/1.1 keep-alive). The
+  connection closes when the client sends `Connection: close`, on
+  HTTP/1.0 requests without `Connection: keep-alive`, after a parse
+  error, or when the idle timeout expires.
   """
   var _tcp_connection: lori.TCPConnection = lori.TCPConnection.none()
   var _state: _ConnectionState = _Active
   let _responder: Responder
   let _handler: Handler
   var _parser: (_RequestParser | None) = None
+  let _config: ServerConfig
+  let _timers: (Timers | None)
+  var _keep_alive: Bool = true
+  var _idle: Bool = true
+  var _idle_timer: (Timer tag | None) = None
 
   new create(
     auth: lori.TCPServerAuth,
     fd: U32,
-    handler_factory: HandlerFactory)
+    handler_factory: HandlerFactory,
+    config: ServerConfig,
+    timers: (Timers | None) = None)
   =>
     // Initialize responder and handler first with placeholder connection.
     // _parser defaults to None, so all fields are now initialized and
     // `this` becomes `ref` — required by TCPConnection.server and
     // _RequestParser.
+    _config = config
+    _timers = timers
     _responder = Responder._create(_tcp_connection)
     _handler = handler_factory(_responder)
     _tcp_connection = lori.TCPConnection.server(auth, fd, this, this)
     _responder._set_connection(_tcp_connection)
-    _parser = _RequestParser(this)
+    _parser = _RequestParser(this, _config._parser_config())
 
   //
   // TCPConnectionActor / ServerLifecycleEventReceiver
@@ -42,11 +75,26 @@ actor _Connection is
   fun ref _connection(): lori.TCPConnection =>
     _tcp_connection
 
+  fun ref _on_started() =>
+    _start_idle_timer()
+
   fun ref _on_received(data: Array[U8] iso) =>
     _state.on_received(this, consume data)
 
   fun ref _on_closed() =>
+    _cancel_idle_timer()
     _state.on_closed(this)
+
+  fun ref _on_start_failure() =>
+    // Connection failed before _on_started — handler was never activated.
+    // Don't call _handler.closed(); just mark as closed for GC.
+    _state = _Closed
+
+  fun ref _on_throttled() =>
+    _state.on_throttled(this)
+
+  fun ref _on_unthrottled() =>
+    _state.on_unthrottled(this)
 
   //
   // _RequestParserNotify — forwarding parser events to handler
@@ -58,6 +106,9 @@ actor _Connection is
     version: Version,
     headers: Headers val)
   =>
+    _keep_alive = _KeepAliveDecision(version, headers.get("connection"))
+    _idle = false
+    _cancel_idle_timer()
     _responder._set_version(version)
     _handler.request(method, uri, version, headers)
 
@@ -66,17 +117,40 @@ actor _Connection is
 
   fun ref request_complete() =>
     _handler.request_complete()
-    // Phase 3: always close after request completes
+
+    // If handler didn't respond, send 500 and close unconditionally.
+    // Protocol state is uncertain so we always close regardless of
+    // _keep_alive.
+    if not _responder.responded() then
+      _tcp_connection.send(_ErrorResponse.no_response())
+      _tcp_connection.close()
+      _state = _Closed
+      return
+    end
+
+    if _keep_alive then
+      _responder._reset()
+      _idle = true
+      _start_idle_timer()
+    else
+      _tcp_connection.close()
+      _state = _Closed
+    end
+
+  fun ref parse_error(err: ParseError) =>
+    _tcp_connection.send(_ErrorResponse.for_error(err))
     _tcp_connection.close()
     _state = _Closed
 
-  fun ref parse_error(err: ParseError) =>
-    let response = _ResponseSerializer(
-      StatusBadRequest,
-      recover val Headers end)
-    _tcp_connection.send(consume response)
-    _tcp_connection.close()
-    _state = _Closed
+  //
+  // Idle timeout
+  //
+
+  // Sent by _IdleTimerNotify when the idle timer fires. Arrives
+  // asynchronously — a new request may have started since the timer
+  // was scheduled.
+  be _idle_timeout() =>
+    _state.on_idle_timeout(this)
 
   //
   // Internal methods called by state classes
@@ -92,3 +166,57 @@ actor _Connection is
     """Notify the handler that the connection has closed."""
     _handler.closed()
     _state = _Closed
+
+  fun ref _handle_throttled() =>
+    """Apply backpressure: mute the TCP connection and notify the handler."""
+    _tcp_connection.mute()
+    _handler.throttled()
+
+  fun ref _handle_unthrottled() =>
+    """Release backpressure: unmute the TCP connection and notify the handler."""
+    _tcp_connection.unmute()
+    _handler.unthrottled()
+
+  fun ref _handle_idle_timeout() =>
+    """Close the connection if it is idle (between requests)."""
+    if _idle then
+      _tcp_connection.close()
+      _state = _Closed
+    end
+
+  //
+  // Timer helpers
+  //
+
+  fun ref _start_idle_timer() =>
+    if _config.idle_timeout == 0 then return end
+    match _timers
+    | let timers: Timers =>
+      let timer = Timer(
+        _IdleTimerNotify(this),
+        _config.idle_timeout * 1_000_000_000)
+      let t: Timer tag = timer
+      timers(consume timer)
+      _idle_timer = t
+    end
+
+  fun ref _cancel_idle_timer() =>
+    match (_timers, _idle_timer)
+    | (let timers: Timers, let timer: Timer tag) =>
+      timers.cancel(timer)
+      _idle_timer = None
+    end
+
+class _IdleTimerNotify is TimerNotify
+  """Timer notify that sends an idle timeout message to a connection."""
+  let _connection: _Connection tag
+
+  new iso create(connection: _Connection tag) =>
+    _connection = connection
+
+  fun ref apply(timer: Timer, count: U64): Bool =>
+    _connection._idle_timeout()
+    false // One-shot: don't reschedule
+
+  fun ref cancel(timer: Timer) =>
+    None

--- a/http_server/_connection_state.pony
+++ b/http_server/_connection_state.pony
@@ -3,10 +3,9 @@ trait ref _ConnectionState
   Connection lifecycle state.
 
   Dispatches lori events to the appropriate connection methods based on
-  what operations are valid in each state. Phase 3 has two states:
-  `_Active` (processing requests) and `_Closed` (all operations are
-  no-ops). Phase 4 can split `_Active` into finer-grained states for
-  keep-alive.
+  what operations are valid in each state. Two states: `_Active`
+  (processing requests, including idle keep-alive periods) and `_Closed`
+  (all operations are no-ops).
   """
 
   fun ref on_received(conn: _Connection ref, data: Array[U8] iso)
@@ -14,6 +13,15 @@ trait ref _ConnectionState
 
   fun ref on_closed(conn: _Connection ref)
     """Handle connection close notification."""
+
+  fun ref on_throttled(conn: _Connection ref)
+    """Handle backpressure applied notification."""
+
+  fun ref on_unthrottled(conn: _Connection ref)
+    """Handle backpressure released notification."""
+
+  fun ref on_idle_timeout(conn: _Connection ref)
+    """Handle idle timeout expiration."""
 
 class ref _Active is _ConnectionState
   """
@@ -26,6 +34,15 @@ class ref _Active is _ConnectionState
   fun ref on_closed(conn: _Connection ref) =>
     conn._handle_closed()
 
+  fun ref on_throttled(conn: _Connection ref) =>
+    conn._handle_throttled()
+
+  fun ref on_unthrottled(conn: _Connection ref) =>
+    conn._handle_unthrottled()
+
+  fun ref on_idle_timeout(conn: _Connection ref) =>
+    conn._handle_idle_timeout()
+
 class ref _Closed is _ConnectionState
   """
   Connection is closed — all operations are no-ops.
@@ -35,4 +52,13 @@ class ref _Closed is _ConnectionState
     None
 
   fun ref on_closed(conn: _Connection ref) =>
+    None
+
+  fun ref on_throttled(conn: _Connection ref) =>
+    None
+
+  fun ref on_unthrottled(conn: _Connection ref) =>
+    None
+
+  fun ref on_idle_timeout(conn: _Connection ref) =>
     None

--- a/http_server/_error_response.pony
+++ b/http_server/_error_response.pony
@@ -1,0 +1,29 @@
+primitive _ErrorResponse
+  """
+  Pre-built HTTP error response strings for parse errors.
+
+  All responses are string literals — zero allocation at runtime.
+  Each includes `Connection: close` and `Content-Length: 0` since the
+  connection is always closed after a parse error.
+  """
+
+  fun for_error(err: ParseError): String val =>
+    """Map a parse error to the appropriate HTTP error response."""
+    match err
+    | TooLarge =>
+      "HTTP/1.1 431 Request Header Fields Too Large\r\nConnection: close\r\nContent-Length: 0\r\n\r\n"
+    | BodyTooLarge =>
+      "HTTP/1.1 413 Payload Too Large\r\nConnection: close\r\nContent-Length: 0\r\n\r\n"
+    | InvalidVersion =>
+      "HTTP/1.1 505 HTTP Version Not Supported\r\nConnection: close\r\nContent-Length: 0\r\n\r\n"
+    else
+      "HTTP/1.1 400 Bad Request\r\nConnection: close\r\nContent-Length: 0\r\n\r\n"
+    end
+
+  fun no_response(): String val =>
+    """
+    Response sent when a handler completes without calling `respond()`.
+
+    This is a server error (500) — the handler should always send a response.
+    """
+    "HTTP/1.1 500 Internal Server Error\r\nConnection: close\r\nContent-Length: 0\r\n\r\n"

--- a/http_server/_test.pony
+++ b/http_server/_test.pony
@@ -65,3 +65,15 @@ actor \nodoc\ Main is TestList
     // Server integration tests
     test(_TestServerHelloWorld)
     test(_TestServerParseError)
+    test(_TestKeepAlive)
+    test(_TestConnectionClose)
+    test(_TestHTTP10Close)
+    test(_TestErrorResponse413)
+    test(_TestErrorResponse431)
+    test(_TestErrorResponse505)
+    test(_TestIdleTimeout)
+    test(_TestServerNotifyListening)
+
+    // Keep-alive decision property test
+    test(Property1UnitTest[(Version, (String val | None))](
+      _PropertyKeepAliveDecision))

--- a/http_server/_test_server.pony
+++ b/http_server/_test_server.pony
@@ -1,5 +1,11 @@
+use "pony_check"
 use "pony_test"
+use "time"
 use lori = "lori"
+
+// ---------------------------------------------------------------------------
+// Existing tests (updated for new _Connection constructor)
+// ---------------------------------------------------------------------------
 
 class \nodoc\ iso _TestServerHelloWorld is UnitTest
   """
@@ -11,7 +17,15 @@ class \nodoc\ iso _TestServerHelloWorld is UnitTest
   fun apply(h: TestHelper) =>
     h.long_test(5_000_000_000)
     let port = "45871"
-    let listener = _TestServerListener(h, port, _TestHelloFactory)
+    let host = ifdef linux then "127.0.0.2" else "localhost" end
+    let config = ServerConfig(host, port)
+    let listener = _TestServerListener(h, port, _TestHelloFactory, config,
+      {(h': TestHelper, port': String) =>
+        let request = "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n"
+        let client = _TestHTTPClient(h', port', request, "200 OK",
+          "Hello, World!")
+        h'.dispose_when_done(client)
+      })
     h.dispose_when_done(listener)
 
 class \nodoc\ iso _TestServerParseError is UnitTest
@@ -24,8 +38,250 @@ class \nodoc\ iso _TestServerParseError is UnitTest
   fun apply(h: TestHelper) =>
     h.long_test(5_000_000_000)
     let port = "45872"
-    let listener = _TestServerListener(h, port, _TestHelloFactory)
+    let host = ifdef linux then "127.0.0.2" else "localhost" end
+    let config = ServerConfig(host, port)
+    let listener = _TestServerListener(h, port, _TestHelloFactory, config,
+      {(h': TestHelper, port': String) =>
+        let client = _TestHTTPClient(h', port', "GARBAGE DATA\r\n\r\n",
+          "400 Bad Request", None)
+        h'.dispose_when_done(client)
+      })
     h.dispose_when_done(listener)
+
+// ---------------------------------------------------------------------------
+// New integration tests
+// ---------------------------------------------------------------------------
+
+class \nodoc\ iso _TestKeepAlive is UnitTest
+  """
+  Send two HTTP/1.1 requests on the same connection. Verify both get
+  200 OK responses (connection stays open between requests).
+  """
+  fun name(): String => "server/keep-alive"
+
+  fun apply(h: TestHelper) =>
+    h.long_test(5_000_000_000)
+    let port = "45873"
+    let host = ifdef linux then "127.0.0.2" else "localhost" end
+    let config = ServerConfig(host, port)
+    let listener = _TestServerListener(h, port, _TestHelloFactory, config,
+      {(h': TestHelper, port': String) =>
+        let client = _TestKeepAliveClient(h', port')
+        h'.dispose_when_done(client)
+      })
+    h.dispose_when_done(listener)
+
+class \nodoc\ iso _TestConnectionClose is UnitTest
+  """
+  Send an HTTP/1.1 request with Connection: close. Verify the response
+  arrives and the connection closes.
+  """
+  fun name(): String => "server/connection close"
+
+  fun apply(h: TestHelper) =>
+    h.long_test(5_000_000_000)
+    let port = "45874"
+    let host = ifdef linux then "127.0.0.2" else "localhost" end
+    let config = ServerConfig(host, port)
+    let listener = _TestServerListener(h, port, _TestHelloFactory, config,
+      {(h': TestHelper, port': String) =>
+        let request =
+          "GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n"
+        let client = _TestHTTPClientExpectClose(h', port', request, "200 OK")
+        h'.dispose_when_done(client)
+      })
+    h.dispose_when_done(listener)
+
+class \nodoc\ iso _TestHTTP10Close is UnitTest
+  """
+  Send an HTTP/1.0 request without Connection: keep-alive. Verify the
+  response arrives and the connection closes.
+  """
+  fun name(): String => "server/http 1.0 close"
+
+  fun apply(h: TestHelper) =>
+    h.long_test(5_000_000_000)
+    let port = "45875"
+    let host = ifdef linux then "127.0.0.2" else "localhost" end
+    let config = ServerConfig(host, port)
+    let listener = _TestServerListener(h, port, _TestHelloFactory, config,
+      {(h': TestHelper, port': String) =>
+        let request = "GET / HTTP/1.0\r\nHost: localhost\r\n\r\n"
+        let client = _TestHTTPClientExpectClose(h', port', request, "200 OK")
+        h'.dispose_when_done(client)
+      })
+    h.dispose_when_done(listener)
+
+class \nodoc\ iso _TestErrorResponse413 is UnitTest
+  """
+  Configure a small max_body_size. Send a request with Content-Length
+  exceeding the limit. Verify 413 Payload Too Large response.
+  """
+  fun name(): String => "server/error 413"
+
+  fun apply(h: TestHelper) =>
+    h.long_test(5_000_000_000)
+    let port = "45876"
+    let host = ifdef linux then "127.0.0.2" else "localhost" end
+    let config = ServerConfig(host, port where max_body_size' = 10)
+    let listener = _TestServerListener(h, port, _TestHelloFactory, config,
+      {(h': TestHelper, port': String) =>
+        let request =
+          "POST / HTTP/1.1\r\nHost: localhost\r\nContent-Length: 100\r\n\r\n"
+        let client = _TestHTTPClient(h', port', request,
+          "413 Payload Too Large", None)
+        h'.dispose_when_done(client)
+      })
+    h.dispose_when_done(listener)
+
+class \nodoc\ iso _TestErrorResponse431 is UnitTest
+  """
+  Configure a small max_header_size. Send a request with headers exceeding
+  the limit. Verify 431 Request Header Fields Too Large response.
+  """
+  fun name(): String => "server/error 431"
+
+  fun apply(h: TestHelper) =>
+    h.long_test(5_000_000_000)
+    let port = "45877"
+    let host = ifdef linux then "127.0.0.2" else "localhost" end
+    let config = ServerConfig(host, port where max_header_size' = 10)
+    let listener = _TestServerListener(h, port, _TestHelloFactory, config,
+      {(h': TestHelper, port': String) =>
+        let request = "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n"
+        let client = _TestHTTPClient(h', port', request,
+          "431 Request Header Fields Too Large", None)
+        h'.dispose_when_done(client)
+      })
+    h.dispose_when_done(listener)
+
+class \nodoc\ iso _TestErrorResponse505 is UnitTest
+  """
+  Send a request with HTTP/2.0 version. Verify 505 HTTP Version Not
+  Supported response.
+  """
+  fun name(): String => "server/error 505"
+
+  fun apply(h: TestHelper) =>
+    h.long_test(5_000_000_000)
+    let port = "45878"
+    let host = ifdef linux then "127.0.0.2" else "localhost" end
+    let config = ServerConfig(host, port)
+    let listener = _TestServerListener(h, port, _TestHelloFactory, config,
+      {(h': TestHelper, port': String) =>
+        let request = "GET / HTTP/2.0\r\nHost: localhost\r\n\r\n"
+        let client = _TestHTTPClient(h', port', request,
+          "505 HTTP Version Not Supported", None)
+        h'.dispose_when_done(client)
+      })
+    h.dispose_when_done(listener)
+
+class \nodoc\ iso _TestIdleTimeout is UnitTest
+  """
+  Configure a 1-second idle timeout. Send one request, receive the response,
+  then wait. Verify the connection closes within the test timeout.
+  """
+  fun name(): String => "server/idle timeout"
+
+  fun apply(h: TestHelper) =>
+    h.long_test(5_000_000_000)
+    let port = "45879"
+    let host = ifdef linux then "127.0.0.2" else "localhost" end
+    let config = ServerConfig(host, port where idle_timeout' = 1)
+    let timers = Timers
+    let listener = _TestServerListener(h, port, _TestHelloFactory, config,
+      {(h': TestHelper, port': String) =>
+        let request = "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n"
+        let client = _TestHTTPClientExpectClose(h', port', request, "200 OK")
+        h'.dispose_when_done(client)
+      }, timers)
+    h.dispose_when_done(timers)
+    h.dispose_when_done(listener)
+
+class \nodoc\ iso _TestServerNotifyListening is UnitTest
+  """
+  Create a Server with a ServerNotify. Verify that the listening()
+  callback fires.
+  """
+  fun name(): String => "server/notify listening"
+
+  fun apply(h: TestHelper) =>
+    h.long_test(5_000_000_000)
+    let auth = lori.TCPListenAuth(h.env.root)
+    let host = ifdef linux then "127.0.0.2" else "localhost" end
+    let config = ServerConfig(host, "45881")
+    let notify = _TestListenNotify(h)
+    let server = Server(auth, _TestHelloFactory, config, notify)
+    h.dispose_when_done(server)
+
+// ---------------------------------------------------------------------------
+// Property-based test: keep-alive decision
+// ---------------------------------------------------------------------------
+
+class \nodoc\ iso _PropertyKeepAliveDecision
+  is Property1[(Version, (String val | None))]
+  """
+  The keep-alive decision matches the HTTP/1.x spec:
+  - HTTP/1.1 + no header → keep-alive
+  - HTTP/1.1 + Connection: close (any case) → close
+  - HTTP/1.0 + no header → close
+  - HTTP/1.0 + Connection: keep-alive (any case) → keep-alive
+  - Unrecognized Connection values use version default
+  """
+  fun name(): String => "keep-alive/decision"
+
+  fun gen(): Generator[(Version, (String val | None))] =>
+    let version_gen = Generators.one_of[Version](
+      [as Version: HTTP10; HTTP11])
+
+    let known_gen: Generator[(String val | None)] =
+      Generators.one_of[(String val | None)](
+        [as (String val | None):
+          None; "close"; "Close"; "CLOSE"
+          "keep-alive"; "Keep-Alive"; "KEEP-ALIVE"])
+
+    let random_gen: Generator[(String val | None)] =
+      Generators.ascii_printable(1, 20)
+        .map[(String val | None)](
+          {(s: String val): (String val | None) => s})
+
+    let connection_gen = Generators.frequency[(String val | None)]([
+      as WeightedGenerator[(String val | None)]:
+      (5, known_gen)
+      (2, random_gen)
+    ])
+
+    Generators.zip2[Version, (String val | None)](
+      version_gen, connection_gen)
+
+  fun ref property(
+    arg1: (Version, (String val | None)),
+    ph: PropertyHelper)
+  =>
+    (let version, let connection) = arg1
+    let result = _KeepAliveDecision(version, connection)
+
+    match connection
+    | let c: String =>
+      let lower = c.lower()
+      if lower == "close" then
+        ph.assert_false(result,
+          "Connection: close should always close")
+        return
+      end
+      if lower == "keep-alive" then
+        ph.assert_true(result,
+          "Connection: keep-alive should always keep alive")
+        return
+      end
+    end
+
+    // No header or unrecognized value: version-dependent
+    if version is HTTP11 then
+      ph.assert_true(result, "HTTP/1.1 default should be keep-alive")
+    else
+      ph.assert_false(result, "HTTP/1.0 default should be close")
+    end
 
 // ---------------------------------------------------------------------------
 // Test handler: responds with "Hello, World!" on every request
@@ -58,13 +314,26 @@ actor \nodoc\ _TestServerListener is lori.TCPListenerActor
   var _tcp_listener: lori.TCPListener = lori.TCPListener.none()
   let _server_auth: lori.TCPServerAuth
   let _handler_factory: HandlerFactory
+  let _config: ServerConfig
+  let _timers: (Timers | None)
   let _h: TestHelper
   let _port: String
+  let _start_client: {(TestHelper, String)} val
 
-  new create(h: TestHelper, port: String, handler_factory: HandlerFactory) =>
+  new create(
+    h: TestHelper,
+    port: String,
+    handler_factory: HandlerFactory,
+    config: ServerConfig,
+    start_client: {(TestHelper, String)} val,
+    timers: (Timers | None) = None)
+  =>
     _h = h
     _port = port
     _handler_factory = handler_factory
+    _config = config
+    _timers = timers
+    _start_client = start_client
     let listen_auth = lori.TCPListenAuth(_h.env.root)
     _server_auth = lori.TCPServerAuth(listen_auth)
     let host = ifdef linux then "127.0.0.2" else "localhost" end
@@ -74,26 +343,23 @@ actor \nodoc\ _TestServerListener is lori.TCPListenerActor
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _Connection =>
-    _Connection(_server_auth, fd, _handler_factory)
+    _Connection(_server_auth, fd, _handler_factory, _config, _timers)
 
   fun ref _on_listening() =>
-    // Server is ready — start the test client based on which test is running
-    if _port == "45871" then
-      // Hello world test: send valid HTTP request
-      let request = "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n"
-      let client = _TestHTTPClient(_h, _port, request, "200 OK",
-        "Hello, World!")
-      _h.dispose_when_done(client)
-    elseif _port == "45872" then
-      // Parse error test: send garbage
-      let client = _TestHTTPClient(_h, _port, "GARBAGE DATA\r\n\r\n",
-        "400 Bad Request", None)
-      _h.dispose_when_done(client)
-    end
+    _start_client(_h, _port)
 
   fun ref _on_listen_failure() =>
     _h.fail("Listener failed to start on port " + _port)
     _h.complete(false)
+
+// ---------------------------------------------------------------------------
+// Test server notify: completes test on listening
+// ---------------------------------------------------------------------------
+
+class \nodoc\ val _TestListenNotify is ServerNotify
+  let _h: TestHelper
+  new val create(h: TestHelper) => _h = h
+  fun listening(server: Server tag) => _h.complete(true)
 
 // ---------------------------------------------------------------------------
 // Test client: sends request bytes, verifies response
@@ -164,3 +430,124 @@ actor \nodoc\ _TestHTTPClient is
     end
 
     _h.complete(true)
+
+// ---------------------------------------------------------------------------
+// Test client: sends request, verifies response AND connection close
+// ---------------------------------------------------------------------------
+
+actor \nodoc\ _TestHTTPClientExpectClose is
+  (lori.TCPConnectionActor & lori.ClientLifecycleEventReceiver)
+
+  var _tcp_connection: lori.TCPConnection = lori.TCPConnection.none()
+  let _h: TestHelper
+  let _request: String val
+  let _expected_status: String val
+  var _response: String ref = String
+  var _response_ok: Bool = false
+
+  new create(
+    h: TestHelper,
+    port: String,
+    request: String val,
+    expected_status: String val)
+  =>
+    _h = h
+    _request = request
+    _expected_status = expected_status
+    let host = ifdef linux then "127.0.0.2" else "localhost" end
+    _tcp_connection = lori.TCPConnection.client(
+      lori.TCPConnectAuth(_h.env.root), host, port, "", this, this)
+
+  fun ref _connection(): lori.TCPConnection =>
+    _tcp_connection
+
+  fun ref _on_connected() =>
+    _tcp_connection.send(_request)
+
+  fun ref _on_received(data: Array[U8] iso) =>
+    _response.append(consume data)
+    if _response.contains("\r\n\r\n") then
+      let response: String val = _response.clone()
+      if response.contains(_expected_status) then
+        _response_ok = true
+      else
+        _h.fail("Expected status '" + _expected_status
+          + "' not found in response:\n" + response)
+        _h.complete(false)
+      end
+    end
+
+  fun ref _on_closed() =>
+    if _response_ok then
+      _h.complete(true)
+    else
+      // Response may not have been checked yet — check now
+      let response: String val = _response.clone()
+      if response.contains(_expected_status) then
+        _h.complete(true)
+      else
+        _h.fail("Connection closed before valid response received")
+        _h.complete(false)
+      end
+    end
+
+  fun ref _on_connection_failure() =>
+    _h.fail("Client connection failed")
+    _h.complete(false)
+
+// ---------------------------------------------------------------------------
+// Test client: sends two requests on same connection (keep-alive)
+// ---------------------------------------------------------------------------
+
+actor \nodoc\ _TestKeepAliveClient is
+  (lori.TCPConnectionActor & lori.ClientLifecycleEventReceiver)
+
+  var _tcp_connection: lori.TCPConnection = lori.TCPConnection.none()
+  let _h: TestHelper
+  var _response: String ref = String
+  var _requests_sent: USize = 0
+
+  new create(h: TestHelper, port: String) =>
+    _h = h
+    let host = ifdef linux then "127.0.0.2" else "localhost" end
+    _tcp_connection = lori.TCPConnection.client(
+      lori.TCPConnectAuth(_h.env.root), host, port, "", this, this)
+
+  fun ref _connection(): lori.TCPConnection =>
+    _tcp_connection
+
+  fun ref _on_connected() =>
+    _requests_sent = 1
+    _tcp_connection.send(
+      "GET /1 HTTP/1.1\r\nHost: localhost\r\n\r\n")
+
+  fun ref _on_received(data: Array[U8] iso) =>
+    _response.append(consume data)
+    let r: String val = _response.clone()
+
+    if _requests_sent == 1 then
+      // Wait for first complete response
+      try
+        r.find("Hello, World!")?
+        // First response received — send second request
+        _requests_sent = 2
+        _tcp_connection.send(
+          "GET /2 HTTP/1.1\r\nHost: localhost\r\n\r\n")
+      end
+    elseif _requests_sent == 2 then
+      // Wait for second "Hello, World!" (the 2nd occurrence, 0-indexed nth)
+      try
+        r.find("Hello, World!", 0, 1)?
+        _h.complete(true)
+      end
+    end
+
+  fun ref _on_closed() =>
+    if _requests_sent < 2 then
+      _h.fail("Connection closed before both requests completed")
+      _h.complete(false)
+    end
+
+  fun ref _on_connection_failure() =>
+    _h.fail("Client connection failed")
+    _h.complete(false)

--- a/http_server/http_server.pony
+++ b/http_server/http_server.pony
@@ -1,8 +1,8 @@
 """
 HTTP server for Pony, built on lori.
 
-Start a server with `Server`, passing a `HandlerFactory` that creates a
-`Handler` for each connection. Use `Responder.respond()` to send responses:
+Start a server with `Server`, passing a `HandlerFactory` and `ServerConfig`.
+Use `Responder.respond()` to send responses:
 
 ```pony
 use "http_server"
@@ -10,7 +10,8 @@ use lori = "lori"
 
 actor Main
   new create(env: Env) =>
-    Server(lori.TCPListenAuth(env.root), "localhost", "8080", MyFactory)
+    let config = ServerConfig("localhost", "8080")
+    Server(lori.TCPListenAuth(env.root), MyFactory, config)
 
 class val MyFactory is HandlerFactory
   fun apply(responder: Responder): Handler ref^ =>

--- a/http_server/responder.pony
+++ b/http_server/responder.pony
@@ -48,12 +48,19 @@ class ref Responder
       | None => recover val Headers end
       end
       let response = _ResponseSerializer(status, h, body, _version)
-      _tcp_connection.send(consume response)
+      match _tcp_connection.send(consume response)
+      | let _: lori.SendError =>
+        _tcp_connection.close()
+      end
     end
 
   fun responded(): Bool =>
     """Whether a response has already been sent."""
     _responded
+
+  fun ref _reset() =>
+    """Reset for the next request on a keep-alive connection."""
+    _responded = false
 
   fun ref _set_connection(tcp_connection: lori.TCPConnection) =>
     """Update the TCP connection (called by the connection after init)."""

--- a/http_server/server.pony
+++ b/http_server/server.pony
@@ -1,4 +1,5 @@
 use lori = "lori"
+use "time"
 
 actor Server is lori.TCPListenerActor
   """
@@ -16,31 +17,56 @@ actor Server is lori.TCPListenerActor
   actor Main
     new create(env: Env) =>
       let auth = lori.TCPListenAuth(env.root)
-      Server(auth, "localhost", "8080", MyHandlerFactory)
+      let config = ServerConfig("localhost", "8080")
+      Server(auth, MyHandlerFactory, config)
   ```
   """
   var _tcp_listener: lori.TCPListener = lori.TCPListener.none()
   let _handler_factory: HandlerFactory
   let _server_auth: lori.TCPServerAuth
+  let _config: ServerConfig
+  let _notify: (ServerNotify | None)
+  let _timers: (Timers | None)
 
   new create(
     auth: lori.TCPListenAuth,
-    host: String,
-    port: String,
-    handler_factory: HandlerFactory)
+    handler_factory: HandlerFactory,
+    config: ServerConfig,
+    notify: (ServerNotify | None) = None)
   =>
     """
-    Start an HTTP server listening on the given host and port.
+    Start an HTTP server listening on the configured host and port.
 
     The `handler_factory` creates a new `Handler` for each accepted
-    connection. It must be `val` (immutable and shareable).
+    connection. It must be `val` (immutable and shareable). The optional
+    `notify` receives lifecycle callbacks (listening, listen failure).
     """
     _handler_factory = handler_factory
+    _config = config
+    _notify = notify
     _server_auth = lori.TCPServerAuth(auth)
-    _tcp_listener = lori.TCPListener(auth, host, port, this)
+    _timers = if config.idle_timeout > 0 then Timers else None end
+    _tcp_listener = lori.TCPListener(
+      auth, config.host, config.port, this, config.max_concurrent_connections)
 
   fun ref _listener(): lori.TCPListener =>
     _tcp_listener
 
   fun ref _on_accept(fd: U32): _Connection =>
-    _Connection(_server_auth, fd, _handler_factory)
+    _Connection(_server_auth, fd, _handler_factory, _config, _timers)
+
+  fun ref _on_listening() =>
+    match _notify
+    | let n: ServerNotify => n.listening(this)
+    end
+
+  fun ref _on_listen_failure() =>
+    match _notify
+    | let n: ServerNotify => n.listen_failure(this)
+    end
+
+  be dispose() =>
+    match _timers
+    | let t: Timers => t.dispose()
+    end
+    _tcp_listener.close()

--- a/http_server/server_config.pony
+++ b/http_server/server_config.pony
@@ -1,0 +1,61 @@
+class val ServerConfig
+  """
+  Server-level configuration.
+
+  Host and port specify the listen address. Parser limits control the maximum
+  size of request components. Idle timeout controls how long a keep-alive
+  connection can sit without activity before being closed.
+
+  ```pony
+  // All defaults
+  ServerConfig("localhost", "8080")
+
+  // Custom limits
+  ServerConfig("0.0.0.0", "80" where
+    max_body_size' = 10_485_760,  // 10 MB
+    idle_timeout' = 60)           // 60 seconds
+  ```
+  """
+  let host: String
+  let port: String
+  let max_request_line_size: USize
+  let max_header_size: USize
+  let max_chunk_header_size: USize
+  let max_body_size: USize
+  let max_concurrent_connections: (U32 | None)
+  let idle_timeout: U64
+
+  new val create(
+    host': String,
+    port': String,
+    max_request_line_size': USize = 8192,
+    max_header_size': USize = 8192,
+    max_chunk_header_size': USize = 128,
+    max_body_size': USize = 1_048_576,
+    max_concurrent_connections': (U32 | None) = None,
+    idle_timeout': U64 = 0)
+  =>
+    """
+    Create server configuration.
+
+    `host'` and `port'` specify the listen address. Parser limits default to
+    sensible values. `idle_timeout'` is in seconds (0 disables idle timeout).
+    `max_concurrent_connections'` limits simultaneous connections (`None` for
+    unlimited).
+    """
+    host = host'
+    port = port'
+    max_request_line_size = max_request_line_size'
+    max_header_size = max_header_size'
+    max_chunk_header_size = max_chunk_header_size'
+    max_body_size = max_body_size'
+    max_concurrent_connections = max_concurrent_connections'
+    idle_timeout = idle_timeout'
+
+  fun _parser_config(): _ParserConfig val =>
+    """Create a parser config from the parser limit fields."""
+    _ParserConfig(
+      max_request_line_size,
+      max_header_size,
+      max_chunk_header_size,
+      max_body_size)

--- a/http_server/server_notify.pony
+++ b/http_server/server_notify.pony
@@ -1,0 +1,25 @@
+interface val ServerNotify
+  """
+  Notifications for server lifecycle events.
+
+  Implement this to be notified when the server starts listening or fails to
+  start. Both callbacks default to no-ops.
+
+  ```pony
+  class val MyNotify is ServerNotify
+    let _env: Env
+    new val create(env: Env) => _env = env
+    fun listening(server: Server tag) =>
+      _env.out.print("Listening")
+    fun listen_failure(server: Server tag) =>
+      _env.out.print("Failed to start")
+  ```
+  """
+
+  fun listening(server: Server tag) =>
+    """Called when the server is listening and ready to accept connections."""
+    None
+
+  fun listen_failure(server: Server tag) =>
+    """Called when the server failed to bind to the configured address."""
+    None


### PR DESCRIPTION
Connections are now persistent by default (HTTP/1.1 keep-alive) instead of closing after every response. Keep-alive decisions follow the spec: HTTP/1.1 defaults to keep-alive, HTTP/1.0 defaults to close, and an explicit Connection header overrides either default.

- `ServerConfig` centralizes server configuration (host, port, parser limits, max concurrent connections, idle timeout)
- `ServerNotify` provides listen lifecycle callbacks (`listening`, `listen_failure`)
- Parse errors map to correct HTTP status codes (400, 413, 431, 505) via `_ErrorResponse`
- Backpressure from lori propagates to `Handler` via `throttled`/`unthrottled` callbacks with TCP mute/unmute
- Idle timeout uses a shared `Timers` actor with one-shot timers per connection, guarded by an `_idle` flag for race safety
- Handler gets a 500 response and connection close if it completes without calling `respond()`

12 new tests (11 integration + 1 property-based) covering keep-alive, connection close, HTTP/1.0 close, error responses (413, 431, 505), idle timeout, server notify, and keep-alive decision logic. All 45 tests pass.

Design: #2