### PR TITLE
Add \exhaustive\ annotation to exhaustive match blocks

### DIFF
--- a/examples/streaming/main.pony
+++ b/examples/streaming/main.pony
@@ -78,7 +78,7 @@ actor StreamServer is stallion.HTTPServerActor
       h.set("content-type", "text/plain")
       h
     end
-    match responder.start_chunked_response(stallion.StatusOK, headers)
+    match \exhaustive\ responder.start_chunked_response(stallion.StatusOK, headers)
     | stallion.StreamingStarted =>
       responder.send_chunk("chunk 1 of 5\n")
       _responder = responder

--- a/stallion/_chunked_encoder.pony
+++ b/stallion/_chunked_encoder.pony
@@ -18,7 +18,7 @@ primitive _ChunkedEncoder
     The caller must not pass empty data — use `final_chunk()` for the
     terminal chunk instead.
     """
-    let size: USize = match data
+    let size: USize = match \exhaustive\ data
     | let s: String val => s.size()
     | let a: Array[U8] val => a.size()
     end

--- a/stallion/_parser_state.pony
+++ b/stallion/_parser_state.pony
@@ -79,7 +79,7 @@ class _ExpectRequestLine is _ParserState
     let available = p.buf.size() - p.pos
 
     // Check for CRLF marking end of request line
-    match _BufferScan.find_crlf(p.buf, p.pos)
+    match \exhaustive\ _BufferScan.find_crlf(p.buf, p.pos)
     | let crlf: USize =>
       let line_len = crlf - p.pos
       if line_len > p.config.max_request_line_size then
@@ -87,14 +87,14 @@ class _ExpectRequestLine is _ParserState
       end
 
       // Find first space: separates method from URI
-      let method_end = match _BufferScan.find_byte(p.buf, ' ', p.pos, crlf)
+      let method_end = match \exhaustive\ _BufferScan.find_byte(p.buf, ' ', p.pos, crlf)
         | let i: USize => i
         | None => return UnknownMethod
         end
 
       // Parse method
       let method_str: String val = p.extract_string(p.pos, method_end)
-      let method = match Methods.parse(method_str)
+      let method = match \exhaustive\ Methods.parse(method_str)
         | let m: Method => m
         | None => return UnknownMethod
         end
@@ -110,7 +110,7 @@ class _ExpectRequestLine is _ParserState
       end
 
       // Find second space: separates URI from version
-      let uri_end = match _BufferScan.find_byte(p.buf, ' ', uri_start, crlf)
+      let uri_end = match \exhaustive\ _BufferScan.find_byte(p.buf, ' ', uri_start, crlf)
         | let i: USize => i
         | None => return InvalidVersion
         end
@@ -223,7 +223,7 @@ class _ExpectHeaders is _ParserState
   fun ref parse(p: _RequestParser ref): _ParseResult =>
     // Loop through header lines
     while true do
-      match _BufferScan.find_crlf(p.buf, p.pos)
+      match \exhaustive\ _BufferScan.find_crlf(p.buf, p.pos)
       | let crlf: USize =>
         if crlf == p.pos then
           // Empty line: end of headers
@@ -250,7 +250,7 @@ class _ExpectHeaders is _ParserState
             return _ParseContinue
           end
 
-          match _content_length
+          match \exhaustive\ _content_length
           | let cl: USize if cl > 0 =>
             p.state = _ExpectFixedBody(cl)
             return _ParseContinue
@@ -280,7 +280,7 @@ class _ExpectHeaders is _ParserState
         end
 
         // Find colon separator
-        let colon_pos = match _BufferScan.find_byte(p.buf, ':', p.pos, crlf)
+        let colon_pos = match \exhaustive\ _BufferScan.find_byte(p.buf, ':', p.pos, crlf)
           | let i: USize => i
           | None => return MalformedHeaders
           end
@@ -322,9 +322,9 @@ class _ExpectHeaders is _ParserState
         // Detect special headers
         let lower_name: String val = name.lower()
         if lower_name == "content-length" then
-          match _parse_content_length(value)
+          match \exhaustive\ _parse_content_length(value)
           | let cl: USize =>
-            match _content_length
+            match \exhaustive\ _content_length
             | let existing: USize =>
               if existing != cl then
                 return InvalidContentLength
@@ -420,7 +420,7 @@ class _ExpectChunkHeader is _ParserState
     _config = config
 
   fun ref parse(p: _RequestParser ref): _ParseResult =>
-    match _BufferScan.find_crlf(p.buf, p.pos)
+    match \exhaustive\ _BufferScan.find_crlf(p.buf, p.pos)
     | let crlf: USize =>
       let line_len = crlf - p.pos
       if line_len > _config.max_chunk_header_size then
@@ -431,7 +431,7 @@ class _ExpectChunkHeader is _ParserState
       end
 
       // Find optional chunk extension (semicolon)
-      let size_end = match _BufferScan.find_byte(p.buf, ';', p.pos, crlf)
+      let size_end = match \exhaustive\ _BufferScan.find_byte(p.buf, ';', p.pos, crlf)
         | let i: USize => i
         | None => crlf
         end
@@ -543,7 +543,7 @@ class _ExpectChunkTrailer is _ParserState
 
   fun ref parse(p: _RequestParser ref): _ParseResult =>
     while true do
-      match _BufferScan.find_crlf(p.buf, p.pos)
+      match \exhaustive\ _BufferScan.find_crlf(p.buf, p.pos)
       | let crlf: USize =>
         if crlf == p.pos then
           // Empty line: end of chunked message

--- a/stallion/_request_parser.pony
+++ b/stallion/_request_parser.pony
@@ -42,7 +42,7 @@ class _RequestParser
     // Parse loop: process data until we need more or hit an error
     var continue_parsing = true
     while continue_parsing do
-      match state.parse(this)
+      match \exhaustive\ state.parse(this)
       | _ParseContinue =>
         // A handler callback (triggered by state.parse) may have called
         // stop() — check before continuing to the next state transition.

--- a/stallion/_test_request_parser.pony
+++ b/stallion/_test_request_parser.pony
@@ -169,7 +169,7 @@ class \nodoc\ iso _PropertyHeadersRoundtrip
         end
         if not already_seen then
           seen.push(lower)
-          match headers.get(hdr_name)
+          match \exhaustive\ headers.get(hdr_name)
           | let v: String val =>
             ph.assert_eq[String val](hdr_value, v,
               "header " + hdr_name + " mismatch")
@@ -378,7 +378,7 @@ class \nodoc\ iso _TestParserKnownGoodRequests is UnitTest
       h.assert_true(v is HTTP11, "version should be HTTP/1.1")
       h.assert_eq[String val](
         "www.example.com",
-        match hdrs.get("Host")
+        match \exhaustive\ hdrs.get("Host")
         | let s: String val => s
         else "" end,
         "Host header")

--- a/stallion/_test_response_queue.pony
+++ b/stallion/_test_response_queue.pony
@@ -29,7 +29,7 @@ class \nodoc\ ref _TestQueueNotify is _ResponseQueueNotify
     flushed_data.push(data)
     flushed_tokens.push(token)
     if close_on_flush_data then
-      let s: String val = match data
+      let s: String val = match \exhaustive\ data
       | let sv: String val => sv
       | let a: Array[U8] val => String.from_array(a)
       end
@@ -52,7 +52,7 @@ class \nodoc\ ref _TestQueueNotify is _ResponseQueueNotify
     """Convert all flushed data to strings for easier assertion."""
     let result = Array[String val](flushed_data.size())
     for data in flushed_data.values() do
-      match data
+      match \exhaustive\ data
       | let s: String val => result.push(s)
       | let a: Array[U8] val => result.push(String.from_array(a))
       end
@@ -467,11 +467,11 @@ class \nodoc\ iso _TestQueueTokenBufferedFlush is UnitTest
     // Verify both data items flushed: e0-data (None token), e1-data (token)
     h.assert_eq[USize](2, notify.flushed_tokens.size())
     try
-      match notify.flushed_tokens(0)?
+      match \exhaustive\ notify.flushed_tokens(0)?
       | let _: ChunkSendToken => h.fail("Head entry should have None token")
       | None => None  // expected
       end
-      match notify.flushed_tokens(1)?
+      match \exhaustive\ notify.flushed_tokens(1)?
       | let ct: ChunkSendToken =>
         h.assert_true(ct == token, "Buffered token should match")
       else

--- a/stallion/_test_server.pony
+++ b/stallion/_test_server.pony
@@ -218,7 +218,7 @@ class \nodoc\ iso _TestMaxRequestsPerConnection is UnitTest
     h.long_test(5_000_000_000)
     let port = "45895"
     let host = ifdef linux then "127.0.0.2" else "localhost" end
-    let max_req = match MakeMaxRequestsPerConnection(2)
+    let max_req = match \exhaustive\ MakeMaxRequestsPerConnection(2)
     | let m: MaxRequestsPerConnection => m
     | let _: ValidationFailure =>
       h.fail("Failed to create MaxRequestsPerConnection")
@@ -1166,7 +1166,7 @@ actor \nodoc\ _TestChunkedFallbackServer is HTTPServerActor
       h.set("content-type", "text/plain")
       h
     end
-    match responder.start_chunked_response(StatusOK, headers)
+    match \exhaustive\ responder.start_chunked_response(StatusOK, headers)
     | StreamingStarted =>
       responder.send_chunk("chunk1")
       responder.finish_response()
@@ -1366,7 +1366,7 @@ actor \nodoc\ _TestURIParsingServer is HTTPServerActor
   fun ref _http_connection(): HTTPServer => _http
 
   fun ref on_request_complete(request': Request val, responder: Responder) =>
-    let uri_query: String val = match request'.uri.query
+    let uri_query: String val = match \exhaustive\ request'.uri.query
     | let q: String val => q
     | None => ""
     end
@@ -1435,7 +1435,7 @@ actor \nodoc\ _TestConnectURIServer is HTTPServerActor
     match request'.uri.authority
     | let a: uri.URIAuthority val =>
       host = a.host
-      port = match a.port
+      port = match \exhaustive\ a.port
       | let p: U16 => p.string()
       | None => "none"
       end

--- a/stallion/http_server.pony
+++ b/stallion/http_server.pony
@@ -153,7 +153,7 @@ class HTTPServer is
     // from the RFC 3986 parser (e.g., invalid authority in CONNECT targets).
     let parsed_uri: uri_pkg.URI val =
       if method is CONNECT then
-        match uri_pkg.ParseURIAuthority(raw_uri)
+        match \exhaustive\ uri_pkg.ParseURIAuthority(raw_uri)
         | let a: uri_pkg.URIAuthority val =>
           uri_pkg.URI(None, a, "", None, None)
         | let _: uri_pkg.URIParseError val =>
@@ -161,7 +161,7 @@ class HTTPServer is
           return
         end
       else
-        match uri_pkg.ParseURI(raw_uri)
+        match \exhaustive\ uri_pkg.ParseURI(raw_uri)
         | let u: uri_pkg.URI val => u
         | let _: uri_pkg.URIParseError val =>
           parse_error(InvalidURI)
@@ -183,7 +183,7 @@ class HTTPServer is
     _idle = false
 
     // Safety net: close if too many pipelined requests are pending
-    match _config
+    match \exhaustive\ _config
     | let c: ServerConfig =>
       if _requests_pending > c.max_pending_responses then
         _tcp_connection.send(_ErrorResponse.no_response())
@@ -202,7 +202,7 @@ class HTTPServer is
     end
 
   fun ref body_chunk(data: Array[U8] val) =>
-    match _lifecycle_event_receiver
+    match \exhaustive\ _lifecycle_event_receiver
     | let r: HTTPServerLifecycleEventReceiver ref =>
       r.on_body_chunk(data)
     | None =>
@@ -247,7 +247,7 @@ class HTTPServer is
     connection (which in turn closes the queue, making any remaining
     Responders inert).
     """
