### PR TITLE
Bump lori from 0.8.5 to 0.9.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ The `ssl` option is required because this library and lori depend on the `ssl` p
 
 Package: `stallion` (repo name is `stallion`, Pony package name is `stallion`)
 
-Built on lori (v0.8.4). Lori provides raw TCP I/O with a connection-actor model: `_on_received(data: Array[U8] iso)` for incoming data, `TCPConnection.send(data): (SendToken | SendError)` for outgoing, plus backpressure notifications, SSL support, and per-connection ASIO-level idle timers.
+Built on lori (v0.9.0). Lori provides raw TCP I/O with a connection-actor model: `_on_received(data: Array[U8] iso)` for incoming data, `TCPConnection.send(data): (SendToken | SendError)` for outgoing, plus backpressure notifications, SSL support, and per-connection ASIO-level idle timers.
 
 ### Key design decisions
 

--- a/corral.json
+++ b/corral.json
@@ -13,7 +13,7 @@
   "deps": [
     {
       "locator": "github.com/ponylang/lori.git",
-      "version": "0.8.5"
+      "version": "0.9.0"
     },
     {
       "locator": "github.com/ponylang/ssl.git",

--- a/stallion/_test_server.pony
+++ b/stallion/_test_server.pony
@@ -289,7 +289,7 @@ actor \nodoc\ _TestMaxRequestsClient is
       _h.complete(true)
     end
 
-  fun ref _on_connection_failure() =>
+  fun ref _on_connection_failure(reason: lori.ConnectionFailureReason) =>
     _h.fail("Client connection failed")
     _h.complete(false)
 
@@ -503,7 +503,7 @@ actor \nodoc\ _TestHTTPClient is
       _verify_response()
     end
 
-  fun ref _on_connection_failure() =>
+  fun ref _on_connection_failure(reason: lori.ConnectionFailureReason) =>
     _h.fail("Client connection failed")
     _h.complete(false)
 
@@ -591,7 +591,7 @@ actor \nodoc\ _TestHTTPClientExpectClose is
       end
     end
 
-  fun ref _on_connection_failure() =>
+  fun ref _on_connection_failure(reason: lori.ConnectionFailureReason) =>
     _h.fail("Client connection failed")
     _h.complete(false)
 
@@ -648,7 +648,7 @@ actor \nodoc\ _TestKeepAliveClient is
       _h.complete(false)
     end
 
-  fun ref _on_connection_failure() =>
+  fun ref _on_connection_failure(reason: lori.ConnectionFailureReason) =>
     _h.fail("Client connection failed")
     _h.complete(false)
 
@@ -920,7 +920,7 @@ actor \nodoc\ _TestPipelineClient is
       end
     end
 
-  fun ref _on_connection_failure() =>
+  fun ref _on_connection_failure(reason: lori.ConnectionFailureReason) =>
     _h.fail("Client connection failed")
     _h.complete(false)
 
@@ -974,7 +974,7 @@ actor \nodoc\ _TestPipelineCloseClient is
       end
     end
 
-  fun ref _on_connection_failure() =>
+  fun ref _on_connection_failure(reason: lori.ConnectionFailureReason) =>
     _h.fail("Client connection failed")
     _h.complete(false)
 
@@ -1027,7 +1027,7 @@ actor \nodoc\ _TestStreamClient is
       _h.complete(true)
     end
 
-  fun ref _on_connection_failure() =>
+  fun ref _on_connection_failure(reason: lori.ConnectionFailureReason) =>
     _h.fail("Client connection failed")
     _h.complete(false)
 
@@ -1125,7 +1125,7 @@ actor \nodoc\ _TestMaxPendingClient is
       _h.complete(false)
     end
 
-  fun ref _on_connection_failure() =>
+  fun ref _on_connection_failure(reason: lori.ConnectionFailureReason) =>
     _h.fail("Client connection failed")
     _h.complete(false)
 
@@ -1307,7 +1307,7 @@ actor \nodoc\ _TestChunkSentClient is
       _h.complete(true)
     end
 
-  fun ref _on_connection_failure() =>
+  fun ref _on_connection_failure(reason: lori.ConnectionFailureReason) =>
     _h.fail("Client connection failed")
     _h.complete(false)
 
@@ -1660,7 +1660,7 @@ actor \nodoc\ _TestPipelinedBodiesClient is
       _h.complete(false)
     end
 
-  fun ref _on_connection_failure() =>
+  fun ref _on_connection_failure(reason: lori.ConnectionFailureReason) =>
     _h.fail("Client connection failed")
     _h.complete(false)
 
@@ -1898,7 +1898,7 @@ actor \nodoc\ _TestSSLHTTPClient is
       _verify_response()
     end
 
-  fun ref _on_connection_failure() =>
+  fun ref _on_connection_failure(reason: lori.ConnectionFailureReason) =>
     _h.fail("SSL client connection failed")
     _h.complete(false)
 
@@ -1984,7 +1984,7 @@ actor \nodoc\ _TestSSLHTTPClientExpectClose is
       end
     end
 
-  fun ref _on_connection_failure() =>
+  fun ref _on_connection_failure(reason: lori.ConnectionFailureReason) =>
     _h.fail("SSL client connection failed")
     _h.complete(false)
 
@@ -2042,7 +2042,7 @@ actor \nodoc\ _TestSSLKeepAliveClient is
       _h.complete(false)
     end
 
-  fun ref _on_connection_failure() =>
+  fun ref _on_connection_failure(reason: lori.ConnectionFailureReason) =>
     _h.fail("SSL client connection failed")
     _h.complete(false)
 
@@ -2096,6 +2096,6 @@ actor \nodoc\ _TestSSLStreamClient is
       _h.complete(true)
     end
 
-  fun ref _on_connection_failure() =>
+  fun ref _on_connection_failure(reason: lori.ConnectionFailureReason) =>
     _h.fail("SSL client connection failed")
     _h.complete(false)

--- a/stallion/http_server.pony
+++ b/stallion/http_server.pony
@@ -121,7 +121,7 @@ class HTTPServer is
   fun ref _on_closed() =>
     _state.on_closed(this)
 
-  fun ref _on_start_failure() =>
+  fun ref _on_start_failure(reason: lori.StartFailureReason) =>
     // Connection failed before _on_started — receiver was never activated.
     // Don't call _receiver.on_closed(); just mark as closed for GC.
     _state = _Closed


### PR DESCRIPTION
Picks up two lori changes:

- **0.9.0**: Structured failure reasons on connection callbacks (breaking — signatures updated), and `yield_read()` for cooperative scheduler fairness
- **0.8.5 → 0.9.0 path**: The IdleTimeout overflow fix was already picked up in 0.8.5

The breaking change adds a reason parameter to `_on_start_failure`, `_on_connection_failure`, and `_on_tls_failure`. Stallion overrides two of these — `_on_start_failure` in `HTTPServer` and `_on_connection_failure` in 14 test client actors. The reason parameters are unused since the existing behavior doesn't need to distinguish failure causes.

No user-facing changes — all affected methods are internal or test-only.