### PR TITLE
Split HTTPServer into create and ssl constructors

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -12,7 +12,7 @@ Constructs responses dynamically using `ResponseBuilder`. Demonstrates the build
 
 ## [ssl](ssl/)
 
-HTTPS server using SSL/TLS. Demonstrates creating an `SSLContext`, loading certificate and key files, and passing the context to connection actors via `_on_accept`. The `HTTPServer` handles SSL dispatch internally — the actor code is identical for HTTP and HTTPS.
+HTTPS server using SSL/TLS. Demonstrates creating an `SSLContext`, loading certificate and key files, and passing the context to connection actors via `_on_accept`. Actors use `HTTPServer.ssl` instead of `HTTPServer` to create an HTTPS connection.
 
 ## [streaming](streaming/)
 

--- a/examples/builder/main.pony
+++ b/examples/builder/main.pony
@@ -10,7 +10,6 @@ Send the built response via `Responder.respond()`.
 use http_server = "../../http_server"
 use uri = "uri"
 use lori = "lori"
-use ssl_net = "ssl/net"
 use "time"
 
 actor Main
@@ -38,7 +37,7 @@ actor Listener is lori.TCPListenerActor
   fun ref _listener(): lori.TCPListener => _tcp_listener
 
   fun ref _on_accept(fd: U32): lori.TCPConnectionActor =>
-    HelloServer(_server_auth, fd, _config, None, None)
+    HelloServer(_server_auth, fd, _config, None)
 
   fun ref _on_listening() =>
     try
@@ -61,11 +60,9 @@ actor HelloServer is http_server.HTTPServerActor
     auth: lori.TCPServerAuth,
     fd: U32,
     config: http_server.ServerConfig,
-    ssl_ctx: (ssl_net.SSLContext val | None),
     timers: (Timers | None))
   =>
-    _http = http_server.HTTPServer(auth, fd, ssl_ctx, this,
-      config, timers)
+    _http = http_server.HTTPServer(auth, fd, this, config, timers)
 
   fun ref _http_connection(): http_server.HTTPServer => _http
 

--- a/examples/hello/main.pony
+++ b/examples/hello/main.pony
@@ -12,7 +12,6 @@ request bodies — for body accumulation, see the streaming example.
 use http_server = "../../http_server"
 use uri = "uri"
 use lori = "lori"
-use ssl_net = "ssl/net"
 use "time"
 
 actor Main
@@ -40,7 +39,7 @@ actor Listener is lori.TCPListenerActor
   fun ref _listener(): lori.TCPListener => _tcp_listener
 
   fun ref _on_accept(fd: U32): lori.TCPConnectionActor =>
-    HelloServer(_server_auth, fd, _config, None, None)
+    HelloServer(_server_auth, fd, _config, None)
 
   fun ref _on_listening() =>
     try
@@ -63,11 +62,9 @@ actor HelloServer is http_server.HTTPServerActor
     auth: lori.TCPServerAuth,
     fd: U32,
     config: http_server.ServerConfig,
-    ssl_ctx: (ssl_net.SSLContext val | None),
     timers: (Timers | None))
   =>
-    _http = http_server.HTTPServer(auth, fd, ssl_ctx, this,
-      config, timers)
+    _http = http_server.HTTPServer(auth, fd, this, config, timers)
 
   fun ref _http_connection(): http_server.HTTPServer => _http
 

--- a/examples/ssl/main.pony
+++ b/examples/ssl/main.pony
@@ -3,8 +3,8 @@ HTTPS server that responds to every request with "Hello, World!".
 
 Demonstrates SSL/TLS support: creating an `SSLContext`, loading certificate
 and key files, and passing the context to connection actors via `_on_accept`.
-The `HTTPServer` handles SSL dispatch internally — actors are identical for
-HTTP and HTTPS.
+Actors use `HTTPServer.ssl` instead of `HTTPServer` to create an HTTPS
+connection.
 
 Must be run from the project root so the relative certificate paths resolve
 correctly. Test with `curl -k https://localhost:8443/`.
@@ -84,10 +84,10 @@ actor HelloServer is http_server.HTTPServerActor
     auth: lori.TCPServerAuth,
     fd: U32,
     config: http_server.ServerConfig,