-    match _tcp_connection.send(data)
+    match \exhaustive\ _tcp_connection.send(data)
     | let _: lori.SendToken =>
       _pending_sent_tokens.push(token)
     | let _: lori.SendError =>
@@ -302,7 +302,7 @@ class HTTPServer is
     match _parser | let p: _RequestParser => p.stop() end
     match _queue | let q: _ResponseQueue => q.close() end
     _pending_sent_tokens.clear()
-    match _lifecycle_event_receiver
+    match \exhaustive\ _lifecycle_event_receiver
     | let r: HTTPServerLifecycleEventReceiver ref => r.on_closed()
     | None => _Unreachable()
     end
@@ -312,7 +312,7 @@ class HTTPServer is
     """Apply backpressure: mute the TCP connection and notify the receiver."""
     _tcp_connection.mute()
     match _queue | let q: _ResponseQueue => q.throttle() end
-    match _lifecycle_event_receiver
+    match \exhaustive\ _lifecycle_event_receiver
     | let r: HTTPServerLifecycleEventReceiver ref => r.on_throttled()
     | None => _Unreachable()
     end
@@ -321,7 +321,7 @@ class HTTPServer is
     """Release backpressure: unmute the TCP connection and notify the receiver."""
     _tcp_connection.unmute()
     match _queue | let q: _ResponseQueue => q.unthrottle() end
