### PR TITLE
Use pony-doc for doc generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ PACKAGE := stallion
 GET_DEPENDENCIES_WITH := corral fetch
 CLEAN_DEPENDENCIES_WITH := corral clean
 COMPILE_WITH := corral run -- ponyc
+BUILD_DOCS_WITH := corral run -- pony-doc
 
 BUILD_DIR ?= build/$(config)
 SRC_DIR := $(PACKAGE)
@@ -64,7 +65,7 @@ clean:
 $(docs_dir): $(SOURCE_FILES)
 	rm -rf $(docs_dir)
 	$(GET_DEPENDENCIES_WITH)
-	$(PONYC) --docs-public --pass=docs --output build $(SRC_DIR)
+	$(BUILD_DOCS_WITH) --output build $(SRC_DIR)
 
 docs: $(docs_dir)
 


### PR DESCRIPTION
pony-doc is a dedicated documentation tool that defaults to public-only output, replacing ponyc's --docs-public --pass=docs flags.