### PR TITLE
Add query_params() convenience method to URI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,12 +73,13 @@ No release notes until after the first release. This project is pre-1.0 and hasn
   - `_connection.pony` — Per-connection actor (`_Connection`, owns TCP + parser + URI parsing + handler + response queue + idle timer)
   - `server.pony` — Listener actor (`Server`, accepts connections, creates `_Connection` actors)
   - `uri/` — URI parsing subpackage (RFC 3986)
-    - `uri.pony` — Package docstring and `URI` class
+    - `uri.pony` — Package docstring and `URI` class (`query_params()` convenience method)
     - `uri_authority.pony` — `URIAuthority` class
     - `percent_encoding.pony` — `PercentDecode`, `PercentEncode`, `URIPart` types, `InvalidPercentEncoding`
     - `parse_uri.pony` — `ParseURI` factory
     - `parse_uri_authority.pony` — `ParseURIAuthority` factory
     - `uri_parse_error.pony` — Error types and `URIParseError` union
+    - `query_params.pony` — `QueryParams` class (key-based lookup for parsed query parameters)
     - `query_parameters.pony` — `ParseQueryParameters` primitive
     - `path_segments.pony` — `PathSegments` primitive
     - `_mort.pony` — `_Unreachable`, `_IllegalState` (package-private duplicate)

--- a/examples/basic/main.pony
+++ b/examples/basic/main.pony
@@ -42,13 +42,10 @@ class ref _HelloHandler is http_server.Handler
   =>
     // Extract a "name" query parameter if present
     _name = "World"
-    match request_uri.query
-    | let q: String val =>
-      match uri.ParseQueryParameters(q)
-      | let params: Array[(String val, String val)] val =>
-        for (k, v) in params.values() do
-          if k == "name" then _name = v end
-        end
+    match request_uri.query_params()
+    | let params: uri.QueryParams val =>
+      match params.get("name")
+      | let name: String => _name = name
       end
     end
 

--- a/http_server/uri/_test.pony
+++ b/http_server/uri/_test.pony
@@ -42,3 +42,8 @@ actor \nodoc\ Main is TestList
     test(Property1UnitTest[String val](_PropertyQueryParamsPlusDecodes))
     test(Property1UnitTest[String val](_PropertyQueryParamsInvalidRejected))
     test(_TestQueryParametersKnownGood)
+    test(_TestURIQueryParams)
+    test(_TestQueryParamsGet)
+    test(_TestQueryParamsGetAll)
+    test(_TestQueryParamsContains)
+    test(_TestQueryParamsSize)

--- a/http_server/uri/_test_query_parameters.pony
+++ b/http_server/uri/_test_query_parameters.pony
@@ -42,7 +42,7 @@ class \nodoc\ iso _PropertyQueryParamsRoundtrip
     let query = "&".join(parts.values())
 
     match ParseQueryParameters(consume query)
-    | let parsed: Array[(String val, String val)] val =>
+    | let parsed: QueryParams val =>
       ph.assert_eq[USize](arg1.size(), parsed.size(),
         "pair count mismatch")
       var i: USize = 0
@@ -72,7 +72,7 @@ class \nodoc\ iso _PropertyQueryParamsPlusDecodes is Property1[String val]
   fun ref property(arg1: String val, ph: PropertyHelper) =>
     let query = "key=" + arg1
     match ParseQueryParameters(consume query)
-    | let parsed: Array[(String val, String val)] val =>
+    | let parsed: QueryParams val =>
       try
         (_, let v) = parsed(0)?
         let exp = String(arg1.size())
@@ -98,7 +98,7 @@ class \nodoc\ iso _PropertyQueryParamsInvalidRejected
 
   fun ref property(arg1: String val, ph: PropertyHelper) =>
     match ParseQueryParameters(arg1)
-    | let parsed: Array[(String val, String val)] val =>
+    | let parsed: QueryParams val =>
       ph.fail("expected error for: " + arg1)
     | let err: InvalidPercentEncoding val =>
       ph.assert_true(true)