-    match _lifecycle_event_receiver
+    match \exhaustive\ _lifecycle_event_receiver
     | let r: HTTPServerLifecycleEventReceiver ref => r.on_unthrottled()
     | None => _Unreachable()
     end
@@ -337,7 +337,7 @@ class HTTPServer is
     try
       match _pending_sent_tokens.shift()?
       | let ct: ChunkSendToken =>
-        match _lifecycle_event_receiver
+        match \exhaustive\ _lifecycle_event_receiver
         | let r: HTTPServerLifecycleEventReceiver ref => r.on_chunk_sent(ct)
         | None => _Unreachable()
         end
@@ -378,7 +378,7 @@ class HTTPServer is
       match _parser | let p: _RequestParser => p.stop() end
       match _queue | let q: _ResponseQueue => q.close() end
       _pending_sent_tokens.clear()
-      match _lifecycle_event_receiver
+      match \exhaustive\ _lifecycle_event_receiver
       | let r: HTTPServerLifecycleEventReceiver ref => r.on_closed()
       | None => _Unreachable()
       end

--- a/stallion/max_requests_per_connection.pony
+++ b/stallion/max_requests_per_connection.pony
@@ -8,7 +8,7 @@ type MaxRequestsPerConnection is
   Must be at least 1. Use `MakeMaxRequestsPerConnection` to create:
 
   ```pony
-  match MakeMaxRequestsPerConnection(1000)
+  match \exhaustive\ MakeMaxRequestsPerConnection(1000)
   | let m: MaxRequestsPerConnection =>
     ServerConfig("0.0.0.0", "80" where max_requests_per_connection' = m)
   | let e: ValidationFailure =>

--- a/stallion/responder.pony
+++ b/stallion/responder.pony
@@ -33,7 +33,7 @@ class ref Responder
   incrementally-generated bodies. `start_chunked_response()` returns a
   `StartChunkedResponseResult` indicating success or the reason for failure:
   ```pony
