### PR TITLE
Bind examples to 0.0.0.0 instead of localhost

### DIFF
--- a/examples/hello/main.pony
+++ b/examples/hello/main.pony
@@ -17,7 +17,7 @@ use lori = "lori"
 actor Main
   new create(env: Env) =>
     let auth = lori.TCPListenAuth(env.root)
-    Listener(auth, "localhost", "8080", env.out)
+    Listener(auth, "0.0.0.0", "8080", env.out)
 
 actor Listener is lori.TCPListenerActor
   var _tcp_listener: lori.TCPListener = lori.TCPListener.none()

--- a/examples/ssl/main.pony
+++ b/examples/ssl/main.pony
@@ -35,7 +35,7 @@ actor Main
       end
 
     let auth = lori.TCPListenAuth(env.root)
-    Listener(auth, "localhost", "8443", env.out, sslctx)
+    Listener(auth, "0.0.0.0", "8443", env.out, sslctx)
 
 actor Listener is lori.TCPListenerActor
   var _tcp_listener: lori.TCPListener = lori.TCPListener.none()

--- a/examples/streaming/main.pony
+++ b/examples/streaming/main.pony
@@ -18,7 +18,7 @@ use lori = "lori"
 actor Main
   new create(env: Env) =>
     let auth = lori.TCPListenAuth(env.root)
-    Listener(auth, "localhost", "8080", env.out)
+    Listener(auth, "0.0.0.0", "8080", env.out)
 
 actor Listener is lori.TCPListenerActor
   var _tcp_listener: lori.TCPListener = lori.TCPListener.none()


### PR DESCRIPTION
On systems where "localhost" resolves to ::1 first (common on modern Linux including WSL2), the examples only listen on IPv6. Using 0.0.0.0 binds to all interfaces, which is more useful for example programs and works consistently across platforms.

Changes all three examples (hello, ssl, streaming) from `"localhost"` to `"0.0.0.0"`.