### PR TITLE
Fix docstring corruption from exhaustive annotation

### DIFF
--- a/stallion/max_requests_per_connection.pony
+++ b/stallion/max_requests_per_connection.pony
@@ -8,7 +8,7 @@ type MaxRequestsPerConnection is
   Must be at least 1. Use `MakeMaxRequestsPerConnection` to create:
 
   ```pony
-  match \exhaustive\ MakeMaxRequestsPerConnection(1000)
+  match MakeMaxRequestsPerConnection(1000)
   | let m: MaxRequestsPerConnection =>
     ServerConfig("0.0.0.0", "80" where max_requests_per_connection' = m)
   | let e: ValidationFailure =>

--- a/stallion/responder.pony
+++ b/stallion/responder.pony
@@ -33,7 +33,7 @@ class ref Responder
   incrementally-generated bodies. `start_chunked_response()` returns a
   `StartChunkedResponseResult` indicating success or the reason for failure:
   ```pony
-  match \exhaustive\ responder.start_chunked_response(StatusOK, headers)
+  match responder.start_chunked_response(StatusOK, headers)
   | StreamingStarted =>
     let token1 = responder.send_chunk("chunk 1")
     let token2 = responder.send_chunk("chunk 2")

--- a/stallion/server_config.pony
+++ b/stallion/server_config.pony
@@ -28,7 +28,7 @@ class val ServerConfig
   ServerConfig("localhost", "8080")
 
   // Custom timeout via MakeIdleTimeout (milliseconds)
-  let timeout = match \exhaustive\ lori.MakeIdleTimeout(30_000)
+  let timeout = match lori.MakeIdleTimeout(30_000)
   | let t: lori.IdleTimeout => t
   end
   ServerConfig("0.0.0.0", "80" where
@@ -39,7 +39,7 @@ class val ServerConfig
   ServerConfig("0.0.0.0", "80" where idle_timeout' = None)
 
   // Limit to 1000 requests per connection
-  match \exhaustive\ MakeMaxRequestsPerConnection(1000)
+  match MakeMaxRequestsPerConnection(1000)
   | let m: MaxRequestsPerConnection =>
     ServerConfig("0.0.0.0", "80" where max_requests_per_connection' = m)
   end

--- a/stallion/stallion.pony
+++ b/stallion/stallion.pony
@@ -62,7 +62,7 @@ delivery:
 fun ref on_request_complete(request': stallion.Request val,
   responder: stallion.Responder)
 =>
-  match \exhaustive\ responder.start_chunked_response(stallion.StatusOK)
+  match responder.start_chunked_response(stallion.StatusOK)
   | stallion.StreamingStarted =>
     let token = responder.send_chunk("chunk 1")
     // When on_chunk_sent(token) fires, send the next chunk...


### PR DESCRIPTION
The automated `\exhaustive\` annotation script incorrectly modified "match" inside multi-line docstrings (prose text and code examples), inserting `\exhaustive\` into human-readable text and example code blocks.