### PR TITLE
Add request body buffering

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,7 +38,11 @@ Connections close when the client sends `Connection: close`, on HTTP/1.0 request
 
 **URI parsing in the connection layer**: The connection layer parses the raw request-target string into a `URI val` (from the `http_server/uri` subpackage) before delivering it to the handler. For CONNECT requests, `ParseURIAuthority` parses the authority-form target; for all other methods, `ParseURI` handles origin-form, absolute-form, and asterisk-form targets. Invalid URIs are rejected with 400 Bad Request before reaching the handler. Handlers that override `request()` need `use "http_server/uri"` in their package to name the `URI` type.
 
-**Per-request Responder and response queue**: Each request gets its own `Responder` instance, delivered via `Handler.request_complete(responder)`. The `HandlerFactory` no longer passes a `Responder` — it creates a bare handler. Responders send data through a `_ResponseQueue` that ensures pipelined responses are delivered in request order, regardless of the order handlers respond. The queue calls back to the connection via `_ResponseQueueNotify` for TCP I/O — it never holds the TCP connection directly. Responders support two modes: simple (`respond()` with full body) and streaming (`start_chunked_response()` + `send_chunk()` + `finish_response()` using chunked transfer encoding). After connection close, any Responders the handler still holds become inert — their methods route to the closed queue, which no-ops everything.
+**Two handler traits — buffered and streaming**: `Handler` (buffered) delivers the complete request body as a single `Array[U8] val` in `request_complete(responder, body)`. `StreamingHandler` delivers body data incrementally via `body_chunk(data)` and calls `request_complete(responder)` with no body parameter. Most handlers should use `Handler`; use `StreamingHandler` for large uploads, proxying, or incremental processing.
+
+`Server` and `_Connection` accept `AnyHandlerFactory`. Internally, `_Connection` always works with `StreamingHandler`. When a `HandlerFactory` is provided, the connection wraps the `Handler` in `_BufferingAdapter`, which accumulates body chunks and delivers the complete body at `request_complete`. The adapter resets its buffer between pipelined requests.
+
+**Per-request Responder and response queue**: Each request gets its own `Responder` instance, delivered via `Handler.request_complete()` or `StreamingHandler.request_complete()`. The factory creates a bare handler. Responders send data through a `_ResponseQueue` that ensures pipelined responses are delivered in request order, regardless of the order handlers respond. The queue calls back to the connection via `_ResponseQueueNotify` for TCP I/O — it never holds the TCP connection directly. Responders support two modes: simple (`respond()` with full body) and streaming (`start_chunked_response()` + `send_chunk()` + `finish_response()` using chunked transfer encoding). After connection close, any Responders the handler still holds become inert — their methods route to the closed queue, which no-ops everything.
 
 ### Implementation plan
 
@@ -62,7 +66,8 @@ No release notes until after the first release. This project is pre-1.0 and hasn
   - `_request_parser_notify.pony` — Parser callback trait (synchronous `ref` methods)
   - `_parser_state.pony` — Parser state machine (state interface, 6 state classes, `_BufferScan`)
   - `_request_parser.pony` — Request parser class (entry point, buffer management)
-  - `handler.pony` — Application handler trait (`Handler`, receives `URI val`) and factory interface (`HandlerFactory`)
+  - `handler.pony` — Application handler traits (`Handler` buffered, `StreamingHandler` streaming, receives `URI val`) and factory interfaces (`HandlerFactory`, `StreamingHandlerFactory`)
+  - `_buffering_adapter.pony` — Adapts `Handler` to `StreamingHandler` by buffering body chunks (`_BufferingAdapter`)
   - `responder.pony` — Per-request response sender (`Responder` class, state machine, simple and streaming modes)
   - `_response_queue.pony` — Pipelined response ordering (`_ResponseQueue`, `_ResponseQueueNotify`, `_QueueEntry`)
   - `_chunked_encoder.pony` — Chunked transfer encoding (`_ChunkedEncoder` primitive)
@@ -70,8 +75,8 @@ No release notes until after the first release. This project is pre-1.0 and hasn
   - `server_notify.pony` — Server lifecycle notifications (`ServerNotify` interface)
   - `_error_response.pony` — Pre-built error response strings (`_ErrorResponse` primitive)
   - `_connection_state.pony` — Connection lifecycle states (`_Active`, `_Closed`)
