### PR TITLE
Flesh out README for first release

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# Stallion
+# stallion
 
-An HTTP server for [Pony](https://www.ponylang.io/).
+An HTTP server for [Pony](https://www.ponylang.io/), built on [lori](https://github.com/ponylang/lori). Your actor IS the connection — no hidden internal actors, no notify objects. Responses are built with `ResponseBuilder` for complete responses, or streamed with flow-controlled chunked transfer encoding.
 
 ## Status
 
-This library is under active development. The API is not yet stable.
+stallion is beta quality software that will change frequently. Expect breaking changes. That said, you should feel comfortable using it in your projects.
 
 ## Installation
 
@@ -13,6 +13,58 @@ This library is under active development. The API is not yet stable.
 * `corral fetch` to fetch your dependencies
 * `use "stallion"` to include this package
 * `corral run -- ponyc` to compile your application
+
+You'll also need a SSL library installed on your platform. See the [net-ssl](https://github.com/ponylang/net-ssl) installation instructions for details.
+
+## Usage
+
+A stallion server has two actor types: a listener and one or more connection actors. The listener implements `lori.TCPListenerActor` and creates connection actors in `_on_accept`. Each connection actor implements `HTTPServerActor`, owns an `HTTPServer`, and overrides callbacks to handle requests:
+
+```pony
+use "stallion"
+use lori = "lori"
+
+actor Main
+  new create(env: Env) =>
+    let auth = lori.TCPListenAuth(env.root)
+    MyListener(auth, "localhost", "8080")
+
+actor MyListener is lori.TCPListenerActor
+  var _tcp_listener: lori.TCPListener = lori.TCPListener.none()
+  let _server_auth: lori.TCPServerAuth
+  let _config: ServerConfig
+
+  new create(auth: lori.TCPListenAuth, host: String, port: String) =>
+    _server_auth = lori.TCPServerAuth(auth)
+    _config = ServerConfig(host, port)
+    _tcp_listener = lori.TCPListener(auth, host, port, this)
+
+  fun ref _listener(): lori.TCPListener => _tcp_listener
+
+  fun ref _on_accept(fd: U32): lori.TCPConnectionActor =>
+    MyServer(_server_auth, fd, _config)
+
+actor MyServer is HTTPServerActor
+  var _http: HTTPServer = HTTPServer.none()
+
+  new create(auth: lori.TCPServerAuth, fd: U32, config: ServerConfig) =>
+    _http = HTTPServer(auth, fd, this, config)
+
+  fun ref _http_connection(): HTTPServer => _http
+
+  fun ref on_request_complete(request': Request val,
+    responder: Responder)
+  =>
+    let body: String val = "Hello!"
+    let response = ResponseBuilder(StatusOK)
+      .add_header("Content-Length", body.size().string())
+      .finish_headers()
+      .add_chunk(body)
+      .build()
+    responder.respond(response)
+```
+
+For streaming responses, use chunked transfer encoding with flow-controlled delivery via `on_chunk_sent()` callbacks. For HTTPS, use `HTTPServer.ssl` instead of `HTTPServer`. See the [examples](examples/) for complete working programs demonstrating query parameter extraction, SSL/TLS, and streaming.
 
 ## API Documentation
 


### PR DESCRIPTION
Expand the placeholder README with real content in preparation for first release:

- Lowercase title to match package name per ponylang convention
- Intro paragraph highlighting the actor-is-the-connection design and two response modes
- Beta status statement
- SSL dependency note linking to net-ssl
- Usage section with a complete minimal example showing the listener + connection actor pattern
- Pointer to examples/ for streaming, HTTPS, and query parameter extraction