### PR TITLE
Upgrade lori dependency to 0.10.0

### DIFF
--- a/.release-notes/upgrade-lori-0.10.0.md
+++ b/.release-notes/upgrade-lori-0.10.0.md
@@ -1,0 +1,37 @@
+## Upgrade lori dependency to 0.10.0
+
+The lori dependency has been updated from 0.9.0 to 0.10.0. This brings several changes that affect stallion users who create `TCPListener` instances directly:
+
+**Default connection limit is now 100,000.** Previously, there was no default connection limit (unlimited). Pass `limit = None` to restore the old unlimited behavior:
+
+```pony
+// Restore unlimited connections (was the default in lori 0.9.0)
+TCPListener(auth, host, port, this where limit = None)
+```
+
+**`MaxSpawn` is now a constrained type.** If you were passing a custom `limit` to `TCPListener`, the type has changed from a bare `U32` to a validated type constructed via `MakeMaxSpawn`:
+
+Before:
+
+```pony
+// lori 0.9.0 — limit was (U32 | None)
+_tcp_listener = TCPListener(auth, host, port, this where limit = 500)
+```
+
+After:
+
+```pony
+// lori 0.10.0 — limit is MaxSpawn, created via MakeMaxSpawn
+match MakeMaxSpawn(500)
+| let limit: MaxSpawn =>
+  _tcp_listener = TCPListener(auth, host, port, this where limit = limit)
+end
+```
+
+**New `ip_version` parameter.** `TCPListener.create` now accepts an `ip_version` parameter (`IP4`, `IP6`, or `DualStack`). The default is `DualStack`. If you need to restrict to a specific IP version:
+
+```pony
+TCPListener(auth, host, port, this where ip_version = IP4)
+```
+
+Lori 0.10.0 also includes bug fixes: the accept loop no longer spins on persistent errors, and the read loop correctly yields after exceeding the byte threshold.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ The `ssl` option is required because this library and lori depend on the `ssl` p
 
 Package: `stallion` (repo name is `stallion`, Pony package name is `stallion`)
 
-Built on lori (v0.9.0). Lori provides raw TCP I/O with a connection-actor model: `_on_received(data: Array[U8] iso)` for incoming data, `TCPConnection.send(data): (SendToken | SendError)` for outgoing, plus backpressure notifications, SSL support, and per-connection ASIO-level idle timers.
+Built on lori (v0.10.0). Lori provides raw TCP I/O with a connection-actor model: `_on_received(data: Array[U8] iso)` for incoming data, `TCPConnection.send(data): (SendToken | SendError)` for outgoing, plus backpressure notifications, SSL support, and per-connection ASIO-level idle timers.
 
 ### Key design decisions
 

--- a/corral.json
+++ b/corral.json
@@ -13,7 +13,7 @@
   "deps": [
     {
       "locator": "github.com/ponylang/lori.git",
-      "version": "0.9.0"
+      "version": "0.10.0"
     },
     {
       "locator": "github.com/ponylang/ssl.git",


### PR DESCRIPTION
Bumps lori from 0.9.0 to 0.10.0. Key user-facing changes from lori:

- Default connection limit is now 100,000 (was unlimited). Pass `limit = None` to restore the old behavior.
- `MaxSpawn` is now a constrained type constructed via `MakeMaxSpawn` instead of a bare `U32`.
- New `ip_version` parameter on `TCPListener` (`IP4`, `IP6`, `DualStack`; defaults to `DualStack`).
- Bug fixes: accept loop no longer spins on persistent errors; read loop correctly yields after byte threshold.

No stallion source changes needed — all `TCPListener` call sites use positional args that remain valid with the new defaults.