-  - `_connection.pony` — Per-connection actor (`_Connection`, owns TCP + parser + URI parsing + handler + response queue + idle timer)
-  - `server.pony` — Listener actor (`Server`, accepts connections, creates `_Connection` actors)
+  - `_connection.pony` — Per-connection actor (`_Connection`, owns TCP + parser + URI parsing + handler + response queue + idle timer, accepts `AnyHandlerFactory`)
+  - `server.pony` — Listener actor (`Server`, accepts connections, creates `_Connection` actors, accepts `AnyHandlerFactory`)
   - `uri/` — URI parsing subpackage (RFC 3986)
     - `uri.pony` — Package docstring and `URI` class (`query_params()` convenience method)
     - `uri_authority.pony` — `URIAuthority` class

--- a/examples/basic/main.pony
+++ b/examples/basic/main.pony
@@ -5,6 +5,10 @@ Demonstrates the core API: `Server`, `HandlerFactory`, `Handler`,
 `Responder`, `ServerConfig`, and `ServerNotify`. Also demonstrates
 query parameter extraction from the pre-parsed URI: a `?name=X`
 parameter customizes the greeting.
+
+Uses the buffered `Handler` trait, where the complete request body
+is delivered in `request_complete`. For most use cases (JSON APIs,
+form submissions), this is the appropriate handler.
 """
 use http_server = "../../http_server"
 use uri = "../../http_server/uri"
@@ -49,13 +53,16 @@ class ref _HelloHandler is http_server.Handler
       end
     end
 
-  fun ref request_complete(responder: http_server.Responder) =>
+  fun ref request_complete(
+    responder: http_server.Responder,
+    body: http_server.RequestBody)
+  =>
     _request_count = _request_count + 1
-    let body: String val =
+    let resp_body: String val =
       "Hello, " + _name + "! (request " + _request_count.string() + ")"
     let headers = recover val
       let h = http_server.Headers
       h.set("content-type", "text/plain")
       h
     end
-    responder.respond(http_server.StatusOK, headers, body)
+    responder.respond(http_server.StatusOK, headers, resp_body)

--- a/examples/streaming/main.pony
+++ b/examples/streaming/main.pony
@@ -1,9 +1,13 @@
 """
 HTTP server that streams responses using chunked transfer encoding.
 
-Demonstrates the streaming API: `start_chunked_response()`, `send_chunk()`,
-and `finish_response()`. Each request receives three chunks before the
-response is finalized.
+Demonstrates the streaming response API: `start_chunked_response()`,
+`send_chunk()`, and `finish_response()`. Each request receives three
+chunks before the response is finalized.
+
+Note: this demonstrates streaming *responses*, not streaming request
+bodies. It uses the buffered `Handler` trait since it doesn't need
+incremental request body access.
 """
 use http_server = "../../http_server"
 use lori = "lori"
@@ -31,7 +35,10 @@ class val _StreamFactory is http_server.HandlerFactory
 class ref _StreamHandler is http_server.Handler
   var _request_count: USize = 0
 
-  fun ref request_complete(responder: http_server.Responder) =>
+  fun ref request_complete(
+    responder: http_server.Responder,
+    body: http_server.RequestBody)
+  =>
     _request_count = _request_count + 1
     let headers = recover val
       let h = http_server.Headers

--- a/http_server/_buffering_adapter.pony
+++ b/http_server/_buffering_adapter.pony
@@ -1,0 +1,51 @@
+use "./uri"
+
+class ref _BufferingAdapter is StreamingHandler
+  """
+  Adapts a buffered `Handler` to the `StreamingHandler` interface.
+
+  Accumulates body chunks internally and delivers the complete body
+  to the wrapped handler at `request_complete`. Used by `_Connection`
+  when a `HandlerFactory` is provided, so the connection always works
+  with `StreamingHandler` internally.
+
+  The buffer resets between pipelined requests: `request_complete`
+  swaps the accumulator with a fresh empty array.
+  """
+  let _inner: Handler
+  var _body: Array[U8] iso = recover iso Array[U8] end
+  var _has_body: Bool = false
+
+  new create(inner: Handler) =>
+    _inner = inner
+
+  fun ref request(
+    method: Method,
+    uri: URI val,
+    version: Version,
+    headers: Headers val)
+  =>
+    _inner.request(method, uri, version, headers)
+
+  fun ref body_chunk(data: Array[U8] val) =>
+    _has_body = true
+    _body.append(data)
+
+  fun ref request_complete(responder: Responder) =>
+    if _has_body then
+      _has_body = false
+      let body: Array[U8] val =
+        (_body = recover iso Array[U8] end)
+      _inner.request_complete(responder, body)
+    else
+      _inner.request_complete(responder, None)
+    end
+
+  fun ref closed() =>
+    _inner.closed()
+
+  fun ref throttled() =>
+    _inner.throttled()
+
+  fun ref unthrottled() =>
+    _inner.unthrottled()

--- a/http_server/_test.pony
+++ b/http_server/_test.pony
@@ -109,3 +109,10 @@ actor \nodoc\ Main is TestList
     // URI parsing integration tests
     test(_TestURIParsing)
     test(_TestConnectURIParsing)
+
+    // Request body buffering integration tests
+    test(_TestBufferedBody)
+    test(_TestBufferedNoBody)
+    test(_TestBufferedContentLengthZero)
+    test(_TestBufferedPipelinedBodies)
+    test(_TestStreamingBody)

--- a/http_server/handler.pony
+++ b/http_server/handler.pony
@@ -1,12 +1,110 @@
 use "./uri"
 
+type RequestBody is (Array[U8] val | None)
+  """
+  The complete request body delivered to a buffered `Handler`.
+
+  `None` when the request had no body (including `Content-Length: 0`).
+  """
+
 trait ref Handler
   """