@@ -121,7 +121,7 @@ class \nodoc\ iso _TestQueryParametersKnownGood is UnitTest
     _assert_params(h, "a=1&a=2",
       [("a", "1"); ("a", "2")])
 
-    // Empty string produces empty array
+    // Empty string produces empty QueryParams
     _assert_params(h, "", Array[(String val, String val)](0))
 
     // Key without value (no =)
@@ -154,7 +154,7 @@ class \nodoc\ iso _TestQueryParametersKnownGood is UnitTest
     expected: Array[(String val, String val)] val)
   =>
     match ParseQueryParameters(input)
-    | let parsed: Array[(String val, String val)] val =>
+    | let parsed: QueryParams val =>
       h.assert_eq[USize](expected.size(), parsed.size(),
         "pair count mismatch for: " + input)
       var i: USize = 0
@@ -171,4 +171,140 @@ class \nodoc\ iso _TestQueryParametersKnownGood is UnitTest
       end
     | let err: InvalidPercentEncoding val =>
       h.fail("parse failed for: " + input + ": " + err.string())
+    end
+
+class \nodoc\ iso _TestURIQueryParams is UnitTest
+  """URI.query_params() convenience method."""
+  fun name(): String => "uri/query_parameters/uri_query_params"
+
+  fun ref apply(h: TestHelper) =>
+    // URI with query string returns parsed params
+    let with_query = URI(None, None, "/path", "a=1&b=2", None)
+    match with_query.query_params()
+    | let params: QueryParams val =>
+      h.assert_eq[USize](2, params.size(), "should have 2 params")
+      try
+        h.assert_eq[String val]("a", params(0)?._1)
+        h.assert_eq[String val]("1", params(0)?._2)
+        h.assert_eq[String val]("b", params(1)?._1)
+        h.assert_eq[String val]("2", params(1)?._2)
+      else
+        h.fail("could not read params")
+      end
+    | None =>
+      h.fail("expected params, got None")
+    end
+
+    // URI without query string returns None
+    let no_query = URI(None, None, "/path", None, None)
+    match no_query.query_params()
+    | let _: QueryParams val =>
+      h.fail("expected None for no query")
+    | None => None // expected
+    end
+
+    // URI with empty query string returns empty QueryParams
+    let empty_query = URI(None, None, "/path", "", None)
+    match empty_query.query_params()
+    | let params: QueryParams val =>
+      h.assert_eq[USize](0, params.size(), "empty query = 0 params")
+    | None =>
+      h.fail("expected empty QueryParams, got None")
+    end
+
+    // URI with invalid percent-encoding in query returns None
+    let bad_encoding = URI(None, None, "/path", "key=%GG", None)
+    match bad_encoding.query_params()
+    | let _: QueryParams val =>
+      h.fail("expected None for bad encoding")
+    | None => None // expected
+    end
+
+class \nodoc\ iso _TestQueryParamsGet is UnitTest
+  """QueryParams.get() returns first value for key."""
+  fun name(): String => "uri/query_parameters/query_params_get"
+
+  fun ref apply(h: TestHelper) =>
+    match ParseQueryParameters("a=1&b=2&a=3")
+    | let params: QueryParams val =>
+      // Key present — returns first value
+      h.assert_eq[String val]("1",
+        try params.get("a") as String else "" end,
+        "get should return first value for duplicate key")
+      h.assert_eq[String val]("2",
+        try params.get("b") as String else "" end,
+        "get should return value for unique key")
+
+      // Key absent — returns None
+      match params.get("missing")
+      | let _: String => h.fail("expected None for missing key")
+      | None => None // expected
+      end
+    | let err: InvalidPercentEncoding val =>
+      h.fail("unexpected parse error")
+    end
+
+class \nodoc\ iso _TestQueryParamsGetAll is UnitTest
+  """QueryParams.get_all() returns all values for key."""
+  fun name(): String => "uri/query_parameters/query_params_get_all"
+
+  fun ref apply(h: TestHelper) =>
+    match ParseQueryParameters("a=1&b=2&a=3")
+    | let params: QueryParams val =>
+      // Multiple values
+      let a_vals = params.get_all("a")
+      h.assert_eq[USize](2, a_vals.size(), "should have 2 values for a")
+      try
+        h.assert_eq[String val]("1", a_vals(0)?)
+        h.assert_eq[String val]("3", a_vals(1)?)
+      else
+        h.fail("could not read a values")
+      end
+
+      // Single value
+      let b_vals = params.get_all("b")
+      h.assert_eq[USize](1, b_vals.size(), "should have 1 value for b")
+
+      // Absent key
+      let missing = params.get_all("missing")
+      h.assert_eq[USize](0, missing.size(),
+        "absent key should return empty array")
+    | let err: InvalidPercentEncoding val =>
+      h.fail("unexpected parse error")
+    end
+
+class \nodoc\ iso _TestQueryParamsContains is UnitTest
+  """QueryParams.contains() checks key presence."""
+  fun name(): String => "uri/query_parameters/query_params_contains"
+
+  fun ref apply(h: TestHelper) =>
+    match ParseQueryParameters("a=1&b=2")
+    | let params: QueryParams val =>
+      h.assert_true(params.contains("a"), "should contain a")
+      h.assert_true(params.contains("b"), "should contain b")
+      h.assert_false(params.contains("c"), "should not contain c")
+    | let err: InvalidPercentEncoding val =>
+      h.fail("unexpected parse error")
+    end
+
+class \nodoc\ iso _TestQueryParamsSize is UnitTest
+  """QueryParams.size() reflects pair count including duplicates."""
+  fun name(): String => "uri/query_parameters/query_params_size"
+
+  fun ref apply(h: TestHelper) =>
+    // Empty
+    match ParseQueryParameters("")
+    | let params: QueryParams val =>
+      h.assert_eq[USize](0, params.size(), "empty = 0")
+    | let err: InvalidPercentEncoding val =>
+      h.fail("unexpected parse error")
+    end
+
+    // With duplicates — counts each pair
+    match ParseQueryParameters("a=1&a=2&b=3")
+    | let params: QueryParams val =>
+      h.assert_eq[USize](3, params.size(),
+        "duplicates count separately")
+    | let err: InvalidPercentEncoding val =>
+      h.fail("unexpected parse error")
     end

