### PR TITLE
Add SSL integration tests

### DIFF
--- a/http_server/_test.pony
+++ b/http_server/_test.pony
@@ -117,3 +117,10 @@ actor \nodoc\ Main is TestList
     test(_TestBufferedContentLengthZero)
     test(_TestBufferedPipelinedBodies)
     test(_TestStreamingBody)
+
+    // SSL integration tests
+    test(_TestSSLHelloWorld)
+    test(_TestSSLKeepAlive)
+    test(_TestSSLConnectionClose)
+    test(_TestSSLParseError)
+    test(_TestSSLStreamingResponse)


### PR DESCRIPTION
Exercise the full SSL path through Server: handshake, encrypted request/response, keep-alive, connection close, parse errors, and chunked streaming. Uses the test certificates in assets/ with Server's ssl_ctx parameter.

Five tests cover the main SSL interaction axes:
- Basic HTTPS request/response (hello world)
- Connection persistence (keep-alive over SSL)
- Connection lifecycle (Connection: close over SSL)
- Error handling (parse error over SSL)
- Streaming (chunked transfer encoding over SSL)

Tests use `Server` directly with the `ssl_ctx` parameter, exercising the `Server._on_accept` routing that dispatches to `_Connection.ssl_create`. A shared `_TestSSLContext` primitive creates the `SSLContext val` from the test certs, and `_TestSSLListenNotify` provides the `ServerNotify` callback to launch clients once the server is listening.

Closes #21