-  Application handler for HTTP requests.
+  Application handler for HTTP requests with buffered request bodies.
 
-  All methods run synchronously inside the connection actor. Each request
-  delivers a per-request `Responder` via `request_complete()` for sending
-  responses.
+  The complete request body is delivered as a single value via
+  `request_complete()`. This is the appropriate handler for most use cases
+  (JSON APIs, form submissions, any endpoint that processes the complete body).
+
+  Only `request_complete` must be implemented — the other methods have
+  default no-op implementations for handlers that don't need them.
+  """
+
+  fun ref request(
+    method: Method,
+    uri: URI val,
+    version: Version,
+    headers: Headers val)
+  =>
+    """
+    Called when the request line and all headers have been parsed.
+
+    The `uri` is a pre-parsed RFC 3986 URI with structured components
+    available directly (`uri.path`, `uri.query`, `uri.authority`, etc.).
+    The connection layer parses the raw request-target before delivering
+    it here — invalid URIs are rejected with 400 Bad Request before
+    reaching the handler.
+
+    For CONNECT requests, the URI has only the `authority` component
+    populated (host and port); `path` is empty. Note that
+    `uri.string()` reconstructs to `//host:port` rather than the
+    wire-format `host:port`.
+
+    For requests with a body, the body is buffered internally and
+    delivered as a single `RequestBody` in `request_complete`. For
+    requests without a body, `request_complete` receives `None`.
+    """
+    None
+
+  fun ref request_complete(responder: Responder, body: RequestBody)
+    """
+    Called when the entire request (including any body) has been received.
+
+    The `body` is the complete request body, or `None` if the request had
+    no body (including `Content-Length: 0`). The body size is bounded by
+    `max_body_size` in `ServerConfig` (default 1MB).
+
+    The `responder` is specific to this request. Call `Responder.respond()`
+    to send a complete response, or use `start_chunked_response()`,
+    `send_chunk()`, and `finish_response()` for streaming responses. The
+    handler may hold the responder and respond later (e.g., for deferred
+    processing).
+    """
+
+  fun ref closed() =>
+    """
+    Called when the connection closes.
+
+    Fires whenever the connection closes, whether due to client disconnect,
+    server-initiated close (keep-alive=false, parse error, idle timeout),
+    or any other reason. Not called if the connection fails before starting
+    (i.e., before any handler methods have been called).
+    """
+    None
+
+  fun ref throttled() =>
+    """
+    Called when backpressure is applied on the connection.
+
+    The TCP send buffer is full — the handler should stop generating
+    response data until `unthrottled` is called.
+    """
+    None
+
+  fun ref unthrottled() =>
+    """
+    Called when backpressure is released on the connection.
+
+    The TCP send buffer has drained — the handler may resume generating
+    response data.
+    """
+    None
+
+interface val HandlerFactory
+  """
+  Creates a buffered handler for each new connection.
+
+  The factory is `val` so it can be safely shared across connection actors.
+  """
+  fun apply(): Handler ref^
+
+trait ref StreamingHandler
+  """
+  Application handler for HTTP requests with streaming request bodies.
+
+  Body data is delivered incrementally via `body_chunk()` as it arrives,
+  rather than being buffered. Use this for large uploads, proxying, or
+  any case where processing data incrementally is preferred over waiting
+  for the complete body.
 
   Only `request_complete` must be implemented — the other methods have
   default no-op implementations for handlers that don't need them.