--- a/http_server/uri/query_parameters.pony
+++ b/http_server/uri/query_parameters.pony
@@ -1,6 +1,6 @@
 primitive ParseQueryParameters
   """
-  Parse a query string into key-value pairs.
+  Parse a query string into a `QueryParams` collection.
 
   Splits on `&`, then on the first `=`. Decodes `+` as space and
   percent-decodes both keys and values.
@@ -13,10 +13,11 @@ primitive ParseQueryParameters
   in practice.
   """
   fun apply(query: String val)
-    : (Array[(String val, String val)] val | InvalidPercentEncoding val)
+    : (QueryParams val | InvalidPercentEncoding val)
   =>
     if query.size() == 0 then
-      return recover val Array[(String val, String val)](0) end
+      return QueryParams(
+        recover val Array[(String val, String val)](0) end)
     end
 
     // Count pairs for pre-allocation
@@ -51,7 +52,7 @@ primitive ParseQueryParameters
     for pair in pairs.values() do
       result.push(pair)
     end
-    consume result
+    QueryParams(consume result)
 
   fun _parse_pair(pair: String val)
     : ((String val, String val) | InvalidPercentEncoding val)

--- a/http_server/uri/query_params.pony
+++ b/http_server/uri/query_params.pony
@@ -1,0 +1,55 @@
+class val QueryParams
+  """
+  Parsed query parameters with key-based lookup.
+
+  Stores decoded key-value pairs in their original order. Duplicate keys
+  are preserved — use `get()` for the first value or `get_all()` for every
+  value associated with a key. Lookups are linear scans, which is
+  appropriate for the small parameter counts typical of query strings.
+  """
+  let _pairs: Array[(String val, String val)] val
+
+  new val create(p: Array[(String val, String val)] val) =>
+    """Create from an array of decoded key-value pairs."""
+    _pairs = p
+
+  fun apply(i: USize): (String val, String val) ? =>
+    """The pair at index `i`. Raises an error if out of bounds."""
+    _pairs(i)?
+
+  fun get(key: String): (String val | None) =>
+    """
+    First value for `key`, or `None` if the key is absent.
+
+    When duplicate keys are possible and all values are needed, use
+    `get_all()` instead.
+    """
+    for (k, v) in _pairs.values() do
+      if k == key then return v end
+    end
+    None
+
+  fun get_all(key: String): Array[String val] val =>
+    """All values for `key`, in order. Empty array if absent."""
+    let result = recover iso Array[String val] end
+    for (k, v) in _pairs.values() do
+      if k == key then result.push(v) end
+    end
+    consume result
+
+  fun contains(key: String): Bool =>
+    """Whether `key` is present."""
+    for (k, _) in _pairs.values() do
+      if k == key then return true end
+    end
+    false
+
+  fun pairs(): ArrayValues[(String val, String val),
+    Array[(String val, String val)] val]^
+  =>
+    """All pairs in their original order."""
+    _pairs.values()
+
+  fun size(): USize =>
+    """Number of pairs, including duplicates."""
+    _pairs.size()