-    ssl_ctx: (SSLContext val | None),
+    ssl_ctx: SSLContext val,
     timers: (Timers | None))
   =>
-    _http = http_server.HTTPServer(auth, fd, ssl_ctx, this,
+    _http = http_server.HTTPServer.ssl(auth, ssl_ctx, fd, this,
       config, timers)
 
   fun ref _http_connection(): http_server.HTTPServer => _http

--- a/examples/streaming/main.pony
+++ b/examples/streaming/main.pony
@@ -15,7 +15,6 @@ example ignores request bodies.
 """
 use http_server = "../../http_server"
 use lori = "lori"
-use ssl_net = "ssl/net"
 use "time"
 
 actor Main
@@ -45,7 +44,7 @@ actor Listener is lori.TCPListenerActor
   fun ref _listener(): lori.TCPListener => _tcp_listener
 
   fun ref _on_accept(fd: U32): lori.TCPConnectionActor =>
-    StreamServer(_server_auth, fd, _config, None, _timers)
+    StreamServer(_server_auth, fd, _config, _timers)
 
   fun ref _on_listening() =>
     try
@@ -72,12 +71,10 @@ actor StreamServer is http_server.HTTPServerActor
     auth: lori.TCPServerAuth,
     fd: U32,
     config: http_server.ServerConfig,
-    ssl_ctx: (ssl_net.SSLContext val | None),
     timers: Timers)
   =>
     _timers = timers
-    _http = http_server.HTTPServer(auth, fd, ssl_ctx, this,
-      config, timers)
+    _http = http_server.HTTPServer(auth, fd, this, config, timers)
 
   fun ref _http_connection(): http_server.HTTPServer => _http
 

--- a/http_server/_test_server.pony
+++ b/http_server/_test_server.pony
@@ -312,7 +312,12 @@ actor \nodoc\ _TestHelloServer is HTTPServerActor
     ssl_ctx: (ssl_net.SSLContext val | None),
     timers: (Timers | None))
   =>
-    _http = HTTPServer(auth, fd, ssl_ctx, this, config, timers)
+    _http = match ssl_ctx
+    | let ctx: ssl_net.SSLContext val =>
+      HTTPServer.ssl(auth, ctx, fd, this, config, timers)
+    else
+      HTTPServer(auth, fd, this, config, timers)
+    end
 
   fun ref _http_connection(): HTTPServer => _http
 
@@ -713,7 +718,12 @@ actor \nodoc\ _TestPipelineServer is HTTPServerActor
     timers: (Timers | None))
   =>
     _responders = Array[Responder]
-    _http = HTTPServer(auth, fd, ssl_ctx, this, config, timers)
+    _http = match ssl_ctx
+    | let ctx: ssl_net.SSLContext val =>
+      HTTPServer.ssl(auth, ctx, fd, this, config, timers)
+    else
+      HTTPServer(auth, fd, this, config, timers)
+    end
 
   fun ref _http_connection(): HTTPServer => _http
 
@@ -762,7 +772,12 @@ actor \nodoc\ _TestStreamServer is HTTPServerActor
     ssl_ctx: (ssl_net.SSLContext val | None),
     timers: (Timers | None))
   =>
-    _http = HTTPServer(auth, fd, ssl_ctx, this, config, timers)
+    _http = match ssl_ctx
+    | let ctx: ssl_net.SSLContext val =>
+      HTTPServer.ssl(auth, ctx, fd, this, config, timers)
+    else
+      HTTPServer(auth, fd, this, config, timers)
+    end
 
   fun ref _http_connection(): HTTPServer => _http
 
@@ -964,7 +979,12 @@ actor \nodoc\ _TestPartialRespondServer is HTTPServerActor
     ssl_ctx: (ssl_net.SSLContext val | None),
     timers: (Timers | None))
   =>
-    _http = HTTPServer(auth, fd, ssl_ctx, this, config, timers)
+    _http = match ssl_ctx
+    | let ctx: ssl_net.SSLContext val =>
+      HTTPServer.ssl(auth, ctx, fd, this, config, timers)
+    else
+      HTTPServer(auth, fd, this, config, timers)
+    end
 
   fun ref _http_connection(): HTTPServer => _http
 
@@ -1058,7 +1078,12 @@ actor \nodoc\ _TestChunkedFallbackServer is HTTPServerActor
     ssl_ctx: (ssl_net.SSLContext val | None),
     timers: (Timers | None))
   =>
-    _http = HTTPServer(auth, fd, ssl_ctx, this, config, timers)
+    _http = match ssl_ctx
+    | let ctx: ssl_net.SSLContext val =>
+      HTTPServer.ssl(auth, ctx, fd, this, config, timers)
+    else
+      HTTPServer(auth, fd, this, config, timers)
+    end
 
   fun ref _http_connection(): HTTPServer => _http
 
@@ -1130,7 +1155,12 @@ actor \nodoc\ _TestURIParsingServer is HTTPServerActor
     ssl_ctx: (ssl_net.SSLContext val | None),
     timers: (Timers | None))
   =>
-    _http = HTTPServer(auth, fd, ssl_ctx, this, config, timers)
+    _http = match ssl_ctx
+    | let ctx: ssl_net.SSLContext val =>
+      HTTPServer.ssl(auth, ctx, fd, this, config, timers)
+    else
+      HTTPServer(auth, fd, this, config, timers)
+    end
 
   fun ref _http_connection(): HTTPServer => _http
 
@@ -1191,7 +1221,12 @@ actor \nodoc\ _TestConnectURIServer is HTTPServerActor
     ssl_ctx: (ssl_net.SSLContext val | None),
     timers: (Timers | None))
   =>
-    _http = HTTPServer(auth, fd, ssl_ctx, this, config, timers)
+    _http = match ssl_ctx
+    | let ctx: ssl_net.SSLContext val =>
+      HTTPServer.ssl(auth, ctx, fd, this, config, timers)
+    else
+      HTTPServer(auth, fd, this, config, timers)
+    end
 
   fun ref _http_connection(): HTTPServer => _http
 
@@ -1265,7 +1300,12 @@ actor \nodoc\ _TestBodyServer is HTTPServerActor
     ssl_ctx: (ssl_net.SSLContext val | None),
     timers: (Timers | None))
   =>
-    _http = HTTPServer(auth, fd, ssl_ctx, this, config, timers)
+    _http = match ssl_ctx
+    | let ctx: ssl_net.SSLContext val =>
+      HTTPServer.ssl(auth, ctx, fd, this, config, timers)
+    else
+      HTTPServer(auth, fd, this, config, timers)
+    end
 
   fun ref _http_connection(): HTTPServer => _http
 

--- a/http_server/http_server_actor.pony
+++ b/http_server/http_server_actor.pony
@@ -19,10 +19,9 @@ trait tag HTTPServerActor is
 
     new create(auth: lori.TCPServerAuth, fd: U32,
       config: ServerConfig,
-      ssl_ctx: (ssl_net.SSLContext val | None),
       timers: (Timers | None))
     =>
-      _http = HTTPServer(auth, fd, ssl_ctx, this, config, timers)
+      _http = HTTPServer(auth, fd, this, config, timers)
 
     fun ref _http_connection(): HTTPServer => _http
 
@@ -32,9 +31,12 @@ trait tag HTTPServerActor is
       // build and send response using request' and responder
   ```
 
+  For HTTPS, use `HTTPServer.ssl(auth, ssl_ctx, fd, this, config, timers)`
+  instead of `HTTPServer(auth, fd, this, config, timers)`.
+
   The `none()` default ensures all fields are initialized before the
   constructor body runs, so `this` is `ref` when passed to
-  `HTTPServer.create()`.
+  `HTTPServer.create()` or `HTTPServer.ssl()`.
   """
 
   fun ref _http_connection(): HTTPServer


### PR DESCRIPTION
The single constructor took `(SSLContext val | None)` and dispatched internally, hiding whether the connection was HTTP or HTTPS behind a union type. Splitting into `create` (plain HTTP) and `ssl` (HTTPS) mirrors lori's own `TCPConnection.server` / `ssl_server` pattern and makes the choice explicit at the type level — `create` can only make plain HTTP, `ssl` always requires a context.

Non-SSL examples (hello, builder, streaming) drop the `ssl_ctx` parameter entirely. The SSL example uses `HTTPServer.ssl` with a non-optional `SSLContext val`. Test server actors dispatch via `match` since the test factory interface still needs to handle both paths.

Closes #29