@@ -86,10 +184,15 @@ trait ref Handler
     """
     None
 
-interface val HandlerFactory
+interface val StreamingHandlerFactory
   """
-  Creates a handler for each new connection.
+  Creates a streaming handler for each new connection.
 
   The factory is `val` so it can be safely shared across connection actors.
   """
-  fun apply(): Handler ref^
+  fun apply(): StreamingHandler ref^
+
+type AnyHandlerFactory is (HandlerFactory | StreamingHandlerFactory)
+  """
+  Union of both handler factory types, accepted by `Server` and `_Connection`.
+  """

--- a/http_server/http_server.pony
+++ b/http_server/http_server.pony
@@ -1,8 +1,10 @@
 """
 HTTP server for Pony, built on lori.
 
-Start a server with `Server`, passing a `HandlerFactory` and `ServerConfig`.
-Use `Responder.respond()` to send responses:
+Start a server with `Server`, passing a handler factory and `ServerConfig`.
+
+Most handlers should use `Handler` (buffered), where the complete request
+body is delivered in `request_complete`:
 
 ```pony
 use "http_server"
@@ -18,15 +20,33 @@ class val MyFactory is HandlerFactory
     MyHandler
 
 class ref MyHandler is Handler
-  fun ref request_complete(responder: Responder) =>
+  fun ref request_complete(responder: Responder, body: RequestBody) =>
     responder.respond(StatusOK, None, "Hello!")
+```
+
+For streaming request bodies (large uploads, proxying), use
+`StreamingHandler` where body data arrives incrementally via
+`body_chunk()`:
+
+```pony
+class val MyStreamingFactory is StreamingHandlerFactory
+  fun apply(): StreamingHandler ref^ =>
+    MyStreamingHandler
+
+class ref MyStreamingHandler is StreamingHandler
+  fun ref body_chunk(data: Array[U8] val) =>
+    // process data incrementally
+    None
+
+  fun ref request_complete(responder: Responder) =>
+    responder.respond(StatusOK, None, "Done!")
 ```
 
 For streaming responses, use chunked transfer encoding:
 
 ```pony
-class ref StreamHandler is Handler
-  fun ref request_complete(responder: Responder) =>
+class ref ChunkedResponseHandler is Handler
+  fun ref request_complete(responder: Responder, body: RequestBody) =>
     responder.start_chunked_response(StatusOK)
     responder.send_chunk("chunk 1")
     responder.send_chunk("chunk 2")

--- a/http_server/responder.pony
+++ b/http_server/responder.pony
@@ -9,7 +9,8 @@ class ref Responder
   """
   Sends an HTTP response for a single request.
 
-  Each request receives its own `Responder` via `Handler.request_complete()`.
+  Each request receives its own `Responder` via `Handler.request_complete()`
+  or `StreamingHandler.request_complete()`.
   The Responder buffers response data through the connection's response queue,
   which ensures pipelined responses are sent in request order.
 


### PR DESCRIPTION
Split the single `Handler` trait into two:

- **`Handler`** (buffered): delivers the complete request body as `Array[U8] val` in `request_complete(responder, body)`. This is the common case for JSON APIs, form submissions, and any endpoint that processes the complete body.
- **`StreamingHandler`**: delivers body data incrementally via `body_chunk(data)`, calling `request_complete(responder)` with no body parameter. Use this for large uploads, proxying, or incremental processing.

`Server` and `_Connection` accept `(HandlerFactory | StreamingHandlerFactory)`. Internally, `_Connection` always works with `StreamingHandler` — when a `HandlerFactory` is provided, the handler is wrapped in `_BufferingAdapter` which accumulates body chunks and delivers the complete body at `request_complete`. The adapter resets its buffer between pipelined requests.

Design: #9