### PR TITLE
Add closed() callback to ServerNotify

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ Built on lori (v0.8.1). Lori provides raw TCP I/O with a connection-actor model:
 
 **Relationship to `ponylang/http_server`**: That project is built on the stdlib `net` package and has actor-interaction issues we want to avoid. We may borrow internal logic (e.g., parsing techniques) but the overall architecture and actor interactions are designed fresh around lori's model.
 
-**Connection lifecycle**: Connections are persistent by default (HTTP/1.1 keep-alive). The `Server` constructor takes a `ServerConfig` for listen address, parser limits, connection limits, and idle timeout, plus an optional `ServerNotify` for lifecycle callbacks:
+**Connection lifecycle**: Connections are persistent by default (HTTP/1.1 keep-alive). The `Server` constructor takes a `ServerConfig` for listen address, parser limits, connection limits, and idle timeout, plus an optional `ServerNotify` for lifecycle callbacks (listening, listen failure, closed):
 
 ```pony
 let config = ServerConfig("localhost", "8080" where idle_timeout' = 60)

--- a/examples/basic/main.pony
+++ b/examples/basic/main.pony
@@ -30,6 +30,9 @@ class val _ServerNotify is http_server.ServerNotify
   fun listen_failure(server: http_server.Server tag) =>
     _env.out.print("Failed to start server")
 
+  fun closed(server: http_server.Server tag) =>
+    _env.out.print("Server closed")
+
 class val _HelloFactory is http_server.HandlerFactory
   fun apply(): http_server.Handler ref^ =>
     _HelloHandler

--- a/examples/ssl/main.pony
+++ b/examples/ssl/main.pony
@@ -48,6 +48,9 @@ class val _ServerNotify is http_server.ServerNotify
   fun listen_failure(server: http_server.Server tag) =>
     _env.out.print("Failed to start server")
 
+  fun closed(server: http_server.Server tag) =>
+    _env.out.print("Server closed")
+
 class val _HelloFactory is http_server.HandlerFactory
   fun apply(): http_server.Handler ref^ =>
     _HelloHandler

--- a/examples/streaming/main.pony
+++ b/examples/streaming/main.pony
@@ -28,6 +28,9 @@ class val _ServerNotify is http_server.ServerNotify
   fun listen_failure(server: http_server.Server tag) =>
     _env.out.print("Failed to start server")
 
+  fun closed(server: http_server.Server tag) =>
+    _env.out.print("Server closed")
+
 class val _StreamFactory is http_server.HandlerFactory
   fun apply(): http_server.Handler ref^ =>
     _StreamHandler

--- a/http_server/_test.pony
+++ b/http_server/_test.pony
@@ -77,6 +77,7 @@ actor \nodoc\ Main is TestList
     test(_TestErrorResponse505)
     test(_TestIdleTimeout)
     test(_TestServerNotifyListening)
+    test(_TestServerNotifyClosed)
 
     // Keep-alive decision property test
     test(Property1UnitTest[(Version, (String val | None))](

--- a/http_server/_test_server.pony
+++ b/http_server/_test_server.pony
@@ -215,6 +215,22 @@ class \nodoc\ iso _TestServerNotifyListening is UnitTest
     let server = Server(auth, _TestHelloFactory, config, notify)
     h.dispose_when_done(server)
 
+class \nodoc\ iso _TestServerNotifyClosed is UnitTest
+  """
+  Create a Server with a ServerNotify. Verify that the closed()
+  callback fires after dispose().
+  """
+  fun name(): String => "server/notify closed"
+
+  fun apply(h: TestHelper) =>
+    h.long_test(5_000_000_000)
+    let auth = lori.TCPListenAuth(h.env.root)
+    let host = ifdef linux then "127.0.0.2" else "localhost" end
+    let config = ServerConfig(host, "45894")
+    let notify = _TestClosedNotify(h)
+    let server = Server(auth, _TestHelloFactory, config, notify)
+    h.dispose_when_done(server)
+
 // ---------------------------------------------------------------------------
 // Property-based test: keep-alive decision
 // ---------------------------------------------------------------------------
@@ -355,6 +371,12 @@ class \nodoc\ val _TestListenNotify is ServerNotify
   let _h: TestHelper
   new val create(h: TestHelper) => _h = h
   fun listening(server: Server tag) => _h.complete(true)
+
+class \nodoc\ val _TestClosedNotify is ServerNotify
+  let _h: TestHelper
+  new val create(h: TestHelper) => _h = h
+  fun listening(server: Server tag) => server.dispose()
+  fun closed(server: Server tag) => _h.complete(true)
 
 // ---------------------------------------------------------------------------
 // Test client: sends request bytes, verifies response

--- a/http_server/server.pony
+++ b/http_server/server.pony
@@ -68,7 +68,7 @@ actor Server is lori.TCPListenerActor
     connection. Pass a `HandlerFactory` for buffered request bodies or a
     `StreamingHandlerFactory` for incremental body delivery. The factory
     must be `val` (immutable and shareable). The optional `notify` receives
-    lifecycle callbacks (listening, listen failure).
+    lifecycle callbacks (listening, listen failure, closed).
 
     Pass an `SSLContext val` to enable HTTPS. Lori handles the SSL
     handshake, encryption, and decryption transparently — handlers see
@@ -105,6 +105,11 @@ actor Server is lori.TCPListenerActor
   fun ref _on_listen_failure() =>
     match _notify
     | let n: ServerNotify => n.listen_failure(this)
+    end
+
+  fun ref _on_closed() =>
+    match _notify
+    | let n: ServerNotify => n.closed(this)
     end
 
   be dispose() =>

--- a/http_server/server_notify.pony
+++ b/http_server/server_notify.pony
@@ -2,8 +2,8 @@ interface val ServerNotify
   """
   Notifications for server lifecycle events.
 
-  Implement this to be notified when the server starts listening or fails to
-  start. Both callbacks default to no-ops.
+  Implement this to be notified when the server starts listening, fails to
+  start, or stops accepting connections. All callbacks default to no-ops.
 
   ```pony
   class val MyNotify is ServerNotify
@@ -13,6 +13,8 @@ interface val ServerNotify
       _env.out.print("Listening")
     fun listen_failure(server: Server tag) =>
       _env.out.print("Failed to start")
+    fun closed(server: Server tag) =>
+      _env.out.print("Server closed")
   ```
   """
 
@@ -22,4 +24,8 @@ interface val ServerNotify
 
   fun listen_failure(server: Server tag) =>
     """Called when the server failed to bind to the configured address."""
+    None
+
+  fun closed(server: Server tag) =>
+    """Called when the server has stopped accepting connections."""
     None


### PR DESCRIPTION
ServerNotify had listening() and listen_failure() but no notification when the server stops accepting connections. Applications that call Server.dispose() had no way to know when the server actually stopped — needed for clean exit, restart, or post-shutdown logic.

Adds a closed(server) callback that fires when the listener closes. The Server actor overrides lori's _on_closed() and forwards to the notify, following the same pattern as _on_listening() and _on_listen_failure().

Changes:
- ServerNotify: new closed() method with default no-op
- Server: _on_closed() override forwarding to notify
- All three examples updated to demonstrate the callback
- Integration test verifying dispose() triggers closed()
- CLAUDE.md and docstrings updated

Closes #16