### PR TITLE
Add URI parsing subpackage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,16 @@ No release notes until after the first release. This project is pre-1.0 and hasn
   - `_connection_state.pony` — Connection lifecycle states (`_Active`, `_Closed`)
   - `_connection.pony` — Per-connection actor (`_Connection`, owns TCP + parser + handler + response queue + idle timer)
   - `server.pony` — Listener actor (`Server`, accepts connections, creates `_Connection` actors)
+  - `uri/` — URI parsing subpackage (RFC 3986)
+    - `uri.pony` — Package docstring and `URI` class
+    - `uri_authority.pony` — `URIAuthority` class
+    - `percent_encoding.pony` — `PercentDecode`, `PercentEncode`, `URIPart` types, `InvalidPercentEncoding`
+    - `parse_uri.pony` — `ParseURI` factory
+    - `parse_uri_authority.pony` — `ParseURIAuthority` factory
+    - `uri_parse_error.pony` — Error types and `URIParseError` union
+    - `query_parameters.pony` — `ParseQueryParameters` primitive
+    - `path_segments.pony` — `PathSegments` primitive
+    - `_mort.pony` — `_Unreachable`, `_IllegalState` (package-private duplicate)
 - `examples/` — example programs
-  - `basic/main.pony` — Hello World HTTP server with `ServerNotify`
+  - `basic/main.pony` — Hello World HTTP server with URI parsing and query parameter extraction
   - `streaming/main.pony` — Chunked transfer encoding streaming response

