### PR TITLE
Add configurable max requests per keep-alive connection

### DIFF
--- a/.release-notes/max-requests-per-connection.md
+++ b/.release-notes/max-requests-per-connection.md
@@ -1,0 +1,10 @@
+## Add configurable max requests per keep-alive connection
+
+`ServerConfig` now accepts a `max_requests_per_connection'` parameter that limits how many requests a single keep-alive connection can serve before the server closes it. This is analogous to nginx's `keepalive_requests` directive. The default is `None` (unlimited), preserving existing behavior. The limit value is a `MaxRequestsPerConnection` constrained type (must be at least 1), created via `MakeMaxRequestsPerConnection`.
+
+```pony
+match MakeMaxRequestsPerConnection(1000)
+| let m: MaxRequestsPerConnection =>
+  ServerConfig("0.0.0.0", "80" where max_requests_per_connection' = m)
+end
+```

--- a/stallion/_test.pony
+++ b/stallion/_test.pony
@@ -82,6 +82,7 @@ actor \nodoc\ Main is TestList
     test(_TestErrorResponse431)
     test(_TestErrorResponse505)
     test(_TestIdleTimeout)
+    test(_TestMaxRequestsPerConnection)
 
     // Keep-alive decision property test
     test(Property1UnitTest[(Version, (String val | None))](

--- a/stallion/max_requests_per_connection.pony
+++ b/stallion/max_requests_per_connection.pony
@@ -1,0 +1,39 @@
+use "constrained_types"
+
+type MaxRequestsPerConnection is
+  Constrained[USize, _MaxRequestsPerConnectionValidator]
+  """
+  A validated maximum number of requests per keep-alive connection.
+
+  Must be at least 1. Use `MakeMaxRequestsPerConnection` to create:
+
+  ```pony
+  match MakeMaxRequestsPerConnection(1000)
+  | let m: MaxRequestsPerConnection =>
+    ServerConfig("0.0.0.0", "80" where max_requests_per_connection' = m)
+  | let e: ValidationFailure =>
+    // handle error — value was 0
+  end
+  ```
+  """
+
+type MakeMaxRequestsPerConnection is
+  MakeConstrained[USize, _MaxRequestsPerConnectionValidator]
+  """
+  Constructs a `MaxRequestsPerConnection` from a `USize`.
+
+  Returns `MaxRequestsPerConnection` on success or `ValidationFailure`
+  if the value is 0.
+  """
+
+primitive _MaxRequestsPerConnectionValidator is Validator[USize]
+  """Validates that the max requests value is at least 1."""
+  fun apply(value: USize): ValidationResult =>
+    recover val
+      if value >= 1 then
+        ValidationSuccess
+      else
+        ValidationFailure(
+          "max_requests_per_connection must be at least 1")
+      end
+    end


### PR DESCRIPTION
`ServerConfig` now accepts `max_requests_per_connection'` to limit how many requests a single keep-alive connection serves before closing — analogous to nginx's `keepalive_requests`. Default is `None` (unlimited), preserving existing behavior.

The check runs in `_response_complete` after each response flushes, so pipelined requests already in flight still get served. Check order: keep-alive=false first, then max-requests, then idle.