### PR TITLE
Use local_address() in example _on_listening() callbacks

### DIFF
--- a/examples/builder/main.pony
+++ b/examples/builder/main.pony
@@ -41,7 +41,12 @@ actor Listener is lori.TCPListenerActor
     HelloServer(_server_auth, fd, _config, None, None)
 
   fun ref _on_listening() =>
-    _out.print("Builder example listening on localhost:8080")
+    try
+      (let host, let port) = _tcp_listener.local_address().name()?
+      _out.print("Builder example listening on " + host + ":" + port)
+    else
+      _out.print("Builder example listening")
+    end
 
   fun ref _on_listen_failure() =>
     _out.print("Failed to start server")

--- a/examples/hello/main.pony
+++ b/examples/hello/main.pony
@@ -43,7 +43,12 @@ actor Listener is lori.TCPListenerActor
     HelloServer(_server_auth, fd, _config, None, None)
 
   fun ref _on_listening() =>
-    _out.print("Server listening on localhost:8080")
+    try
+      (let host, let port) = _tcp_listener.local_address().name()?
+      _out.print("Server listening on " + host + ":" + port)
+    else
+      _out.print("Server listening")
+    end
 
   fun ref _on_listen_failure() =>
     _out.print("Failed to start server")

--- a/examples/ssl/main.pony
+++ b/examples/ssl/main.pony
@@ -64,7 +64,12 @@ actor Listener is lori.TCPListenerActor
     HelloServer(_server_auth, fd, _config, _ssl_ctx, None)
 
   fun ref _on_listening() =>
-    _out.print("HTTPS server listening on localhost:8443")
+    try
+      (let host, let port) = _tcp_listener.local_address().name()?
+      _out.print("HTTPS server listening on " + host + ":" + port)
+    else
+      _out.print("HTTPS server listening")
+    end
 
   fun ref _on_listen_failure() =>
     _out.print("Failed to start server")

--- a/examples/streaming/main.pony
+++ b/examples/streaming/main.pony
@@ -48,7 +48,12 @@ actor Listener is lori.TCPListenerActor
     StreamServer(_server_auth, fd, _config, None, _timers)
 
   fun ref _on_listening() =>
-    _out.print("Server listening on localhost:8080")
+    try
+      (let host, let port) = _tcp_listener.local_address().name()?
+      _out.print("Server listening on " + host + ":" + port)
+    else
+      _out.print("Server listening")
+    end
 
   fun ref _on_listen_failure() =>
     _out.print("Failed to start server")


### PR DESCRIPTION
Replace hardcoded host:port strings in all four example listeners with `_tcp_listener.local_address().name()`. This shows the actual bound address instead of repeating what was passed to `TCPListener`, and demonstrates the lori listener API for users reading the examples.

Closes #15