### PR TITLE
Parse URI in connection layer before handler dispatch

### DIFF
--- a/examples/basic/main.pony
+++ b/examples/basic/main.pony
@@ -3,8 +3,8 @@ Basic HTTP server that responds to every request with "Hello, World!".
 
 Demonstrates the core API: `Server`, `HandlerFactory`, `Handler`,
 `Responder`, `ServerConfig`, and `ServerNotify`. Also demonstrates
-URI parsing with the `http_server/uri` subpackage: each request's
-URI is parsed and query parameters are extracted.
+query parameter extraction from the pre-parsed URI: a `?name=X`
+parameter customizes the greeting.
 """
 use http_server = "../../http_server"
 use uri = "../../http_server/uri"
@@ -36,21 +36,18 @@ class ref _HelloHandler is http_server.Handler
 
   fun ref request(
     method: http_server.Method,
-    uri_str: String val,
+    request_uri: uri.URI val,
     version: http_server.Version,
     headers: http_server.Headers val)
   =>
-    // Parse the URI and extract a "name" query parameter if present
+    // Extract a "name" query parameter if present
     _name = "World"
-    match uri.ParseURI(uri_str)
-    | let u: uri.URI val =>
-      match u.query
-      | let q: String val =>
-        match uri.ParseQueryParameters(q)
-        | let params: Array[(String val, String val)] val =>
-          for (k, v) in params.values() do
-            if k == "name" then _name = v end
-          end
+    match request_uri.query
+    | let q: String val =>
+      match uri.ParseQueryParameters(q)
+      | let params: Array[(String val, String val)] val =>
+        for (k, v) in params.values() do
+          if k == "name" then _name = v end
         end
       end
     end

--- a/http_server/_test.pony
+++ b/http_server/_test.pony
@@ -105,3 +105,7 @@ actor \nodoc\ Main is TestList
     test(_TestStreamingResponse)
     test(_TestMaxPendingOverflow)
     test(_TestHTTP10ChunkedRejection)
+
+    // URI parsing integration tests
+    test(_TestURIParsing)
+    test(_TestConnectURIParsing)

--- a/http_server/handler.pony
+++ b/http_server/handler.pony
@@ -1,3 +1,5 @@
+use "./uri"
+
 trait ref Handler
   """
   Application handler for HTTP requests.
@@ -12,17 +14,23 @@ trait ref Handler
 
   fun ref request(
     method: Method,
-    uri: String val,
+    uri: URI val,
     version: Version,
     headers: Headers val)
   =>
     """
     Called when the request line and all headers have been parsed.
 
-    The `uri` string is the raw request-target from the HTTP request line.
-    Use `ParseURI` from the `http_server/uri` subpackage to parse it into
-    structured components (`URI.path`, `URI.query`, etc.). For CONNECT
-    requests (authority-form `host:port`), use `ParseURIAuthority` instead.
+    The `uri` is a pre-parsed RFC 3986 URI with structured components
+    available directly (`uri.path`, `uri.query`, `uri.authority`, etc.).
+    The connection layer parses the raw request-target before delivering
+    it here — invalid URIs are rejected with 400 Bad Request before
+    reaching the handler.
+
+    For CONNECT requests, the URI has only the `authority` component
+    populated (host and port); `path` is empty. Note that
+    `uri.string()` reconstructs to `//host:port` rather than the
+    wire-format `host:port`.
 
     For requests with a body, `body_chunk` calls follow. For requests
     without a body, `request_complete` is called immediately after.

--- a/http_server/parse_error.pony
+++ b/http_server/parse_error.pony
@@ -9,7 +9,13 @@ primitive UnknownMethod is _ParseError
   fun string(): String iso^ => "UnknownMethod".clone()
 
 primitive InvalidURI is _ParseError
-  """Request URI is empty or contains spaces or control characters."""
+  """
+  Request URI is invalid.
+
+  Raised when the URI is empty, contains control characters, or fails
+  RFC 3986 structural parsing in the connection layer (e.g., invalid
+  authority in CONNECT targets).
+  """
   fun string(): String iso^ => "InvalidURI".clone()
 
 primitive InvalidVersion is _ParseError


### PR DESCRIPTION
Handler.request() now receives `URI val` instead of `String val`. The connection layer parses the raw request-target using `ParseURI` (for origin-form, absolute-form, asterisk-form) or `ParseURIAuthority` (for CONNECT authority-form), rejecting invalid URIs with 400 Bad Request before they reach the handler.

This eliminates the need for every handler to manually parse URIs — handlers can trust that `uri.path`, `uri.query`, `uri.authority` etc. are already available. The basic example shrinks from a triple-nested match chain to a single match on `uri.query`.

The internal `_RequestParserNotify` interface is unchanged (still passes `String val`). URI parsing is a connection-layer concern, not a parser concern.