--- a/http_server/uri/uri.pony
+++ b/http_server/uri/uri.pony
@@ -26,8 +26,12 @@ match ParseURIAuthority("example.com:443")
 end
 ```
 
-Use `PercentDecode`/`PercentEncode` for encoding operations, and
-`ParseQueryParameters`/`PathSegments` for higher-level query and path
+For query parameter access, `URI.query_params()` is the simplest path —
+it returns a `QueryParams` collection with `get()`, `get_all()`, and
+`contains()` methods for key-based lookup. Use `ParseQueryParameters`
+directly on the `query` field when you need to distinguish "no query"
+from "invalid percent-encoding." Use `PercentDecode`/`PercentEncode`
+for encoding operations, and `PathSegments` for decoded path segment
 access.
 """
 
@@ -90,6 +94,25 @@ class val URI is (Stringable & Equatable[URI])
     | let f: String => out.push('#'); out.append(f)
     end
     out
+
+  fun query_params(): (QueryParams val | None) =>
+    """
+    Parse the query string into a `QueryParams` collection.
+
+    Returns the parsed parameters if the query is present and decodes
+    successfully, or `None` if no query is present or if the query
+    contains invalid percent-encoding. For fine-grained error handling
+    (distinguishing "no query" from "decode failure"), use
+    `ParseQueryParameters` directly on the `query` field.
+    """
+    match query
+    | let q: String val =>
+      match ParseQueryParameters(q)
+      | let params: QueryParams val => params
+      | let _: InvalidPercentEncoding => None
+      end
+    | None => None
+    end
 
   fun eq(that: URI box): Bool =>
     let scheme_eq =


### PR DESCRIPTION
Adds a `QueryParams` class that replaces the raw `Array[(String, String)]` return type from `ParseQueryParameters` and `URI.query_params()`. The class provides `get()`, `get_all()`, `contains()`, indexed access via `apply()`, and `pairs()` iteration, eliminating the iteration boilerplate every handler needed to look up a specific query parameter by name.

- `QueryParams` backed by ordered pair array, linear scan for lookups (appropriate for typical query string sizes)
- Updated `ParseQueryParameters` to return `QueryParams val`
- Updated `URI.query_params()` to return `(QueryParams val | None)`
- Simplified the basic example to use `params.get("name")` instead of manual iteration
- Added tests for all `QueryParams` methods (`get`, `get_all`, `contains`, `size`)
- Updated existing property and example-based tests to match on `QueryParams`