--- a/corral.json
+++ b/corral.json
@@ -1,6 +1,7 @@
 {
   "packages": [
-    "http_server"
+    "http_server",
+    "http_server/uri"
   ],
   "info": {
     "description": "HTTP server for Pony",

--- a/http_server/_test.pony
+++ b/http_server/_test.pony
@@ -1,12 +1,16 @@
 use "pony_test"
 use "pony_check"
 use lori = "lori"
+use uri = "./uri"
 
 actor \nodoc\ Main is TestList
   new create(env: Env) =>
     PonyTest(env, this)
 
   fun tag tests(test: PonyTest) =>
+    // URI subpackage tests
+    uri.Main.make().tests(test)
+
     // Method tests
     test(Property1UnitTest[String val](_PropertyValidMethodParsesCorrectly))
     test(Property1UnitTest[String val](_PropertyInvalidMethodReturnsNone))

--- a/http_server/handler.pony
+++ b/http_server/handler.pony
@@ -19,6 +19,11 @@ trait ref Handler
     """
     Called when the request line and all headers have been parsed.
 
+    The `uri` string is the raw request-target from the HTTP request line.
+    Use `ParseURI` from the `http_server/uri` subpackage to parse it into
+    structured components (`URI.path`, `URI.query`, etc.). For CONNECT
+    requests (authority-form `host:port`), use `ParseURIAuthority` instead.
+
     For requests with a body, `body_chunk` calls follow. For requests
     without a body, `request_complete` is called immediately after.
     """

--- a/http_server/uri/_mort.pony
+++ b/http_server/uri/_mort.pony
@@ -1,0 +1,35 @@
+use @exit[None](status: U8)
+use @fprintf[I32](stream: Pointer[U8] tag, fmt: Pointer[U8] tag, ...)
+use @pony_os_stderr[Pointer[U8]]()
+
+primitive _IllegalState
+  """
+  To be used to exit early if we called a function that shouldn't be possible
+  in our current state.
+  """
+  fun apply(loc: SourceLoc = __loc) =>
+    @fprintf(
+      @pony_os_stderr(),
+      ("An illegal state was encountered in %s at line %s\n" +
+       "Please open an issue at " +
+       "https://github.com/ponylang/lori_http_server/issues")
+       .cstring(),
+      loc.file().cstring(),
+      loc.line().string().cstring())
+    @exit(1)
+
+primitive _Unreachable
+  """
+  To be used in places that the compiler can't prove is unreachable but we are
+  certain is unreachable and if we reach it, we'd be silently hiding a bug.
+  """
+  fun apply(loc: SourceLoc = __loc) =>
+    @fprintf(
+      @pony_os_stderr(),
+      ("The unreachable was reached in %s at line %s\n" +
+       "Please open an issue at " +
+       "https://github.com/ponylang/lori_http_server/issues")
+       .cstring(),
+      loc.file().cstring(),
+      loc.line().string().cstring())
+    @exit(1)

--- a/http_server/uri/_test.pony
+++ b/http_server/uri/_test.pony
@@ -1,0 +1,44 @@
+use "pony_test"
+use "pony_check"
+
+actor \nodoc\ Main is TestList
+  new create(env: Env) =>
+    PonyTest(env, this)
+
+  new make() => None
+
+  fun tag tests(test: PonyTest) =>
+    // Percent-encoding tests
+    test(Property1UnitTest[String val](_PropertyPercentRoundtrip))
+    test(Property1UnitTest[String val](
+      _PropertyPercentEncodeOutputLegal))
+    test(Property1UnitTest[String val](
+      _PropertyInvalidPercentSequenceRejected))
+    test(Property1UnitTest[(String val, Bool)](
+      _PropertyPercentDecodeBoundary))
+    test(_TestPercentEncodeKnownGood)
+
+    // URI parsing tests
+    test(Property1UnitTest[_ValidURIInput](_PropertyURIRoundtrip))
+    test(Property1UnitTest[String val](_PropertyInvalidSchemeRejected))
+    test(_TestParseURIKnownGood)
+
+    // Authority parsing tests
+    test(Property1UnitTest[_ValidAuthorityInput](
+      _PropertyAuthorityRoundtrip))
+    test(Property1UnitTest[String val](_PropertyInvalidPortRejected))
+    test(Property1UnitTest[String val](_PropertyInvalidHostRejected))
+    test(_TestParseURIAuthorityKnownGood)
+
+    // Path segment tests
+    test(Property1UnitTest[String val](_PropertyPathSegmentCount))
+    test(Property1UnitTest[String val](_PropertyPathSegmentRoundtrip))
+    test(Property1UnitTest[String val](_PropertyPathSegmentInvalidRejected))
+    test(_TestPathSegmentsKnownGood)
+
+    // Query parameter tests
+    test(Property1UnitTest[Array[(String val, String val)] val](
+      _PropertyQueryParamsRoundtrip))
+    test(Property1UnitTest[String val](_PropertyQueryParamsPlusDecodes))
+    test(Property1UnitTest[String val](_PropertyQueryParamsInvalidRejected))
+    test(_TestQueryParametersKnownGood)

--- a/http_server/uri/_test_parse_uri.pony
+++ b/http_server/uri/_test_parse_uri.pony
@@ -1,0 +1,377 @@
+use "pony_test"
+use "pony_check"
+
+class \nodoc\ iso _PropertyURIRoundtrip is Property1[_ValidURIInput]
+  """
+  For generated valid URIs, ParseURI(uri.string()) produces an equal URI.
+  """
+  fun name(): String => "uri/parse_uri/roundtrip"
+
+  fun gen(): Generator[_ValidURIInput] =>
+    _ValidURIInputGenerator()
+
+  fun ref property(arg1: _ValidURIInput, ph: PropertyHelper) =>
+    let original = URI(
+      arg1.scheme, arg1.authority, arg1.path,
+      arg1.query, arg1.fragment)
+    let serialized = original.string()
+    match ParseURI(consume serialized)
+    | let reparsed: URI val =>
+      ph.assert_true(
+        original == reparsed,
+        "roundtrip failed for: " + original.string())
+    | let err: URIParseError val =>
+      ph.fail("roundtrip parse failed for: " + original.string()
+        + " error: " + err.string())
+    end
+
+class \nodoc\ iso _PropertyInvalidSchemeRejected is Property1[String val]
+  """
+  Invalid schemes (starting with digit, containing illegal chars) produce
+  InvalidScheme.
+  """
+  fun name(): String => "uri/parse_uri/invalid_scheme_rejected"
+
+  fun gen(): Generator[String val] =>
+    Generators.frequency[String val]([
+      as WeightedGenerator[String val]:
+      // starts with digit
+      (1, Generators.ascii_numeric(1, 1)
+        .map[String val]({(s) => s + "foo://host" }))
+      // contains illegal character
+      (1, Generators.one_of[String val](
+        ["sch eme://host"; "sch@eme://host"; "sch[eme://host"]))
+    ])
+
+  fun ref property(arg1: String val, ph: PropertyHelper) =>
+    // These should either parse as relative references (no scheme)
+    // or produce an error. They should NOT parse with a scheme.
+    match ParseURI(arg1)
+    | let u: URI val =>
+      ph.assert_true(
+        u.scheme is None,
+        "expected no scheme for: " + arg1)
+    | let err: URIParseError val =>
+      ph.assert_true(true) // error is also acceptable
+    end
+
+class \nodoc\ iso _TestParseURIKnownGood is UnitTest
+  """
+  RFC 3986 section 1.1.2 examples, HTTP request-target forms, and edge cases.
+  """
+  fun name(): String => "uri/parse_uri/known_good"
+
+  fun ref apply(h: TestHelper) =>
+    // RFC 3986 examples
+    _assert_uri(h, "ftp://ftp.is.co.za/rfc/rfc1808.txt",
+      "ftp", "ftp.is.co.za", "/rfc/rfc1808.txt", None, None)
+
+    _assert_uri(h, "http://www.ietf.org/rfc/rfc2396.txt",
+      "http", "www.ietf.org", "/rfc/rfc2396.txt", None, None)
+
+    _assert_uri(h, "ldap://[2001:db8::7]/c=GB?objectClass?one",
+      "ldap", "[2001:db8::7]", "/c=GB", "objectClass?one", None)
+
+    _assert_uri(h, "mailto:John.Doe@example.com",
+      "mailto", None, "John.Doe@example.com", None, None)
+
+    _assert_uri(h, "tel:+1-816-555-1212",
+      "tel", None, "+1-816-555-1212", None, None)
+
+    _assert_uri(h, "urn:oasis:names:specification:docbook:dtd:xml:4.1.2",
+      "urn", None, "oasis:names:specification:docbook:dtd:xml:4.1.2",
+      None, None)
+
+    // HTTP request-target forms
+    // origin-form
+    _assert_uri(h, "/index.html?page=1",
+      None, None, "/index.html", "page=1", None)
+
+    // absolute-form
+    _assert_uri(h,
+      "http://www.example.org/pub/WWW/TheProject.html",
+      "http", "www.example.org", "/pub/WWW/TheProject.html", None, None)
+
+    // asterisk-form
+    _assert_uri(h, "*", None, None, "*", None, None)
+
+    // Edge cases
+    // empty string = valid empty relative reference
+    _assert_uri(h, "", None, None, "", None, None)
+
+    // query without value
+    match ParseURI("?key")
+    | let u: URI val =>
+      h.assert_eq[String val]("", u.path)
+      match u.query
+      | let q: String => h.assert_eq[String val]("key", q)
+      else h.fail("expected query for ?key")
+      end
+    | let e: URIParseError val =>
+      h.fail("parse failed for ?key: " + e.string())
+    end
+
+    // empty query present (/path?)
+    match ParseURI("/path?")
+    | let u: URI val =>
+      h.assert_eq[String val]("/path", u.path)
+      match u.query
+      | let q: String => h.assert_eq[String val]("", q)
+      else h.fail("expected empty query for /path?")
+      end
+    | let e: URIParseError val =>
+      h.fail("parse failed for /path?: " + e.string())
+    end
+
+    // fragment only
+    _assert_uri(h, "#frag", None, None, "", None, "frag")
+
+    // authority without port
+    _assert_uri(h, "http://example.com/path",
+      "http", "example.com", "/path", None, None)
+
+    // empty authority (file:///etc/hosts)
+    match ParseURI("file:///etc/hosts")
+    | let u: URI val =>
+      match u.scheme
+      | let s: String => h.assert_eq[String val]("file", s)
+      else h.fail("expected scheme for file:///etc/hosts")
+      end
+      match u.authority
+      | let a: URIAuthority =>
+        h.assert_eq[String val]("", a.host)
+      else h.fail("expected authority for file:///etc/hosts")
+      end
+      h.assert_eq[String val]("/etc/hosts", u.path)
+    | let e: URIParseError val =>
+      h.fail("parse failed for file:///etc/hosts: " + e.string())
+    end
+
+    // Percent-encoded delimiters not treated as structural
+    match ParseURI("http://example.com/a%2Fb?c%3Fd")
+    | let u: URI val =>
+      h.assert_eq[String val]("/a%2Fb", u.path)
+      match u.query
+      | let q: String => h.assert_eq[String val]("c%3Fd", q)
+      else h.fail("expected query for percent-encoded test")
+      end
+    | let e: URIParseError val =>
+      h.fail("parse failed for percent-encoded: " + e.string())
+    end
+
+    // Authority with port
+    _assert_uri(h, "http://example.com:8080/path",
+      "http", "example.com:8080", "/path", None, None)
+
+    // Authority with userinfo
+    match ParseURI("http://user:pass@example.com/path")
+    | let u: URI val =>
+      match u.authority
+      | let a: URIAuthority =>
+        match a.userinfo
+        | let ui: String => h.assert_eq[String val]("user:pass", ui)
+        else h.fail("expected userinfo")
+        end
+        h.assert_eq[String val]("example.com", a.host)
+      else h.fail("expected authority")
+      end
+    | let e: URIParseError val =>
+      h.fail("parse failed for userinfo: " + e.string())
+    end
+
+    // Full URI with all components
+    match ParseURI("http://user@example.com:8080/path?query=1#frag")
+    | let u: URI val =>
+      match u.scheme
+      | let s: String => h.assert_eq[String val]("http", s)
+      else h.fail("expected scheme")
+      end
+      match u.authority
+      | let a: URIAuthority =>
+        match a.userinfo
+        | let ui: String => h.assert_eq[String val]("user", ui)
+        else h.fail("expected userinfo")
+        end
+        h.assert_eq[String val]("example.com", a.host)
+        match a.port
+        | let p: U16 => h.assert_eq[U16](8080, p)
+        else h.fail("expected port")
+        end
+      else h.fail("expected authority")
+      end
+      h.assert_eq[String val]("/path", u.path)
+      match u.query
+      | let q: String => h.assert_eq[String val]("query=1", q)
+      else h.fail("expected query")
+      end
+      match u.fragment
+      | let f: String => h.assert_eq[String val]("frag", f)
+      else h.fail("expected fragment")
+      end
+    | let e: URIParseError val =>
+      h.fail("parse failed for full URI: " + e.string())
+    end
+
+  fun _assert_uri(
+    h: TestHelper,
+    input: String val,
+    expected_scheme: (String | None),
+    expected_authority: (String | None),
+    expected_path: String,
+    expected_query: (String | None),
+    expected_fragment: (String | None))
+  =>
+    match ParseURI(input)
+    | let u: URI val =>
+      match (expected_scheme, u.scheme)
+      | (None, None) => None
+      | (let e: String, let a: String) =>
+        h.assert_eq[String val](e, a, "scheme mismatch for: " + input)
+      else
+        h.fail("scheme mismatch for: " + input)
+      end
+
+      match (expected_authority, u.authority)
+      | (None, None) => None
+      | (let e: String, let a: URIAuthority) =>
+        h.assert_eq[String val](e, a.string(),
+          "authority mismatch for: " + input)
+      else
+        h.fail("authority mismatch for: " + input)
+      end
+
+      h.assert_eq[String val](expected_path, u.path,
+        "path mismatch for: " + input)
+
+      match (expected_query, u.query)
+      | (None, None) => None
+      | (let e: String, let a: String) =>
+        h.assert_eq[String val](e, a, "query mismatch for: " + input)
+      else
+        h.fail("query mismatch for: " + input)
+      end
+
+      match (expected_fragment, u.fragment)
+      | (None, None) => None
+      | (let e: String, let a: String) =>
+        h.assert_eq[String val](e, a, "fragment mismatch for: " + input)
+      else
+        h.fail("fragment mismatch for: " + input)
+      end
+    | let err: URIParseError val =>
+      h.fail("parse failed for " + input + ": " + err.string())
+    end
+
+// -- Generators --
+
+class val _ValidURIInput
+  let scheme: (String | None)
+  let authority: (URIAuthority | None)
+  let path: String
+  let query: (String | None)
+  let fragment: (String | None)
+
+  new val create(
+    scheme': (String | None),
+    authority': (URIAuthority | None),
+    path': String,
+    query': (String | None),
+    fragment': (String | None))
+  =>
+    scheme = scheme'
+    authority = authority'
+    path = path'
+    query = query'
+    fragment = fragment'
+
+primitive _ValidURIInputGenerator
+  fun apply(): Generator[_ValidURIInput] =>
+    // PonyCheck has map4 max, so we combine scheme+authority into one
+    // generator via map2, then compose with path, query, fragment.
+    Generators.map4[
+      (String val | None, URIAuthority val | None),
+      String val,
+      (String val | None),
+      (String val | None),
+      _ValidURIInput](
+      _scheme_authority_gen(),
+      _path_gen(),
+      _query_gen(),
+      _fragment_gen(),
+      {(scheme_auth, path, query, fragment) =>
+        (let scheme, let authority) = scheme_auth
+        _ValidURIInput(scheme, authority, path, query, fragment)
+      })
+
+  fun _scheme_authority_gen()
+    : Generator[(String val | None, URIAuthority val | None)]
+  =>
+    Generators.map2[
+      (String val | None),
+      (URIAuthority val | None),
+      (String val | None, URIAuthority val | None)](
+      _scheme_gen(),
+      _authority_gen(),
+      {(scheme, authority) =>
+        // Authority requires a scheme (absolute URI) to roundtrip correctly
+        // through ParseURI — a relative reference with "//" would be
+        // ambiguous without scheme context.
+        match scheme
+        | let _: String => (scheme, authority)
+        else (scheme, None)
+        end
+      })
+
+  fun _scheme_gen(): Generator[(String val | None)] =>
+    Generators.frequency[(String val | None)]([
+      as WeightedGenerator[(String val | None)]:
+      (1, Generators.unit[(String val | None)](None))
+      (2, Generators.one_of[String val](
+        ["http"; "https"; "ftp"; "ssh"])
+        .map[(String val | None)]({(s) => s }))
+    ])
+
+  fun _authority_gen(): Generator[(URIAuthority val | None)] =>
+    Generators.frequency[(URIAuthority val | None)]([
+      as WeightedGenerator[(URIAuthority val | None)]:
+      (1, Generators.unit[(URIAuthority val | None)](None))
+      (1, Generators.one_of[String val](
+        ["example.com"; "localhost"; "192.168.1.1"; "example.com:8080"
+         "example.com:443"])
+        .map[(URIAuthority val | None)]({(host) =>
+          match ParseURIAuthority(host)
+          | let a: URIAuthority val => a
+          else
+            // Generator strings are all valid; fallback to simple host
+            URIAuthority(None, "localhost", None)
+          end
+        }))
+    ])
+
+  fun _path_gen(): Generator[String val] =>
+    Generators.frequency[String val]([
+      as WeightedGenerator[String val]:
+      (1, Generators.unit[String val](""))
+      (1, Generators.unit[String val]("/"))
+      (2, Generators.one_of[String val](
+        ["/path"; "/a/b/c"; "/index.html"; "/foo/bar/baz"
+         "/path/to/resource"]))
+    ])
+
+  fun _query_gen(): Generator[(String val | None)] =>
+    Generators.frequency[(String val | None)]([
+      as WeightedGenerator[(String val | None)]:
+      (2, Generators.unit[(String val | None)](None))
+      (1, Generators.one_of[String val](
+        ["key=value"; "a=1&b=2"; "q=hello+world"; ""; "page=1"])
+        .map[(String val | None)]({(s) => s }))
+    ])
+
+  fun _fragment_gen(): Generator[(String val | None)] =>
+    Generators.frequency[(String val | None)]([
+      as WeightedGenerator[(String val | None)]:
+      (2, Generators.unit[(String val | None)](None))
+      (1, Generators.one_of[String val](
+        ["top"; "section1"; ""; "frag"])
+        .map[(String val | None)]({(s) => s }))
+    ])

--- a/http_server/uri/_test_parse_uri_authority.pony
+++ b/http_server/uri/_test_parse_uri_authority.pony
@@ -1,0 +1,236 @@
+use "pony_test"
+use "pony_check"
+
+class \nodoc\ iso _PropertyAuthorityRoundtrip
+  is Property1[_ValidAuthorityInput]
+  """
+  For generated valid authorities, ParseURIAuthority(auth.string()) produces
+  an equal authority.
+  """
+  fun name(): String => "uri/parse_uri_authority/roundtrip"
+
+  fun gen(): Generator[_ValidAuthorityInput] =>
+    _ValidAuthorityInputGenerator()
+
+  fun ref property(arg1: _ValidAuthorityInput, ph: PropertyHelper) =>
+    let original = URIAuthority(arg1.userinfo, arg1.host, arg1.port)
+    let serialized = original.string()
+    match ParseURIAuthority(consume serialized)
+    | let reparsed: URIAuthority val =>
+      ph.assert_true(
+        original == reparsed,
+        "roundtrip failed for: " + original.string())
+    | let err: URIParseError val =>
+      ph.fail("roundtrip parse failed for: " + original.string()
+        + " error: " + err.string())
+    end
+
+class \nodoc\ iso _PropertyInvalidPortRejected is Property1[String val]
+  """Invalid ports (non-numeric, > 65535) produce InvalidPort."""
+  fun name(): String => "uri/parse_uri_authority/invalid_port"
+
+  fun gen(): Generator[String val] =>
+    Generators.frequency[String val]([
+      as WeightedGenerator[String val]:
+      // non-numeric port
+      (1, Generators.one_of[String val](
+        ["host:abc"; "host:12a"; "host:xy9z"]))
+      // port > 65535
+      (1, Generators.one_of[String val](
+        ["host:65536"; "host:99999"; "host:100000"]))
+    ])
+
+  fun ref property(arg1: String val, ph: PropertyHelper) =>
+    match ParseURIAuthority(arg1)
+    | let a: URIAuthority val =>
+      ph.fail("expected InvalidPort for: " + arg1)
+    | let err: URIParseError val =>
+      ph.assert_true(
+        err is InvalidPort,
+        "expected InvalidPort, got: " + err.string() + " for: " + arg1)
+    end
+
+class \nodoc\ iso _PropertyInvalidHostRejected is Property1[String val]
+  """Malformed IPv6 hosts (unmatched brackets) produce InvalidHost."""
+  fun name(): String => "uri/parse_uri_authority/invalid_host"
+
+  fun gen(): Generator[String val] =>
+    Generators.one_of[String val]([
+      // unmatched opening bracket
+      "[::1"
+      // unmatched with port
+      "[::1:8080"
+      // empty brackets
+      "[]"
+      // garbage after closing bracket (not a port)
+      "[::1]garbage"
+    ])
+
+  fun ref property(arg1: String val, ph: PropertyHelper) =>
+    match ParseURIAuthority(arg1)
+    | let a: URIAuthority val =>
+      ph.fail("expected InvalidHost for: " + arg1)
+    | let err: URIParseError val =>
+      ph.assert_true(
+        err is InvalidHost,
+        "expected InvalidHost, got: " + err.string() + " for: " + arg1)
+    end
+
+class \nodoc\ iso _TestParseURIAuthorityKnownGood is UnitTest
+  """Known authority parsing cases."""
+  fun name(): String => "uri/parse_uri_authority/known_good"
+
+  fun ref apply(h: TestHelper) =>
+    // Simple host
+    match ParseURIAuthority("example.com")
+    | let a: URIAuthority val =>
+      h.assert_true(a.userinfo is None)
+      h.assert_eq[String val]("example.com", a.host)
+      h.assert_true(a.port is None)
+    | let e: URIParseError val =>
+      h.fail("parse failed: " + e.string())
+    end
+
+    // Host with port
+    match ParseURIAuthority("example.com:8080")
+    | let a: URIAuthority val =>
+      h.assert_true(a.userinfo is None)
+      h.assert_eq[String val]("example.com", a.host)
+      match a.port
+      | let p: U16 => h.assert_eq[U16](8080, p)
+      else h.fail("expected port")
+      end
+    | let e: URIParseError val =>
+      h.fail("parse failed: " + e.string())
+    end
+
+    // Userinfo
+    match ParseURIAuthority("user:pass@example.com:443")
+    | let a: URIAuthority val =>
+      match a.userinfo
+      | let u: String => h.assert_eq[String val]("user:pass", u)
+      else h.fail("expected userinfo")
+      end
+      h.assert_eq[String val]("example.com", a.host)
+      match a.port
+      | let p: U16 => h.assert_eq[U16](443, p)
+      else h.fail("expected port")
+      end
+    | let e: URIParseError val =>
+      h.fail("parse failed: " + e.string())
+    end
+
+    // IPv6 host
+    match ParseURIAuthority("[::1]:8080")
+    | let a: URIAuthority val =>
+      h.assert_true(a.userinfo is None)
+      h.assert_eq[String val]("[::1]", a.host)
+      match a.port
+      | let p: U16 => h.assert_eq[U16](8080, p)
+      else h.fail("expected port")
+      end
+    | let e: URIParseError val =>
+      h.fail("parse failed for [::1]:8080: " + e.string())
+    end
+
+    // IPv6 without port
+    match ParseURIAuthority("[2001:db8::7]")
+    | let a: URIAuthority val =>
+      h.assert_eq[String val]("[2001:db8::7]", a.host)
+      h.assert_true(a.port is None)
+    | let e: URIParseError val =>
+      h.fail("parse failed for [2001:db8::7]: " + e.string())
+    end
+
+    // Empty host (used in file:/// URIs)
+    match ParseURIAuthority("")
+    | let a: URIAuthority val =>
+      h.assert_eq[String val]("", a.host)
+      h.assert_true(a.port is None)
+    | let e: URIParseError val =>
+      h.fail("parse failed for empty: " + e.string())
+    end
+
+    // Port at boundary values
+    match ParseURIAuthority("host:0")
+    | let a: URIAuthority val =>
+      match a.port
+      | let p: U16 => h.assert_eq[U16](0, p)
+      else h.fail("expected port 0")
+      end
+    | let e: URIParseError val =>
+      h.fail("parse failed for port 0: " + e.string())
+    end
+
+    match ParseURIAuthority("host:65535")
+    | let a: URIAuthority val =>
+      match a.port
+      | let p: U16 => h.assert_eq[U16](65535, p)
+      else h.fail("expected port 65535")
+      end
+    | let e: URIParseError val =>
+      h.fail("parse failed for port 65535: " + e.string())
+    end
+
+    // Empty port (RFC 3986 allows port = *DIGIT, so empty is valid)
+    match ParseURIAuthority("host:")
+    | let a: URIAuthority val =>
+      h.assert_eq[String val]("host", a.host)
+      h.assert_true(a.port is None,
+        "empty port should parse as None")
+    | let e: URIParseError val =>
+      h.fail("parse failed for empty port: " + e.string())
+    end
+
+// -- Generators --
+
+class val _ValidAuthorityInput
+  let userinfo: (String | None)
+  let host: String
+  let port: (U16 | None)
+
+  new val create(
+    userinfo': (String | None),
+    host': String,
+    port': (U16 | None))
+  =>
+    userinfo = userinfo'
+    host = host'
+    port = port'
+
+primitive _ValidAuthorityInputGenerator
+  fun apply(): Generator[_ValidAuthorityInput] =>
+    Generators.map3[
+      (String val | None),
+      String val,
+      (U16 | None),
+      _ValidAuthorityInput](
+      _userinfo_gen(),
+      _host_gen(),
+      _port_gen(),
+      {(userinfo, host, port) =>
+        _ValidAuthorityInput(userinfo, host, port)
+      })
+
+  fun _userinfo_gen(): Generator[(String val | None)] =>
+    Generators.frequency[(String val | None)]([
+      as WeightedGenerator[(String val | None)]:
+      (2, Generators.unit[(String val | None)](None))
+      (1, Generators.one_of[String val](
+        ["user"; "user:pass"; "admin"; "user%40example"])
+        .map[(String val | None)]({(s) => s }))
+    ])
+
+  fun _host_gen(): Generator[String val] =>
+    Generators.one_of[String val]([
+      "example.com"; "localhost"; "192.168.1.1"
+      "sub.domain.example.org"; "my-host"
+    ])
+
+  fun _port_gen(): Generator[(U16 | None)] =>
+    Generators.frequency[(U16 | None)]([
+      as WeightedGenerator[(U16 | None)]:
+      (1, Generators.unit[(U16 | None)](None))
+      (1, Generators.one_of[U16]([as U16: 80; 443; 8080; 3000; 8443])
+        .map[(U16 | None)]({(p) => p }))
+    ])

--- a/http_server/uri/_test_path_segments.pony
+++ b/http_server/uri/_test_path_segments.pony
@@ -1,0 +1,155 @@
+use "pony_test"
+use "pony_check"
+
+class \nodoc\ iso _PropertyPathSegmentCount is Property1[String val]
+  """
+  PathSegments count equals the number of `/`-delimited parts in a valid path.
+  """
+  fun name(): String => "uri/path_segments/segment_count"
+
+  fun gen(): Generator[String val] =>
+    Generators.one_of[String val]([
+      ""; "/"; "/a"; "/a/b"; "/a/b/c"; "a"; "a/b"; "/a/b/c/d/e"
+      "/index.html"; "/path/to/resource"
+    ])
+
+  fun ref property(arg1: String val, ph: PropertyHelper) =>
+    // Count expected segments: split on '/'
+    var expected: USize = 1
+    for c in arg1.values() do
+      if c == '/' then expected = expected + 1 end
+    end
+    match PathSegments(arg1)
+    | let segs: Array[String val] val =>
+      ph.assert_eq[USize](expected, segs.size(),
+        "segment count mismatch for: " + arg1)
+    | let err: InvalidPercentEncoding val =>
+      ph.fail("unexpected error for: " + arg1)
+    end
+
+class \nodoc\ iso _PropertyPathSegmentRoundtrip is Property1[String val]
+  """
+  Percent-encoding segments and joining with `/` reconstructs a path that
+  produces the same segments when re-parsed.
+  """
+  fun name(): String => "uri/path_segments/roundtrip"
+
+  fun gen(): Generator[String val] =>
+    Generators.one_of[String val]([
+      ""; "/"; "/a"; "/a/b"; "/a/b/c"; "relative"; "a/b"
+      "/path/to/resource"; "/index.html"
+    ])
+
+  fun ref property(arg1: String val, ph: PropertyHelper) =>
+    match PathSegments(arg1)
+    | let segs: Array[String val] val =>
+      // Re-encode and join
+      let parts = Array[String val](segs.size())
+      for seg in segs.values() do
+        parts.push(PercentEncode(seg, URIPartPath))
+      end
+      let rejoined = "/".join(parts.values())
+      match PathSegments(consume rejoined)
+      | let segs2: Array[String val] val =>
+        ph.assert_eq[USize](segs.size(), segs2.size(),
+          "roundtrip segment count mismatch for: " + arg1)
+        var i: USize = 0
+        while i < segs.size() do
+          try
+            ph.assert_eq[String val](segs(i)?, segs2(i)?,
+              "roundtrip segment " + i.string() + " mismatch for: " + arg1)
+          end
+          i = i + 1
+        end
+      | let err: InvalidPercentEncoding val =>
+        ph.fail("roundtrip reparse failed for: " + arg1)
+      end
+    | let err: InvalidPercentEncoding val =>
+      ph.fail("initial parse failed for: " + arg1)
+    end
+
+class \nodoc\ iso _PropertyPathSegmentInvalidRejected
+  is Property1[String val]
+  """Paths with invalid percent-encoding produce InvalidPercentEncoding."""
+  fun name(): String => "uri/path_segments/invalid_rejected"
+
+  fun gen(): Generator[String val] =>
+    Generators.one_of[String val]([
+      "/a%2"; "/a%GG/b"; "/path/%"; "/%XX"; "/a/b%2"
+    ])
+
+  fun ref property(arg1: String val, ph: PropertyHelper) =>
+    match PathSegments(arg1)
+    | let segs: Array[String val] val =>
+      ph.fail("expected error for: " + arg1)
+    | let err: InvalidPercentEncoding val =>
+      ph.assert_true(true)
+    end
+
+class \nodoc\ iso _TestPathSegmentsKnownGood is UnitTest
+  """Known path segment decomposition cases."""
+  fun name(): String => "uri/path_segments/known_good"
+
+  fun ref apply(h: TestHelper) =>
+    // Absolute path
+    _assert_segments(h, "/a/b/c", [""; "a"; "b"; "c"])
+
+    // Relative path
+    _assert_segments(h, "a/b", ["a"; "b"])
+
+    // Root path
+    _assert_segments(h, "/", [""; ""])
+
+    // Empty path
+    _assert_segments(h, "", [""])
+
+    // Single segment absolute
+    _assert_segments(h, "/index.html", [""; "index.html"])
+
+    // Trailing slash
+    _assert_segments(h, "/a/b/", [""; "a"; "b"; ""])
+
+    // Percent-encoded slash preserved within segment
+    match PathSegments("/a%2Fb/c")
+    | let segs: Array[String val] val =>
+      h.assert_eq[USize](3, segs.size())
+      try
+        h.assert_eq[String val]("", segs(0)?)
+        h.assert_eq[String val]("a/b", segs(1)?,
+          "%2F should decode to / within segment")
+        h.assert_eq[String val]("c", segs(2)?)
+      end
+    | let err: InvalidPercentEncoding val =>
+      h.fail("unexpected error for %2F test")
+    end
+
+    // Percent-encoded space
+    match PathSegments("/hello%20world")
+    | let segs: Array[String val] val =>
+      try
+        h.assert_eq[String val]("hello world", segs(1)?)
+      end
+    | let err: InvalidPercentEncoding val =>
+      h.fail("unexpected error for %20 test")
+    end
+
+  fun _assert_segments(
+    h: TestHelper,
+    input: String val,
+    expected: Array[String val] val)
+  =>
+    match PathSegments(input)
+    | let segs: Array[String val] val =>
+      h.assert_eq[USize](expected.size(), segs.size(),
+        "segment count mismatch for: " + input)
+      var i: USize = 0
+      while i < expected.size() do
+        try
+          h.assert_eq[String val](expected(i)?, segs(i)?,
+            "segment " + i.string() + " mismatch for: " + input)
+        end
+        i = i + 1
+      end
+    | let err: InvalidPercentEncoding val =>
+      h.fail("parse failed for: " + input)
+    end

--- a/http_server/uri/_test_percent_encoding.pony
+++ b/http_server/uri/_test_percent_encoding.pony
@@ -1,0 +1,238 @@
+use "pony_test"
+use "pony_check"
+
+class \nodoc\ iso _PropertyPercentRoundtrip is Property1[String val]
+  """
+  PercentDecode(PercentEncode(s, part)) roundtrips for arbitrary strings.
+  Tests with URIPartPath as representative; the encode/decode cycle should
+  preserve content regardless of which characters are encoded.
+  """
+  fun name(): String => "uri/percent_encoding/roundtrip"
+
+  fun gen(): Generator[String val] =>
+    Generators.ascii(0, 100)
+
+  fun ref property(arg1: String val, ph: PropertyHelper) =>
+    let encoded = PercentEncode(arg1, URIPartPath)
+    match PercentDecode(encoded)
+    | let decoded: String val =>
+      ph.assert_eq[String val](arg1, decoded)
+    | let err: InvalidPercentEncoding val =>
+      ph.fail("roundtrip decode failed for: " + arg1)
+    end
+
+class \nodoc\ iso _PropertyPercentEncodeOutputLegal
+  is Property1[String val]
+  """
+  PercentEncode output for path contains only RFC 3986-legal characters
+  for the path component: unreserved, sub-delims, ':', '@', '/', and
+  percent-encoded sequences.
+  """
+  fun name(): String => "uri/percent_encoding/output_legal"
+
+  fun gen(): Generator[String val] =>
+    Generators.ascii(1, 100)
+
+  fun ref property(arg1: String val, ph: PropertyHelper) =>
+    let encoded = PercentEncode(arg1, URIPartPath)
+    var i: USize = 0
+    while i < encoded.size() do
+      try
+        let c = encoded(i)?
+        if c == '%' then
+          // Must be followed by exactly two hex digits
+          ph.assert_true(
+            (i + 2) < encoded.size(),
+            "truncated percent encoding at position " + i.string())
+          try
+            let h1 = encoded(i + 1)?
+            let h2 = encoded(i + 2)?
+            ph.assert_true(
+              _is_hex(h1),
+              "non-hex digit after % at position " + (i + 1).string())
+            ph.assert_true(
+              _is_hex(h2),
+              "non-hex digit after % at position " + (i + 2).string())
+          end
+          i = i + 3
+        else
+          ph.assert_true(
+            _is_path_legal(c),
+            "illegal character in encoded output: " + String.from_array([c])
+              + " (0x" + _hex_string(c) + ")")
+          i = i + 1
+        end
+      else
+        ph.fail("index out of bounds at " + i.string())
+        return
+      end
+    end
+
+  fun _is_hex(c: U8): Bool =>
+    ((c >= '0') and (c <= '9'))
+      or ((c >= 'A') and (c <= 'F'))
+      or ((c >= 'a') and (c <= 'f'))
+
+  fun _is_path_legal(c: U8): Bool =>
+    // unreserved
+    ((c >= 'A') and (c <= 'Z'))
+      or ((c >= 'a') and (c <= 'z'))
+      or ((c >= '0') and (c <= '9'))
+      or (c == '-') or (c == '.') or (c == '_') or (c == '~')
+      // sub-delims
+      or (c == '!') or (c == '$') or (c == '&') or (c == '\'')
+      or (c == '(') or (c == ')') or (c == '*') or (c == '+')
+      or (c == ',') or (c == ';') or (c == '=')
+      // path-specific
+      or (c == ':') or (c == '@') or (c == '/')
+
+  fun _hex_string(c: U8): String val =>
+    let hex = "0123456789ABCDEF"
+    recover val
+      let out = String(2)
+      try
+        out.push(hex(c.usize() >> 4)?)
+        out.push(hex(c.usize() and 0x0F)?)
+      end
+      out
+    end
+
+class \nodoc\ iso _PropertyInvalidPercentSequenceRejected
+  is Property1[String val]
+  """
+  Invalid percent sequences — truncated, non-hex digits — produce
+  InvalidPercentEncoding.
+  """
+  fun name(): String => "uri/percent_encoding/invalid_rejected"
+
+  fun gen(): Generator[String val] =>
+    Generators.frequency[String val]([
+      as WeightedGenerator[String val]:
+      // trailing percent with no hex digits
+      (1, Generators.ascii(0, 10)
+        .map[String val]({(s) => s + "%" }))
+      // trailing percent with only one hex digit
+      (1, Generators.ascii(0, 10)
+        .map[String val]({(s) => s + "%A" }))
+      // non-hex after percent
+      (1, Generators.ascii(0, 10)
+        .map[String val]({(s) => s + "%GG" }))
+      // non-hex in second position
+      (1, Generators.ascii(0, 10)
+        .map[String val]({(s) => s + "%AZ" }))
+    ])
+
+  fun ref property(arg1: String val, ph: PropertyHelper) =>
+    match PercentDecode(arg1)
+    | let s: String val =>
+      ph.fail("should have rejected: " + arg1)
+    | let err: InvalidPercentEncoding val =>
+      ph.assert_true(true)
+    end
+
+class \nodoc\ iso _PropertyPercentDecodeBoundary
+  is Property1[(String val, Bool)]
+  """
+  Mixed valid/invalid generator — PercentDecode succeeds iff input is the
+  valid variant.
+  """
+  fun name(): String => "uri/percent_encoding/decode_boundary"
+
+  fun gen(): Generator[(String val, Bool)] =>
+    let valid_gen: Generator[(String val, Bool)] =
+      Generators.ascii(0, 50)
+        .map[String val]({(s) => PercentEncode(s, URIPartPath) })
+        .map[(String val, Bool)]({(s) => (s, true) })
+
+    let invalid_gen: Generator[(String val, Bool)] =
+      Generators.frequency[String val]([
+        as WeightedGenerator[String val]:
+        (1, Generators.ascii(0, 10)
+          .map[String val]({(s) => s + "%" }))
+        (1, Generators.ascii(0, 10)
+          .map[String val]({(s) => s + "%A" }))
+        (1, Generators.ascii(0, 10)
+          .map[String val]({(s) => s + "%GG" }))
+        (1, Generators.ascii(0, 10)
+          .map[String val]({(s) => s + "%AZ" }))
+      ]).map[(String val, Bool)]({(s) => (s, false) })
+
+    Generators.frequency[(String val, Bool)]([
+      as WeightedGenerator[(String val, Bool)]:
+      (1, valid_gen)
+      (1, invalid_gen)
+    ])
+
+  fun ref property(arg1: (String val, Bool), ph: PropertyHelper) =>
+    (let input, let should_succeed) = arg1
+    let result = PercentDecode(input)
+    if should_succeed then
+      match result
+      | let s: String val =>
+        ph.assert_true(true)
+      | let err: InvalidPercentEncoding val =>
+        ph.fail("expected decode success for: " + input)
+      end
+    else
+      match result
+      | let s: String val =>
+        ph.fail("expected decode failure for: " + input)
+      | let err: InvalidPercentEncoding val =>
+        ph.assert_true(true)
+      end
+    end
+
+class \nodoc\ iso _TestPercentEncodeKnownGood is UnitTest
+  """
+  Known encodings from RFC 3986 section 2.1 and common cases.
+  """
+  fun name(): String => "uri/percent_encoding/known_good"
+
+  fun ref apply(h: TestHelper) =>
+    // Space encodes as %20
+    h.assert_eq[String val]("%20", PercentEncode(" ", URIPartPath))
+
+    // Unreserved characters pass through unchanged
+    h.assert_eq[String val](
+      "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~",
+      PercentEncode(
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~",
+        URIPartPath))
+
+    // RFC 3986 section 2.1 example: 'A' = %41
+    match PercentDecode("%41")
+    | let s: String val => h.assert_eq[String val]("A", s)
+    | let err: InvalidPercentEncoding val =>
+      h.fail("should decode %41")
+    end
+
+    // Lowercase hex is accepted
+    match PercentDecode("%6a")
+    | let s: String val => h.assert_eq[String val]("j", s)
+    | let err: InvalidPercentEncoding val =>
+      h.fail("should decode %6a")
+    end
+
+    // Empty string roundtrips
+    h.assert_eq[String val]("", PercentEncode("", URIPartPath))
+    match PercentDecode("")
+    | let s: String val => h.assert_eq[String val]("", s)
+    | let err: InvalidPercentEncoding val =>
+      h.fail("should decode empty string")
+    end
+
+    // PercentEncode uses uppercase hex
+    h.assert_eq[String val]("%3C", PercentEncode("<", URIPartPath))
+
+    // Path allows / and : unencoded
+    h.assert_eq[String val]("/foo:bar", PercentEncode("/foo:bar", URIPartPath))
+
+    // Query allows / : ? unencoded
+    h.assert_eq[String val](
+      "/foo:bar?baz", PercentEncode("/foo:bar?baz", URIPartQuery))
+
+    // Userinfo allows : but encodes @
+    h.assert_eq[String val](
+      "user:pass", PercentEncode("user:pass", URIPartUserinfo))
+    h.assert_eq[String val](
+      "user%40host", PercentEncode("user@host", URIPartUserinfo))

--- a/http_server/uri/_test_query_parameters.pony
+++ b/http_server/uri/_test_query_parameters.pony
@@ -1,0 +1,174 @@
+use "pony_test"
+use "pony_check"
+
+class \nodoc\ iso _PropertyQueryParamsRoundtrip
+  is Property1[Array[(String val, String val)] val]
+  """
+  Generated key-value pairs serialized as `k=v&k2=v2` parse back to
+  matching pairs.
+  """
+  fun name(): String => "uri/query_parameters/roundtrip"
+
+  fun gen(): Generator[Array[(String val, String val)] val] =>
+    let key_gen = Generators.one_of[String val](
+      ["key"; "name"; "q"; "page"; "id"; "foo"; "bar"])
+    let val_gen = Generators.one_of[String val](
+      ["value"; "1"; "hello"; ""; "test"; "42"; "abc"])
+    let pair_gen = Generators.zip2[String val, String val](key_gen, val_gen)
+    Generators.array_of[
+      (String val, String val)](pair_gen where min = 0, max = 5)
+      .map[Array[(String val, String val)] val](
+        {(arr: Array[(String val, String val)] ref)
+          : Array[(String val, String val)] val
+        =>
+          let out = recover iso
+            Array[(String val, String val)](arr.size())
+          end
+          for pair in arr.values() do
+            out.push(pair)
+          end
+          consume out
+        })
+
+  fun ref property(
+    arg1: Array[(String val, String val)] val,
+    ph: PropertyHelper)
+  =>
+    // Serialize
+    let parts = Array[String val](arg1.size())
+    for (k, v) in arg1.values() do
+      parts.push(k + "=" + v)
+    end
+    let query = "&".join(parts.values())
+
+    match ParseQueryParameters(consume query)
+    | let parsed: Array[(String val, String val)] val =>
+      ph.assert_eq[USize](arg1.size(), parsed.size(),
+        "pair count mismatch")
+      var i: USize = 0
+      while i < arg1.size() do
+        try
+          (let ek, let ev) = arg1(i)?
+          (let pk, let pv) = parsed(i)?
+          ph.assert_eq[String val](ek, pk,
+            "key mismatch at " + i.string())
+          ph.assert_eq[String val](ev, pv,
+            "value mismatch at " + i.string())
+        end
+        i = i + 1
+      end
+    | let err: InvalidPercentEncoding val =>
+      ph.fail("roundtrip parse failed")
+    end
+
+class \nodoc\ iso _PropertyQueryParamsPlusDecodes is Property1[String val]
+  """`+` in query values decodes as space."""
+  fun name(): String => "uri/query_parameters/plus_decodes"
+
+  fun gen(): Generator[String val] =>
+    Generators.one_of[String val](
+      ["hello+world"; "a+b+c"; "+"; "no+spaces+here"; "++"])
+
+  fun ref property(arg1: String val, ph: PropertyHelper) =>
+    let query = "key=" + arg1
+    match ParseQueryParameters(consume query)
+    | let parsed: Array[(String val, String val)] val =>
+      try
+        (_, let v) = parsed(0)?
+        let exp = String(arg1.size())
+        for c in arg1.values() do
+          if c == '+' then exp.push(' ') else exp.push(c) end
+        end
+        ph.assert_eq[String val](exp.clone(), v,
+          "+ should decode as space in: " + arg1)
+      end
+    | let err: InvalidPercentEncoding val =>
+      ph.fail("unexpected error for: " + arg1)
+    end
+
+class \nodoc\ iso _PropertyQueryParamsInvalidRejected
+  is Property1[String val]
+  """Query strings with invalid percent-encoding produce errors."""
+  fun name(): String => "uri/query_parameters/invalid_rejected"
+
+  fun gen(): Generator[String val] =>
+    Generators.one_of[String val]([
+      "key=%GG"; "k=%2"; "a=b&c=%"; "bad=%XX&good=1"; "%ZZ=val"
+    ])
+
+  fun ref property(arg1: String val, ph: PropertyHelper) =>
+    match ParseQueryParameters(arg1)
+    | let parsed: Array[(String val, String val)] val =>
+      ph.fail("expected error for: " + arg1)
+    | let err: InvalidPercentEncoding val =>
+      ph.assert_true(true)
+    end
+
+class \nodoc\ iso _TestQueryParametersKnownGood is UnitTest
+  """Known query parameter parsing cases."""
+  fun name(): String => "uri/query_parameters/known_good"
+
+  fun ref apply(h: TestHelper) =>
+    // Simple key-value pairs
+    _assert_params(h, "a=1&b=2",
+      [("a", "1"); ("b", "2")])
+
+    // Plus as space
+    _assert_params(h, "key=hello+world",
+      [("key", "hello world")])
+
+    // Duplicate keys preserved in order
+    _assert_params(h, "a=1&a=2",
+      [("a", "1"); ("a", "2")])
+
+    // Empty string produces empty array
+    _assert_params(h, "", Array[(String val, String val)](0))
+
+    // Key without value (no =)
+    _assert_params(h, "key",
+      [("key", "")])
+
+    // Key with empty value
+    _assert_params(h, "key=",
+      [("key", "")])
+
+    // Multiple keys without values
+    _assert_params(h, "a&b&c",
+      [("a", ""); ("b", ""); ("c", "")])
+
+    // Percent-encoded key and value
+    _assert_params(h, "hello%20world=foo%26bar",
+      [("hello world", "foo&bar")])
+
+    // Value with multiple = signs (only first splits)
+    _assert_params(h, "key=a=b=c",
+      [("key", "a=b=c")])
+
+    // Mixed forms
+    _assert_params(h, "a=1&b&c=3",
+      [("a", "1"); ("b", ""); ("c", "3")])
+
+  fun _assert_params(
+    h: TestHelper,
+    input: String val,
+    expected: Array[(String val, String val)] val)
+  =>
+    match ParseQueryParameters(input)
+    | let parsed: Array[(String val, String val)] val =>
+      h.assert_eq[USize](expected.size(), parsed.size(),
+        "pair count mismatch for: " + input)
+      var i: USize = 0
+      while i < expected.size() do
+        try
+          (let ek, let ev) = expected(i)?
+          (let pk, let pv) = parsed(i)?
+          h.assert_eq[String val](ek, pk,
+            "key mismatch at " + i.string() + " for: " + input)
+          h.assert_eq[String val](ev, pv,
+            "value mismatch at " + i.string() + " for: " + input)
+        end
+        i = i + 1
+      end
+    | let err: InvalidPercentEncoding val =>
+      h.fail("parse failed for: " + input + ": " + err.string())
+    end

--- a/http_server/uri/parse_uri.pony
+++ b/http_server/uri/parse_uri.pony
@@ -1,0 +1,156 @@
+primitive ParseURI
+  """
+  Parse a URI-reference (RFC 3986 section 4.1) into structured components.
+
+  Handles both absolute URIs (`http://host/path?query`) and relative
+  references (`/path?query`). Components are stored percent-encoded.
+
+  The parsing algorithm follows RFC 3986 section 3: scan for `:` before
+  any of `/?#` to identify the scheme, then check for `//` to identify
+  authority, then extract path (up to `?` or `#`), query (between `?`
+  and `#`), and fragment (after `#`). Scanning operates on literal
+  delimiter characters only — percent-encoded delimiters (`%2F`, `%3F`,
+  `%23`) are not treated as structural boundaries.
+
+  Scheme validation: the scheme must start with a letter and contain
+  only letters, digits, `+`, `-`, and `.` (RFC 3986 section 3.1).
+
+  The asterisk-form (`*`) used by HTTP OPTIONS is a valid relative
+  reference under RFC 3986 — it parses as a URI with path `*` and no
+  other components.
+  """
+  fun apply(raw: String val): (URI val | URIParseError val) =>
+    var pos: USize = 0
+    let len = raw.size()
+
+    // Step 1: Detect scheme by scanning for ':' before any of '/?#'
+    var scheme: (String | None) = None
+    try
+      var i: USize = 0
+      while i < len do
+        let c = raw(i)?
+        if c == ':' then
+          // Everything before ':' is potential scheme
+          let candidate: String val = raw.substring(0, i.isize())
+          if _valid_scheme(candidate) then
+            scheme = candidate
+            pos = i + 1
+          end
+          break
+        elseif (c == '/') or (c == '?') or (c == '#') then
+          break
+        end
+        i = i + 1
+      end
+    else
+      _Unreachable()
+    end
+
+    // Step 2: Check for authority (starts with "//")
+    var authority: (URIAuthority | None) = None
+    try
+      if ((pos + 1) < len) and (raw(pos)? == '/') and (raw(pos + 1)? == '/')
+      then
+        pos = pos + 2
+        // Find end of authority: next '/', '?', or '#'
+        var auth_end = pos
+        while auth_end < len do
+          let c = raw(auth_end)?
+          if (c == '/') or (c == '?') or (c == '#') then
+            break
+          end
+          auth_end = auth_end + 1
+        end
+        match ParseURIAuthority._parse(raw, pos, auth_end)
+        | let a: URIAuthority val =>
+          authority = a
+        | let e: URIParseError val =>
+          return e
+        end
+        pos = auth_end
+      end
+    else
+      _Unreachable()
+    end
+
+    // Step 3: Extract path (up to '?' or '#')
+    var path_end = pos
+    try
+      while path_end < len do
+        let c = raw(path_end)?
+        if (c == '?') or (c == '#') then
+          break
+        end
+        path_end = path_end + 1
+      end
+    else
+      _Unreachable()
+    end
+    let path: String val = raw.substring(pos.isize(), path_end.isize())
+    pos = path_end
+
+    // Step 4: Extract query (between '?' and '#')
+    var query: (String | None) = None
+    try
+      if (pos < len) and (raw(pos)? == '?') then
+        pos = pos + 1
+        var query_end = pos
+        while query_end < len do
+          if raw(query_end)? == '#' then
+            break
+          end
+          query_end = query_end + 1
+        end
+        let q: String val = raw.substring(pos.isize(), query_end.isize())
+        query = q
+        pos = query_end
+      end
+    else
+      _Unreachable()
+    end
+
+    // Step 5: Extract fragment (after '#')
+    var fragment: (String | None) = None
+    try
+      if (pos < len) and (raw(pos)? == '#') then
+        pos = pos + 1
+        let f: String val = raw.substring(pos.isize(), len.isize())
+        fragment = f
+      end
+    else
+      _Unreachable()
+    end
+
+    URI(scheme, authority, path, query, fragment)
+
+  fun _valid_scheme(candidate: String val): Bool =>
+    """
+    RFC 3986 section 3.1: scheme = ALPHA *( ALPHA / DIGIT / "+" / "-" / "." )
+    """
+    if candidate.size() == 0 then
+      return false
+    end
+    try
+      let first = candidate(0)?
+      if not (((first >= 'A') and (first <= 'Z'))
+        or ((first >= 'a') and (first <= 'z')))
+      then
+        return false
+      end
+      var i: USize = 1
+      while i < candidate.size() do
+        let c = candidate(i)?
+        if not (
+          ((c >= 'A') and (c <= 'Z'))
+            or ((c >= 'a') and (c <= 'z'))
+            or ((c >= '0') and (c <= '9'))
+            or (c == '+') or (c == '-') or (c == '.'))
+        then
+          return false
+        end
+        i = i + 1
+      end
+    else
+      _Unreachable()
+    end
+    true

--- a/http_server/uri/parse_uri_authority.pony
+++ b/http_server/uri/parse_uri_authority.pony
@@ -1,0 +1,286 @@
+primitive ParseURIAuthority
+  """
+  Parse a standalone authority string (`[userinfo@]host[:port]`).
+
+  Use this for HTTP CONNECT request-targets (authority-form) where the
+  request-target is `host:port` without a scheme or `//` prefix.
+  `ParseURI` would misinterpret `host:port` as `scheme:path`.
+
+  The `@` delimiter is identified by scanning for the last `@` in the
+  authority string, following the WHATWG URL Standard convention. RFC 3986
+  grammar makes the first `@` the delimiter (userinfo cannot contain
+  literal `@`, only `%40`), but using the last `@` is more robust against
+  real-world URIs with unencoded `@` in userinfo.
+  """
+  fun apply(raw: String val): (URIAuthority val | URIParseError val) =>
+    _parse(raw, 0, raw.size())
+
+  fun _parse(raw: String val, start: USize, end_pos: USize)
+    : (URIAuthority val | URIParseError val)
+  =>
+    // Find @ for userinfo
+    var userinfo: (String | None) = None
+    var host_start = start
+
+    // Check for IP-literal first — if the host starts with '[', @ before
+    // the closing ']' is part of the IP-literal, not a userinfo delimiter.
+    var at_pos: USize = end_pos // sentinel: no @ found
+    try
+      if (host_start < end_pos) and (raw(host_start)? == '[') then
+        // IP-literal: find closing ']' first, then look for @ before '['
+        // Actually, in authority "[::1]:8080", there's no userinfo.
+        // But in "user@[::1]:8080", the @ is before the '['.
+        // We need to find the LAST @ before any '[' or just the last @.
+        // RFC 3986: userinfo = *( unreserved / pct-encoded / sub-delims / ":" )
+        // The @ delimiter separates userinfo from host.
+        // Scan for @ only before the '['.
+        None // no @ possible when first char is '['
+      else
+        // Scan for last @ (RFC 3986 says first @ delimits, but in practice
+        // the last @ is used since userinfo can contain encoded @)
+        var i = start
+        while i < end_pos do
+          if raw(i)? == '@' then
+            at_pos = i
+          end
+          i = i + 1
+        end
+      end
+    else
+      _Unreachable()
+    end
+
+    if at_pos < end_pos then
+      let ui: String val = raw.substring(start.isize(), at_pos.isize())
+      userinfo = ui
+      host_start = at_pos + 1
+    end
+
+    // Check for IP-literal (starts with '[')
+    try
+      if (host_start < end_pos) and (raw(host_start)? == '[') then
+        // Find closing ']'
+        var bracket_end: USize = host_start + 1
+        var found = false
+        while bracket_end < end_pos do
+          if raw(bracket_end)? == ']' then
+            found = true
+            break
+          end
+          bracket_end = bracket_end + 1
+        end
+        if not found then
+          return InvalidHost
+        end
+
+        // Validate IP-literal content
+        let literal_content: String val =
+          raw.substring((host_start + 1).isize(), bracket_end.isize())
+        if not _valid_ip_literal(literal_content) then
+          return InvalidHost
+        end
+
+        let host_str: String val =
+          raw.substring(host_start.isize(), (bracket_end + 1).isize())
+
+        // After ']', optional ':port'
+        let after_bracket = bracket_end + 1
+        if after_bracket < end_pos then
+          try
+            if raw(after_bracket)? == ':' then
+              let port_str: String val =
+                raw.substring((after_bracket + 1).isize(), end_pos.isize())
+              match _parse_port(port_str)
+              | let p: U16 =>
+                return URIAuthority(userinfo, host_str, p)
+              | None =>
+                return URIAuthority(userinfo, host_str, None)
+              | let e: URIParseError val =>
+                return e
+              end
+            else
+              return InvalidHost
+            end
+          else
+            _Unreachable()
+          end
+        end
+        return URIAuthority(userinfo, host_str, None)
+      end
+    else
+      _Unreachable()
+    end
+
+    // Regular host (reg-name or IPv4) — find ':' for port, scanning from end
+    // to handle IPv6 addresses (though those should be in brackets)
+    var colon_pos: USize = end_pos // sentinel
+    try
+      var i = end_pos
+      while i > host_start do
+        i = i - 1
+        if raw(i)? == ':' then
+          colon_pos = i
+          break
+        end
+      end
+    else
+      _Unreachable()
+    end
+
+    if colon_pos < end_pos then
+      let host_str: String val =
+        raw.substring(host_start.isize(), colon_pos.isize())
+      let port_str: String val =
+        raw.substring((colon_pos + 1).isize(), end_pos.isize())
+      match _parse_port(port_str)
+      | let p: U16 =>
+        URIAuthority(userinfo, host_str, p)
+      | None =>
+        URIAuthority(userinfo, host_str, None)
+      | let e: URIParseError val =>
+        e
+      end
+    else
+      let host_val: String val =
+        raw.substring(host_start.isize(), end_pos.isize())
+      URIAuthority(userinfo, host_val, None)
+    end
+
+  fun _parse_port(port_str: String val): (U16 | None | URIParseError val) =>
+    if port_str.size() == 0 then
+      // Empty port (e.g., "host:") — RFC 3986 allows empty port
+      return None
+    end
+
+    // All characters must be digits
+    for c in port_str.values() do
+      if (c < '0') or (c > '9') then
+        return InvalidPort
+      end
+    end
+
+    // Parse as U64 first to detect overflow
+    try
+      let value = port_str.u64()?
+      if value > 65535 then
+        return InvalidPort
+      end
+      value.u16()
+    else
+      InvalidPort
+    end
+
+  fun _valid_ip_literal(content: String val): Bool =>
+    if content.size() == 0 then
+      return false
+    end
+
+    // IPvFuture: starts with 'v' (case-insensitive)
+    try
+      let first = content(0)?
+      if (first == 'v') or (first == 'V') then
+        return _valid_ipvfuture(content)
+      end
+    else
+      _Unreachable() // content.size() > 0 guaranteed above
+    end
+
+    // Otherwise must be IPv6
+    _valid_ipv6(content)
+
+  fun _valid_ipv6(content: String val): Bool =>
+    // Basic validation: only hex digits, ':', and '.' (for IPv4-mapped)
+    for c in content.values() do
+      if not (
+        ((c >= '0') and (c <= '9'))
+          or ((c >= 'A') and (c <= 'F'))
+          or ((c >= 'a') and (c <= 'f'))
+          or (c == ':') or (c == '.'))
+      then
+        return false
+      end
+    end
+    true
+
+  fun _valid_ipvfuture(content: String val): Bool =>
+    // IPvFuture = "v" 1*HEXDIG "." 1*( unreserved / sub-delims / ":" )
+    // Must have at least "v" + hexdig + "." + char = 4 chars
+    if content.size() < 4 then
+      return false
+    end
+
+    // Find the '.' separator
+    var dot_pos: USize = 0
+    var found_dot = false
+    try
+      var i: USize = 1  // skip 'v'
+      while i < content.size() do
+        if content(i)? == '.' then
+          dot_pos = i
+          found_dot = true
+          break
+        end
+        i = i + 1
+      end
+    else
+      _Unreachable()
+    end
+
+    if not found_dot then
+      return false
+    end
+
+    // Must have at least one hex digit between 'v' and '.'
+    if dot_pos < 2 then
+      return false
+    end
+
+    // Validate hex digits between 'v' and '.'
+    try
+      var i: USize = 1
+      while i < dot_pos do
+        let c = content(i)?
+        if not (
+          ((c >= '0') and (c <= '9'))
+            or ((c >= 'A') and (c <= 'F'))
+            or ((c >= 'a') and (c <= 'f')))
+        then
+          return false
+        end
+        i = i + 1
+      end
+    else
+      _Unreachable()
+    end
+
+    // Must have at least one char after '.'
+    if (dot_pos + 1) >= content.size() then
+      return false
+    end
+
+    // Validate chars after '.': unreserved / sub-delims / ":"
+    try
+      var i: USize = dot_pos + 1
+      while i < content.size() do
+        let c = content(i)?
+        if not (_is_unreserved(c) or _is_sub_delim(c) or (c == ':')) then
+          return false
+        end
+        i = i + 1
+      end
+    else
+      _Unreachable()
+    end
+
+    true
+
+  fun _is_unreserved(c: U8): Bool =>
+    ((c >= 'A') and (c <= 'Z'))
+      or ((c >= 'a') and (c <= 'z'))
+      or ((c >= '0') and (c <= '9'))
+      or (c == '-') or (c == '.') or (c == '_') or (c == '~')
+
+  fun _is_sub_delim(c: U8): Bool =>
+    (c == '!') or (c == '$') or (c == '&') or (c == '\'')
+      or (c == '(') or (c == ')') or (c == '*') or (c == '+')
+      or (c == ',') or (c == ';') or (c == '=')

--- a/http_server/uri/path_segments.pony
+++ b/http_server/uri/path_segments.pony
@@ -1,0 +1,57 @@
+primitive PathSegments
+  """
+  Split a URI path on `/` delimiters, then percent-decode each segment.
+
+  A leading `/` produces an empty first segment (distinguishes absolute
+  from relative paths). Splitting happens before decoding, so a
+  percent-encoded `/` (`%2F`) within a segment is preserved as a literal
+  slash in the decoded segment, not treated as a delimiter.
+  """
+  fun apply(path: String val)
+    : (Array[String val] val | InvalidPercentEncoding val)
+  =>
+    // Empty path produces a single empty segment
+    if path.size() == 0 then
+      return recover val Array[String val](1) .> push("") end
+    end
+
+    // Count segments for pre-allocation
+    var count: USize = 1
+    for c in path.values() do
+      if c == '/' then count = count + 1 end
+    end
+
+    let segments = Array[String val](count)
+    var start: USize = 0
+    var i: USize = 0
+
+    while i < path.size() do
+      try
+        if path(i)? == '/' then
+          let raw: String val = path.substring(start.isize(), i.isize())
+          match PercentDecode(raw)
+          | let decoded: String val => segments.push(decoded)
+          | let err: InvalidPercentEncoding val => return err
+          end
+          start = i + 1
+        end
+      else
+        _Unreachable()
+      end
+      i = i + 1
+    end
+
+    // Final segment after last '/' (or entire path if no '/')
+    let raw: String val = path.substring(start.isize(), path.size().isize())
+    match PercentDecode(raw)
+    | let decoded: String val => segments.push(decoded)
+    | let err: InvalidPercentEncoding val => return err
+    end
+
+    let result: Array[String val] iso = recover iso
+      Array[String val](segments.size())
+    end
+    for seg in segments.values() do
+      result.push(seg)
+    end
+    consume result

--- a/http_server/uri/percent_encoding.pony
+++ b/http_server/uri/percent_encoding.pony
@@ -1,0 +1,135 @@
+primitive InvalidPercentEncoding is Stringable
+  """Percent-encoded sequence is truncated or contains non-hex digits."""
+  fun string(): String iso^ => "InvalidPercentEncoding".clone()
+
+primitive URIPartUserinfo
+  """Encoding rules for the userinfo component."""
+primitive URIPartHost
+  """Encoding rules for the host component (reg-name only)."""
+primitive URIPartPath
+  """Encoding rules for the path component."""
+primitive URIPartQuery
+  """Encoding rules for the query component."""
+primitive URIPartFragment
+  """Encoding rules for the fragment component."""
+
+type URIPart is
+  ( URIPartUserinfo | URIPartHost | URIPartPath
+  | URIPartQuery | URIPartFragment )
+
+primitive PercentDecode
+  """
+  Decode all percent-encoded sequences in the input.
+
+  Does NOT decode `+` as space — that convention belongs to
+  `application/x-www-form-urlencoded` (handled by `ParseQueryParameters`),
+  not RFC 3986 percent-encoding.
+  """
+  fun apply(input: String val): (String val | InvalidPercentEncoding val) =>
+    // Fast path: no percent signs means nothing to decode
+    if not input.contains("%") then
+      return input
+    end
+
+    let out = String(input.size())
+    var i: USize = 0
+    while i < input.size() do
+      try
+        let c = input(i)?
+        if c == '%' then
+          if (i + 2) >= input.size() then
+            return InvalidPercentEncoding
+          end
+          let hi = _hex_value(input(i + 1)?)?
+          let lo = _hex_value(input(i + 2)?)?
+          out.push((hi * 16) + lo)
+          i = i + 3
+        else
+          out.push(c)
+          i = i + 1
+        end
+      else
+        return InvalidPercentEncoding
+      end
+    end
+    out.clone()
+
+  fun _hex_value(c: U8): U8 ? =>
+    if (c >= '0') and (c <= '9') then
+      c - '0'
+    elseif (c >= 'A') and (c <= 'F') then
+      (c - 'A') + 10
+    elseif (c >= 'a') and (c <= 'f') then
+      (c - 'a') + 10
+    else
+      error
+    end
+
+primitive PercentEncode
+  """
+  Percent-encode characters that are not allowed unencoded in the
+  specified URI component per RFC 3986.
+
+  For `URIPartHost`, this applies to reg-name hosts only. IP-literals
+  (IPv6 addresses and IPvFuture in brackets) have their own syntax and
+  should not be percent-encoded — pass them through unchanged.
+  """
+  fun apply(input: String val, part: URIPart): String val =>
+    let out = String(input.size())
+    for c in input.values() do
+      if _allowed(c, part) then
+        out.push(c)
+      else
+        out.append(_encode_byte(c))
+      end
+    end
+    out.clone()
+
+  fun _encode_byte(c: U8): String val =>
+    let hex = "0123456789ABCDEF"
+    recover val
+      let out = String(3)
+      out.push('%')
+      try
+        out.push(hex(c.usize() >> 4)?)
+        out.push(hex(c.usize() and 0x0F)?)
+      else
+        _Unreachable()
+      end
+      out
+    end
+
+  fun _allowed(c: U8, part: URIPart): Bool =>
+    // unreserved characters are always allowed (RFC 3986 section 2.3)
+    if _is_unreserved(c) then
+      return true
+    end
+
+    // sub-delims are allowed in all components
+    if _is_sub_delim(c) then
+      return true
+    end
+
+    // component-specific allowed characters
+    match part
+    | URIPartUserinfo => c == ':'
+    | URIPartHost => false
+    | URIPartPath => (c == ':') or (c == '@') or (c == '/')
+    | URIPartQuery =>
+      (c == ':') or (c == '@') or (c == '/') or (c == '?')
+    | URIPartFragment =>
+      (c == ':') or (c == '@') or (c == '/') or (c == '?')
+    end
+
+  fun _is_unreserved(c: U8): Bool =>
+    // ALPHA / DIGIT / "-" / "." / "_" / "~"
+    ((c >= 'A') and (c <= 'Z'))
+      or ((c >= 'a') and (c <= 'z'))
+      or ((c >= '0') and (c <= '9'))
+      or (c == '-') or (c == '.') or (c == '_') or (c == '~')
+
+  fun _is_sub_delim(c: U8): Bool =>
+    // "!" / "$" / "&" / "'" / "(" / ")" / "*" / "+" / "," / ";" / "="
+    (c == '!') or (c == '$') or (c == '&') or (c == '\'')
+      or (c == '(') or (c == ')') or (c == '*') or (c == '+')
+      or (c == ',') or (c == ';') or (c == '=')

--- a/http_server/uri/query_parameters.pony
+++ b/http_server/uri/query_parameters.pony
@@ -1,0 +1,112 @@
+primitive ParseQueryParameters
+  """
+  Parse a query string into key-value pairs.
+
+  Splits on `&`, then on the first `=`. Decodes `+` as space and
+  percent-decodes both keys and values.
+
+  Duplicate keys are preserved in order. Keys without `=` get an
+  empty-string value.
+
+  The `;` separator (from an older HTML convention) is not supported —
+  it was dropped from the WHATWG URL Standard and is rarely encountered
+  in practice.
+  """
+  fun apply(query: String val)
+    : (Array[(String val, String val)] val | InvalidPercentEncoding val)
+  =>
+    if query.size() == 0 then
+      return recover val Array[(String val, String val)](0) end
+    end
+
+    // Count pairs for pre-allocation
+    var count: USize = 1
+    for c in query.values() do
+      if c == '&' then count = count + 1 end
+    end
+
+    let pairs = Array[(String val, String val)](count)
+    var start: USize = 0
+    var i: USize = 0
+
+    while i <= query.size() do
+      let at_end = i == query.size()
+      let at_amp = try not at_end and (query(i)? == '&') else false end
+
+      if at_end or at_amp then
+        let pair_str: String val =
+          query.substring(start.isize(), i.isize())
+        match _parse_pair(pair_str)
+        | (let k: String val, let v: String val) => pairs.push((k, v))
+        | let err: InvalidPercentEncoding val => return err
+        end
+        start = i + 1
+      end
+      i = i + 1
+    end
+
+    let result: Array[(String val, String val)] iso = recover iso
+      Array[(String val, String val)](pairs.size())
+    end
+    for pair in pairs.values() do
+      result.push(pair)
+    end
+    consume result
+
+  fun _parse_pair(pair: String val)
+    : ((String val, String val) | InvalidPercentEncoding val)
+  =>
+    // Find first '='
+    var eq_pos: USize = pair.size() // sentinel: no '=' found
+    var j: USize = 0
+    while j < pair.size() do
+      try
+        if pair(j)? == '=' then
+          eq_pos = j
+          break
+        end
+      else
+        _Unreachable()
+      end
+      j = j + 1
+    end
+
+    let raw_key: String val =
+      if eq_pos < pair.size() then
+        pair.substring(0, eq_pos.isize())
+      else
+        pair
+      end
+
+    let raw_value: String val =
+      if eq_pos < pair.size() then
+        pair.substring((eq_pos + 1).isize(), pair.size().isize())
+      else
+        ""
+      end
+
+    let key_plus: String val = _plus_to_space(raw_key)
+    let value_plus: String val = _plus_to_space(raw_value)
+
+    match PercentDecode(key_plus)
+    | let key: String val =>
+      match PercentDecode(value_plus)
+      | let value: String val => (key, value)
+      | let err: InvalidPercentEncoding val => err
+      end
+    | let err: InvalidPercentEncoding val => err
+    end
+
+  fun _plus_to_space(input: String val): String val =>
+    if not input.contains("+") then
+      return input
+    end
+    let out = String(input.size())
+    for c in input.values() do
+      if c == '+' then
+        out.push(' ')
+      else
+        out.push(c)
+      end
+    end
+    out.clone()

--- a/http_server/uri/uri.pony
+++ b/http_server/uri/uri.pony
@@ -1,0 +1,124 @@
+"""
+# URI Parsing (RFC 3986)
+
+This package parses URI-references into structured components per RFC 3986.
+
+## Entry Points
+
+Use `ParseURI` for standard URI-references (absolute URIs and relative
+references — covers origin-form, absolute-form, and asterisk-form HTTP
+request-targets):
+
+```pony
+match ParseURI("/index.html?page=1")
+| let u: URI val => // u.path, u.query, etc.
+| let e: URIParseError val => // handle error
+end
+```
+
+Use `ParseURIAuthority` for HTTP CONNECT authority-form targets
+(`host:port` without scheme or `//`):
+
+```pony
+match ParseURIAuthority("example.com:443")
+| let a: URIAuthority val => // a.host, a.port
+| let e: URIParseError val => // handle error
+end
+```
+
+Use `PercentDecode`/`PercentEncode` for encoding operations, and
+`ParseQueryParameters`/`PathSegments` for higher-level query and path
+access.
+"""
+
+class val URI is (Stringable & Equatable[URI])
+  """
+  A parsed RFC 3986 URI-reference.
+
+  Components are stored in their percent-encoded form as they appeared in
+  the input. Delimiter characters (`:` after scheme, `//` before authority,
+  `?` before query, `#` before fragment) are stripped — use `string()` to
+  reconstruct the full URI with delimiters.
+
+  `string()` reconstruction follows RFC 3986 section 5.3. Components that
+  are `None` are omitted entirely (no delimiter). A component that is an
+  empty `String` (present but empty) includes its delimiter — e.g.,
+  `query` of `""` produces a trailing `?` with no value. This distinction
+  allows faithful reconstruction of inputs like `http://example.com/path?`
+  (empty query present, `query = ""`) vs. `http://example.com/path`
+  (no query at all, `query = None`).
+
+  Equality is structural: two URIs are equal when all their stored
+  (percent-encoded) components are equal. No normalization is applied
+  before comparison.
+  """
+  let scheme: (String | None)
+  let authority: (URIAuthority | None)
+  let path: String
+  let query: (String | None)
+  let fragment: (String | None)
+
+  new val create(
+    scheme': (String | None),
+    authority': (URIAuthority | None),
+    path': String,
+    query': (String | None),
+    fragment': (String | None))
+  =>
+    scheme = scheme'
+    authority = authority'
+    path = path'
+    query = query'
+    fragment = fragment'
+
+  fun string(): String iso^ =>
+    // RFC 3986 section 5.3
+    let out = recover iso String end
+    match scheme
+    | let s: String => out.append(s); out.push(':')
+    end
+    match authority
+    | let a: URIAuthority =>
+      out.append("//")
+      out.append(a.string())
+    end
+    out.append(path)
+    match query
+    | let q: String => out.push('?'); out.append(q)
+    end
+    match fragment
+    | let f: String => out.push('#'); out.append(f)
+    end
+    out
+
+  fun eq(that: URI box): Bool =>
+    let scheme_eq =
+      match (scheme, that.scheme)
+      | (None, None) => true
+      | (let a: String, let b: String) => a == b
+      else
+        false
+      end
+    let authority_eq =
+      match (authority, that.authority)
+      | (None, None) => true
+      | (let a: URIAuthority, let b: URIAuthority) => a == b
+      else
+        false
+      end
+    let query_eq =
+      match (query, that.query)
+      | (None, None) => true
+      | (let a: String, let b: String) => a == b
+      else
+        false
+      end
+    let fragment_eq =
+      match (fragment, that.fragment)
+      | (None, None) => true
+      | (let a: String, let b: String) => a == b
+      else
+        false
+      end
+    scheme_eq and authority_eq and (path == that.path)
+      and query_eq and fragment_eq

--- a/http_server/uri/uri_authority.pony
+++ b/http_server/uri/uri_authority.pony
@@ -1,0 +1,51 @@
+class val URIAuthority is (Stringable & Equatable[URIAuthority])
+  """
+  A parsed URI authority component (RFC 3986 section 3.2).
+
+  Format: `[userinfo@]host[:port]`
+
+  The host may be empty — this occurs in URIs like `file:///path` where
+  the authority is present (indicated by `//`) but contains no host.
+  IP-literals (IPv6 and IPvFuture) include their brackets in the host
+  string (e.g., `[::1]`).
+  """
+  let userinfo: (String | None)
+  let host: String
+  let port: (U16 | None)
+
+  new val create(
+    userinfo': (String | None),
+    host': String,
+    port': (U16 | None))
+  =>
+    userinfo = userinfo'
+    host = host'
+    port = port'
+
+  fun string(): String iso^ =>
+    let out = recover iso String end
+    match userinfo
+    | let u: String => out.append(u); out.push('@')
+    end
+    out.append(host)
+    match port
+    | let p: U16 => out.push(':'); out.append(p.string())
+    end
+    out
+
+  fun eq(that: URIAuthority box): Bool =>
+    let userinfo_eq =
+      match (userinfo, that.userinfo)
+      | (None, None) => true
+      | (let a: String, let b: String) => a == b
+      else
+        false
+      end
+    let port_eq =
+      match (port, that.port)
+      | (None, None) => true
+      | (let a: U16, let b: U16) => a == b
+      else
+        false
+      end
+    userinfo_eq and (host == that.host) and port_eq

--- a/http_server/uri/uri_parse_error.pony
+++ b/http_server/uri/uri_parse_error.pony
@@ -1,0 +1,14 @@
+primitive InvalidPort is Stringable
+  """Port is non-numeric or exceeds U16 range."""
+  fun string(): String iso^ => "InvalidPort".clone()
+
+primitive InvalidHost is Stringable
+  """
+  Malformed IP-literal (unmatched brackets, illegal characters in IPv6
+  address, or invalid IPvFuture syntax).
+  """
+  fun string(): String iso^ => "InvalidHost".clone()
+
+// URIParseError is any structural parse error returned by ParseURI or
+// ParseURIAuthority.
+type URIParseError is (InvalidPort | InvalidHost)


### PR DESCRIPTION
Adds `http_server/uri/` subpackage implementing RFC 3986 URI parsing, following the plan in Discussion #7.

- `ParseURI`: structural decomposition of URI-references into typed components (scheme, authority, path, query, fragment)
- `ParseURIAuthority`: standalone authority parsing for HTTP CONNECT request-targets
- `PercentDecode`/`PercentEncode`: RFC 3986 percent-encoding with per-component encoding rules
- `ParseQueryParameters`: `application/x-www-form-urlencoded` key-value pair parsing with `+`-as-space
- `PathSegments`: split-then-decode path decomposition preserving `%2F` within segments
- Errors are data types (`InvalidPort`, `InvalidHost`, `InvalidPercentEncoding`) in union returns — no partial functions
- All types are `class val` (immutable after construction)
- 20 new tests (15 property-based, 5 example-based) covering roundtripping, invalid input rejection, RFC 3986 examples, and edge cases
- Updated `examples/basic` to demonstrate URI parsing and query parameter extraction
- Updated `Handler.request()` docstring to reference `ParseURI`

Design: #7