-  match responder.start_chunked_response(StatusOK, headers)
+  match \exhaustive\ responder.start_chunked_response(StatusOK, headers)
   | StreamingStarted =>
     let token1 = responder.send_chunk("chunk 1")
     let token2 = responder.send_chunk("chunk 2")
@@ -142,7 +142,7 @@ class ref Responder
     """
     match _state
     | _ResponderStreaming =>
-      let size: USize = match data
+      let size: USize = match \exhaustive\ data
       | let s: String val => s.size()
       | let a: Array[U8] val => a.size()
       end

--- a/stallion/response_builder.pony
+++ b/stallion/response_builder.pony
@@ -118,7 +118,7 @@ class ref _ResponseBuilderImpl is (ResponseHeadersBuilder & ResponseBodyBuilder)
     this
 
   fun ref add_chunk(data: ByteSeq): ResponseBodyBuilder =>
-    match data
+    match \exhaustive\ data
     | let s: String val => _buf.append(s)
     | let a: Array[U8] val => _buf.append(a)
     end

--- a/stallion/server_config.pony
+++ b/stallion/server_config.pony
@@ -28,7 +28,7 @@ class val ServerConfig
   ServerConfig("localhost", "8080")
 
   // Custom timeout via MakeIdleTimeout (milliseconds)
-  let timeout = match lori.MakeIdleTimeout(30_000)
+  let timeout = match \exhaustive\ lori.MakeIdleTimeout(30_000)
   | let t: lori.IdleTimeout => t
   end
   ServerConfig("0.0.0.0", "80" where
@@ -39,7 +39,7 @@ class val ServerConfig
   ServerConfig("0.0.0.0", "80" where idle_timeout' = None)
 
   // Limit to 1000 requests per connection
-  match MakeMaxRequestsPerConnection(1000)
+  match \exhaustive\ MakeMaxRequestsPerConnection(1000)
   | let m: MaxRequestsPerConnection =>
     ServerConfig("0.0.0.0", "80" where max_requests_per_connection' = m)
   end

--- a/stallion/stallion.pony
+++ b/stallion/stallion.pony
@@ -62,7 +62,7 @@ delivery:
 fun ref on_request_complete(request': stallion.Request val,
   responder: stallion.Responder)
 =>
-  match responder.start_chunked_response(stallion.StatusOK)
+  match \exhaustive\ responder.start_chunked_response(stallion.StatusOK)
   | stallion.StreamingStarted =>
     let token = responder.send_chunk("chunk 1")
     // When on_chunk_sent(token) fires, send the next chunk...


### PR DESCRIPTION
Ponyc recently added an `\exhaustive\` annotation for match expressions. When present, the compiler will fail compilation if the match is not exhaustive. This protects against future breakage if new variants are added to a union type.

This adds `\exhaustive\` to all match blocks that are currently exhaustive and do not have an `else` clause.