### PR TITLE
Add cookie parsing and serialization

### DIFF
--- a/.release-notes/next-release.md
+++ b/.release-notes/next-release.md
@@ -1,0 +1,55 @@
+## Added cookie parsing and serialization
+
+Stallion now provides built-in cookie support in two directions: reading cookies from requests and building `Set-Cookie` response headers.
+
+Cookies are automatically parsed from `Cookie` request headers and available on the `Request` object. Use `request'.cookies.get("name")` to look up a cookie by name, or `request'.cookies.values()` to iterate over all parsed cookies:
+
+```pony
+fun ref on_request_complete(request': stallion.Request val,
+  responder: stallion.Responder)
+=>
+  match request'.cookies.get("session")
+  | let token: String val =>
+    // Use the session token
+  end
+```
+
+For direct parsing outside the request lifecycle, `ParseCookies` accepts a raw `Cookie` header value string or a `Headers val` collection.
+
+To build `Set-Cookie` response headers, use `SetCookieBuilder`. It defaults to `Secure`, `HttpOnly`, and `SameSite=Lax` — override explicitly when needed:
+
+```pony
+match stallion.SetCookieBuilder("session", token)
+  .with_path("/")
+  .with_max_age(3600)
+  .build()
+| let sc: stallion.SetCookie val =>
+  // Add to response: .add_header("Set-Cookie", sc.header_value())
+| let err: stallion.SetCookieBuildError =>
+  // Handle validation error
+end
+```
+
+The builder validates cookie names (RFC 2616 token), values (RFC 6265 cookie-octets), and path/domain attributes (no CTLs or semicolons), enforces `__Host-` and `__Secure-` prefix rules, and checks `SameSite=None` + `Secure` consistency.
+
+New types: `Header`, `RequestCookie`, `RequestCookies`, `ParseCookies`, `SetCookie`, `SetCookieBuilder`, `SetCookieBuildError`, `SameSite` (`SameSiteStrict`, `SameSiteLax`, `SameSiteNone`).
+
+## Changed Headers.values() to yield Header val instead of tuples
+
+`Headers.values()` now yields `Header val` objects instead of `(String, String)` tuples. Code that destructures header values needs to change from field access on tuples to field access on the `Header` class:
+
+Before:
+
+```pony
+for (name, value) in headers.values() do
+  env.out.print(name + ": " + value)
+end
+```
+
+After:
+
+```pony
+for hdr in headers.values() do
+  env.out.print(hdr.name + ": " + hdr.value)
+end
+```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,11 @@ All notable changes to this project will be documented in this file. This projec
 
 ### Added
 
+- Add cookie parsing and serialization ([PR #80](https://github.com/ponylang/stallion/pull/80))
 
 ### Changed
+
+- Change Headers.values() to yield Header val instead of tuples ([PR #80](https://github.com/ponylang/stallion/pull/80))
 
 
 ## [0.4.0] - 2026-03-03

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,7 +55,8 @@ Follow the standard ponylang release notes conventions. Create individual `.md` 
   - `method.pony` — HTTP method types (`Method` interface, 9 primitives, `Methods` parse/enumerate)
   - `version.pony` — HTTP version types (`HTTP10`, `HTTP11`, `Version` closed union)
   - `status.pony` — HTTP status codes (`Status` interface, 35 standard primitives)
-  - `headers.pony` — Case-insensitive header collection (`Headers` class)
+  - `header.pony` — Single HTTP header name-value pair (`Header val` class)
+  - `headers.pony` — Case-insensitive header collection (`Headers` class, stores `Array[Header val]`)
   - `_response_serializer.pony` — Response wire-format serializer (package-private)
   - `_mort.pony` — Runtime enforcement primitives (`_IllegalState`, `_Unreachable`)
   - `parse_error.pony` — Parse error types (`ParseError` union, 8 error primitives)
@@ -63,7 +64,7 @@ Follow the standard ponylang release notes conventions. Create individual `.md` 
   - `_request_parser_notify.pony` — Parser callback trait (synchronous `ref` methods)
   - `_parser_state.pony` — Parser state machine (state interface, 6 state classes, `_BufferScan`)
   - `_request_parser.pony` — Request parser class (entry point, buffer management)
-  - `request.pony` — Immutable request metadata bundle (`Request val`: method, URI, version, headers)
+  - `request.pony` — Immutable request metadata bundle (`Request val`: method, URI, version, headers, cookies)
   - `chunk_send_token.pony` — Opaque chunk send token (`ChunkSendToken val`, `Equatable`, private constructor)
   - `http_server_lifecycle_event_receiver.pony` — HTTP callback trait (`HTTPServerLifecycleEventReceiver`: on_request, on_body_chunk, on_request_complete, on_chunk_sent, on_closed, on_throttled, on_unthrottled)
   - `http_server_actor.pony` — Server actor trait (`HTTPServerActor`: extends `TCPConnectionActor` and `HTTPServerLifecycleEventReceiver`, provides `_connection()` default)
@@ -79,10 +80,20 @@ Follow the standard ponylang release notes conventions. Create individual `.md` 
   - `server_config.pony` — Server configuration (`ServerConfig` class with `max_requests_per_connection: (MaxRequestsPerConnection | None)`, `DefaultIdleTimeout` primitive)
   - `_error_response.pony` — Pre-built error response strings (`_ErrorResponse` primitive)
   - `_connection_state.pony` — Connection lifecycle states (`_Active`, `_Closed`; routes `on_sent` for chunk token delivery)
+  - `request_cookie.pony` — Single parsed cookie name-value pair (`RequestCookie val`, private constructor)
+  - `request_cookies.pony` — Immutable collection of parsed request cookies (`RequestCookies val`, `get()`, `values()`, `size()`)
+  - `parse_cookies.pony` — Cookie parser (`ParseCookies` primitive: `from_headers()`, `apply()`, lenient RFC 6265 §5.4 parsing)
+  - `same_site.pony` — SameSite attribute types (`SameSiteStrict`, `SameSiteLax`, `SameSiteNone`, `SameSite` union)
+  - `set_cookie_build_error.pony` — Build error types (`InvalidCookieName`, `InvalidCookieValue`, `InvalidCookiePath`, `InvalidCookieDomain`, `CookiePrefixViolation`, `SameSiteRequiresSecure`, `SetCookieBuildError` union)
+  - `set_cookie.pony` — Validated, pre-serialized `Set-Cookie` header (`SetCookie val`, `header_value()`, private constructor)
+  - `set_cookie_builder.pony` — `Set-Cookie` header builder (`SetCookieBuilder ref`, secure defaults, chaining, prefix rules)
+  - `_cookie_validator.pony` — Cookie name/value/attribute validation (RFC 2616 token, RFC 6265 cookie-octet, path/domain safety)
+  - `_http_date.pony` — IMF-fixdate formatter for `Expires` attribute (`_HTTPDate` primitive)
 - `assets/` — test assets
   - `cert.pem` — Self-signed test certificate for SSL examples
   - `key.pem` — Test private key for SSL examples
 - `examples/` — example programs
+  - `cookies/main.pony` — Visit counter demonstrating `Request.cookies` and `SetCookieBuilder`
   - `hello/main.pony` — Greeting server with URI parsing and query parameter extraction
   - `ssl/main.pony` — HTTPS server using SSL/TLS
   - `streaming/main.pony` — Flow-controlled chunked transfer encoding streaming response using `on_chunk_sent()` callbacks

--- a/examples/README.md
+++ b/examples/README.md
@@ -6,6 +6,10 @@ Each subdirectory is a self-contained Pony program demonstrating a different par
 
 Greeting server that responds with "Hello, World!" by default, or "Hello, {name}!" when a `?name=X` query parameter is provided. Demonstrates the core API: a listener actor implements `lori.TCPListenerActor`, creates connection actors in `_on_accept`, and each connection actor uses `HTTPServerActor`, `HTTPServer`, `Request`, `Responder`, `ResponseBuilder`, and `ServerConfig`. Start here if you're new to the library.
 
+## [cookies](cookies/)
+
+Visit counter that reads the `visits` cookie from incoming requests, increments it, and sets it back via `Set-Cookie`. Demonstrates both `Request.cookies` for reading cookies parsed from request headers and `SetCookieBuilder` for building validated `Set-Cookie` response headers with secure defaults.
+
 ## [ssl](ssl/)
 
 HTTPS server using SSL/TLS. Demonstrates creating an `SSLContext`, loading certificate and key files, and passing the context to connection actors via `_on_accept`. Actors use `HTTPServer.ssl` instead of `HTTPServer` to create an HTTPS connection.

--- a/examples/cookies/main.pony
+++ b/examples/cookies/main.pony
@@ -1,0 +1,109 @@
+"""
+Visit counter using cookies. Reads the `visits` cookie from the request,
+increments it, and sets it back via `Set-Cookie`. Demonstrates both
+`Request.cookies` for reading and `SetCookieBuilder` for writing cookies.
+
+First visit returns "Visit #1", subsequent visits increment the counter.
+"""
+use stallion = "../../stallion"
+use lori = "lori"
+
+actor Main
+  new create(env: Env) =>
+    let auth = lori.TCPListenAuth(env.root)
+    Listener(auth, "0.0.0.0", "8080", env.out)
+
+actor Listener is lori.TCPListenerActor
+  var _tcp_listener: lori.TCPListener = lori.TCPListener.none()
+  let _out: OutStream
+  let _config: stallion.ServerConfig
+  let _server_auth: lori.TCPServerAuth
+
+  new create(
+    auth: lori.TCPListenAuth,
+    host: String,
+    port: String,
+    out: OutStream)
+  =>
+    _out = out
+    _server_auth = lori.TCPServerAuth(auth)
+    _config = stallion.ServerConfig(host, port)
+    _tcp_listener = lori.TCPListener(auth, host, port, this)
+
+  fun ref _listener(): lori.TCPListener => _tcp_listener
+
+  fun ref _on_accept(fd: U32): lori.TCPConnectionActor =>
+    CookieServer(_server_auth, fd, _config)
+
+  fun ref _on_listening() =>
+    try
+      (let host, let port) = _tcp_listener.local_address().name()?
+      _out.print("Server listening on " + host + ":" + port)
+    else
+      _out.print("Server listening")
+    end
+
+  fun ref _on_listen_failure() =>
+    _out.print("Failed to start server")
+
+  fun ref _on_closed() =>
+    _out.print("Server closed")
+
+actor CookieServer is stallion.HTTPServerActor
+  var _http: stallion.HTTPServer = stallion.HTTPServer.none()
+
+  new create(
+    auth: lori.TCPServerAuth,
+    fd: U32,
+    config: stallion.ServerConfig)
+  =>
+    _http = stallion.HTTPServer(auth, fd, this, config)
+
+  fun ref _http_connection(): stallion.HTTPServer => _http
+
+  fun ref on_request_complete(request': stallion.Request val,
+    responder: stallion.Responder)
+  =>
+    // Read the visits cookie, defaulting to "0"
+    var visits: U64 = 0
+    match request'.cookies.get("visits")
+    | let v: String val =>
+      try visits = v.u64()? end
+    end
+    visits = visits + 1
+
+    let resp_body: String val = "Visit #" + visits.string()
+
+    // Build a Set-Cookie header to store the updated count
+    let set_cookie = match stallion.SetCookieBuilder("visits",
+        visits.string())
+      .with_path("/")
+      .with_http_only(false)
+      .with_secure(false)
+      .with_same_site(stallion.SameSiteLax)
+      .build()
+    | let sc: stallion.SetCookie val => sc
+    | let err: stallion.SetCookieBuildError =>
+      // Cookie name/value are always valid here, so this is unreachable
+      _respond_error(responder)
+      return
+    end
+
+    let response = stallion.ResponseBuilder(stallion.StatusOK)
+      .add_header("Content-Type", "text/plain")
+      .add_header("Content-Length", resp_body.size().string())
+      .add_header("Set-Cookie", set_cookie.header_value())
+      .finish_headers()
+      .add_chunk(resp_body)
+      .build()
+    responder.respond(response)
+
+  fun _respond_error(responder: stallion.Responder ref) =>
+    let body: String val = "Internal Server Error"
+    let response = stallion.ResponseBuilder(
+        stallion.StatusInternalServerError)
+      .add_header("Content-Length", body.size().string())
+      .finish_headers()
+      .add_chunk(body)
+      .build()
+    responder.respond(response)

--- a/stallion/_cookie_validator.pony
+++ b/stallion/_cookie_validator.pony
@@ -1,0 +1,69 @@
+primitive _CookieValidator
+  """
+  Validate cookie names and values per RFC 6265 and RFC 2616.
+
+  Cookie names must be RFC 2616 tokens: ASCII 33–126 excluding
+  separators `( ) < > @ , ; : \\ " / [ ] ? = { }`.
+
+  Cookie values must be RFC 6265 cookie-octets: 0x21, 0x23–0x2B,
+  0x2D–0x3A, 0x3C–0x5B, 0x5D–0x7E.
+  """
+
+  fun valid_name(name: String box): Bool =>
+    """Return true if `name` is a valid cookie name (RFC 2616 token)."""
+    if name.size() == 0 then return false end
+    for byte in name.values() do
+      if not _is_token_char(byte) then return false end
+    end
+    true
+
+  fun valid_value(value: String box): Bool =>
+    """Return true if `value` contains only valid cookie-octets."""
+    for byte in value.values() do
+      if not _is_cookie_octet(byte) then return false end
+    end
+    true
+
+  fun _is_token_char(b: U8): Bool =>
+    """
+    RFC 2616 token character: ASCII 33–126 minus separators.
+
+    Separators: ( ) < > @ , ; : \\ " / [ ] ? = { }
+    """
+    if (b < 33) or (b > 126) then return false end
+    // Check separators
+    match b
+    | '(' | ')' | '<' | '>' | '@'
+    | ',' | ';' | ':' | '\\' | '"'
+    | '/' | '[' | ']' | '?' | '='
+    | '{' | '}' => false
+    else
+      true
+    end
+
+  fun _is_cookie_octet(b: U8): Bool =>
+    """
+    RFC 6265 cookie-octet: 0x21, 0x23–0x2B, 0x2D–0x3A, 0x3C–0x5B, 0x5D–0x7E.
+    """
+    if b == 0x21 then return true end
+    if (b >= 0x23) and (b <= 0x2B) then return true end
+    if (b >= 0x2D) and (b <= 0x3A) then return true end
+    if (b >= 0x3C) and (b <= 0x5B) then return true end
+    if (b >= 0x5D) and (b <= 0x7E) then return true end
+    false
+
+  fun valid_attr_value(value: String box): Bool =>
+    """
+    Return true if `value` is safe as a Set-Cookie attribute value.
+
+    RFC 6265 section 4.1.1 defines path-value as any US-ASCII character
+    (0x20–0x7E) except semicolons. Control characters (0x00–0x1F, 0x7F)
+    and non-ASCII bytes (0x80–0xFF) are rejected. The same constraint
+    prevents attribute injection in domain values.
+    """
+    for byte in value.values() do
+      if (byte < 0x20) or (byte > 0x7E) or (byte == ';') then
+        return false
+      end
+    end
+    true

--- a/stallion/_http_date.pony
+++ b/stallion/_http_date.pony
@@ -1,0 +1,62 @@
+use "time"
+
+primitive _HTTPDate
+  """
+  Format epoch seconds as an IMF-fixdate string (RFC 7231 §7.1.1.1).
+
+  Example: `Thu, 01 Jan 1970 00:00:00 GMT`
+
+  Used by `SetCookieBuilder` for the `Expires` attribute.
+  """
+
+  fun apply(epoch_seconds: I64): String val =>
+    """Format epoch seconds as an IMF-fixdate string."""
+    let d = PosixDate(epoch_seconds)
+
+    // PosixDate.day_of_week uses C's tm_wday: 0=Sunday through 6=Saturday
+    let day_names = [as String val:
+      "Sun"; "Mon"; "Tue"; "Wed"; "Thu"; "Fri"; "Sat"]
+    let month_names = [as String val:
+      "Jan"; "Feb"; "Mar"; "Apr"; "May"; "Jun"
+      "Jul"; "Aug"; "Sep"; "Oct"; "Nov"; "Dec"]
+
+    let day_name = try
+      day_names(d.day_of_week.usize())?
+    else
+      _Unreachable()
+      "Thu"
+    end
+
+    let month_name = try
+      month_names((d.month - 1).usize())?
+    else
+      _Unreachable()
+      "Jan"
+    end
+
+    let buf = recover val
+      String(29)
+        .>append(day_name)
+        .>append(", ")
+        .>append(_pad2(d.day_of_month))
+        .>append(" ")
+        .>append(month_name)
+        .>append(" ")
+        .>append(d.year.string())
+        .>append(" ")
+        .>append(_pad2(d.hour))
+        .>append(":")
+        .>append(_pad2(d.min))
+        .>append(":")
+        .>append(_pad2(d.sec))
+        .>append(" GMT")
+    end
+    buf
+
+  fun _pad2(n: I32): String val =>
+    """Zero-pad an integer to two digits."""
+    if n < 10 then
+      "0" + n.string()
+    else
+      n.string()
+    end

--- a/stallion/_response_serializer.pony
+++ b/stallion/_response_serializer.pony
@@ -31,10 +31,10 @@ primitive _ResponseSerializer
         .>append("\r\n")
 
       // Headers
-      for (name, value) in headers.values() do
-        buf.>append(name)
+      for hdr in headers.values() do
+        buf.>append(hdr.name)
           .>append(": ")
-          .>append(value)
+          .>append(hdr.value)
           .>append("\r\n")
       end
 

--- a/stallion/_test.pony
+++ b/stallion/_test.pony
@@ -132,6 +132,52 @@ actor \nodoc\ Main is TestList
     test(_TestServerContentLengthZero)
     test(_TestPipelinedBodies)
 
+    // Cookie validator tests
+    test(Property1UnitTest[String val](
+      _PropertyValidCookieNameAccepted))
+    test(Property1UnitTest[String val](
+      _PropertyInvalidCookieNameRejected))
+    test(Property1UnitTest[(String val, Bool)](
+      _PropertyCookieNameBoundary))
+    test(Property1UnitTest[String val](
+      _PropertyValidCookieValueAccepted))
+    test(Property1UnitTest[String val](
+      _PropertyInvalidCookieValueRejected))
+    test(Property1UnitTest[(String val, Bool)](
+      _PropertyCookieValueBoundary))
+
+    // Attribute value validator tests
+    test(Property1UnitTest[String val](
+      _PropertyValidAttrValueAccepted))
+    test(Property1UnitTest[String val](
+      _PropertyInvalidAttrValueRejected))
+    test(Property1UnitTest[(String val, Bool)](
+      _PropertyAttrValueBoundary))
+
+    // HTTP date tests
+    test(_TestHTTPDateKnownGood)
+    test(Property1UnitTest[I64](_PropertyHTTPDateFormat))
+
+    // Cookie parsing tests
+    test(_TestParseCookieKnownGood)
+    test(Property1UnitTest[Array[(String val, String val)] ref](
+      _PropertyCookieParseRoundtrip))
+    test(Property1UnitTest[String val](
+      _PropertyCookieParseRobustness))
+
+    // Set-Cookie builder tests
+    test(_TestSetCookieKnownGood)
+    test(_TestSetCookieErrors)
+    test(Property1UnitTest[(String val, String val)](
+      _PropertySetCookieValidBuild))
+    test(Property1UnitTest[String val](
+      _PropertySetCookieInvalidNameErrors))
+    test(Property1UnitTest[String val](
+      _PropertySetCookieInvalidValueErrors))
+
+    // Cookie integration test
+    test(_TestServerCookieParsing)
+
     // SSL integration tests
     test(_TestSSLHelloWorld)
     test(_TestSSLKeepAlive)

--- a/stallion/_test_cookie_parse.pony
+++ b/stallion/_test_cookie_parse.pony
@@ -1,0 +1,179 @@
+use "collections"
+use "pony_check"
+use "pony_test"
+
+class \nodoc\ iso _TestParseCookieKnownGood is UnitTest
+  """
+  Verify parsing of specific cookie header strings.
+  """
+  fun name(): String => "cookie_parse/known_good"
+
+  fun apply(h: TestHelper) =>
+    _test_single_cookie(h)
+    _test_multiple_cookies(h)
+    _test_missing_space_after_semicolon(h)
+    _test_quoted_value(h)
+    _test_equals_in_value(h)
+    _test_empty_name_skipped(h)
+    _test_no_equals_skipped(h)
+    _test_whitespace_trimming(h)
+    _test_empty_string(h)
+    _test_from_headers_multiple(h)
+    _test_case_sensitive_names(h)
+
+  fun _test_single_cookie(h: TestHelper) =>
+    let cookies = ParseCookies("session=abc123")
+    h.assert_eq[USize](1, cookies.size(), "single: count")
+    h.assert_eq[String val]("abc123",
+      _get_or_empty(cookies, "session"),
+      "single: value")
+
+  fun _test_multiple_cookies(h: TestHelper) =>
+    let cookies = ParseCookies("a=1; b=2; c=3")
+    h.assert_eq[USize](3, cookies.size(), "multiple: count")
+    h.assert_eq[String val]("1", _get_or_empty(cookies, "a"),
+      "multiple: a")
+    h.assert_eq[String val]("2", _get_or_empty(cookies, "b"),
+      "multiple: b")
+    h.assert_eq[String val]("3", _get_or_empty(cookies, "c"),
+      "multiple: c")
+
+  fun _test_missing_space_after_semicolon(h: TestHelper) =>
+    let cookies = ParseCookies("a=1;b=2")
+    h.assert_eq[USize](2, cookies.size(), "no space: count")
+    h.assert_eq[String val]("1", _get_or_empty(cookies, "a"),
+      "no space: a")
+    h.assert_eq[String val]("2", _get_or_empty(cookies, "b"),
+      "no space: b")
+
+  fun _test_quoted_value(h: TestHelper) =>
+    let cookies = ParseCookies("token=\"abc\"")
+    h.assert_eq[String val]("abc", _get_or_empty(cookies, "token"),
+      "quoted: value")
+
+  fun _test_equals_in_value(h: TestHelper) =>
+    let cookies = ParseCookies("data=a=b=c")
+    h.assert_eq[String val]("a=b=c", _get_or_empty(cookies, "data"),
+      "equals in value")
+
+  fun _test_empty_name_skipped(h: TestHelper) =>
+    let cookies = ParseCookies("=value; valid=ok")
+    h.assert_eq[USize](1, cookies.size(), "empty name: count")
+    h.assert_eq[String val]("ok", _get_or_empty(cookies, "valid"),
+      "empty name: valid cookie")
+
+  fun _test_no_equals_skipped(h: TestHelper) =>
+    let cookies = ParseCookies("justname; valid=ok")
+    h.assert_eq[USize](1, cookies.size(), "no equals: count")
+    h.assert_eq[String val]("ok", _get_or_empty(cookies, "valid"),
+      "no equals: valid cookie")
+
+  fun _test_whitespace_trimming(h: TestHelper) =>
+    let cookies = ParseCookies("  a  =  1  ;  b  =  2  ")
+    h.assert_eq[USize](2, cookies.size(), "trimming: count")
+    h.assert_eq[String val]("1", _get_or_empty(cookies, "a"),
+      "trimming: a")
+    h.assert_eq[String val]("2", _get_or_empty(cookies, "b"),
+      "trimming: b")
+
+  fun _test_empty_string(h: TestHelper) =>
+    let cookies = ParseCookies("")
+    h.assert_eq[USize](0, cookies.size(), "empty: count")
+
+  fun _test_from_headers_multiple(h: TestHelper) =>
+    let headers = recover val
+      let h' = Headers
+      h'.add("cookie", "a=1; b=2")
+      h'.add("cookie", "c=3")
+      h'.add("content-type", "text/html")
+      h'
+    end
+    let cookies = ParseCookies.from_headers(headers)
+    h.assert_eq[USize](3, cookies.size(), "from_headers: count")
+    h.assert_eq[String val]("1", _get_or_empty(cookies, "a"),
+      "from_headers: a")
+    h.assert_eq[String val]("2", _get_or_empty(cookies, "b"),
+      "from_headers: b")
+    h.assert_eq[String val]("3", _get_or_empty(cookies, "c"),
+      "from_headers: c")
+
+  fun _test_case_sensitive_names(h: TestHelper) =>
+    let cookies = ParseCookies("Name=upper; name=lower")
+    h.assert_eq[USize](2, cookies.size(), "case: count")
+    h.assert_eq[String val]("upper", _get_or_empty(cookies, "Name"),
+      "case: Name")
+    h.assert_eq[String val]("lower", _get_or_empty(cookies, "name"),
+      "case: name")
+
+  fun _get_or_empty(cookies: RequestCookies val, n: String): String val =>
+    match cookies.get(n)
+    | let v: String val => v
+    else ""
+    end
+
+class \nodoc\ iso _PropertyCookieParseRoundtrip
+  is Property1[Array[(String val, String val)] ref]
+  """
+  Generate valid cookie pairs, serialize as a Cookie header, parse back,
+  and verify all pairs are present with correct values.
+  """
+  fun name(): String => "cookie_parse/roundtrip"
+
+  fun gen(): Generator[Array[(String val, String val)] ref] =>
+    let pair_gen = Generators.zip2[String val, String val](
+      _CookieTestGenerators.valid_name(),
+      _CookieTestGenerators.valid_value())
+    Generators.array_of[(String val, String val)](pair_gen, 1, 5)
+
+  fun ref property(
+    arg1: Array[(String val, String val)] ref,
+    ph: PropertyHelper)
+  =>
+    // Deduplicate: keep first occurrence of each name (matches get() semantics)
+    let seen = Map[String val, String val]
+    let unique = Array[(String val, String val)]
+    for (n, v) in arg1.values() do
+      if not seen.contains(n) then
+        seen(n) = v
+        unique.push((n, v))
+      end
+    end
+
+    // Serialize as a Cookie header value
+    var header_value: String val = ""
+    var first = true
+    for (n, v) in unique.values() do
+      if not first then header_value = header_value + "; " end
+      header_value = header_value + n + "=" + v
+      first = false
+    end
+
+    // Parse
+    let cookies = ParseCookies(header_value)
+
+    // Verify each pair is present
+    for (n, v) in unique.values() do
+      let got = match cookies.get(n)
+      | let s: String val => s
+      else ""
+      end
+      ph.assert_eq[String val](v, got,
+        "Cookie '" + n + "' expected '" + v + "' got '" + got + "'")
+    end
+
+class \nodoc\ iso _PropertyCookieParseRobustness
+  is Property1[String val]
+  """
+  Arbitrary strings never crash the parser.
+  """
+  fun name(): String => "cookie_parse/robustness"
+
+  fun gen(): Generator[String val] =>
+    Generators.ascii_printable(0, 100)
+
+  fun ref property(arg1: String val, ph: PropertyHelper) =>
+    // This should never crash — just call it
+    let cookies = ParseCookies(arg1)
+    // size() should return a non-negative value (always true for USize)
+    ph.assert_true(cookies.size() <= arg1.size(),
+      "Cookie count should not exceed input length")

--- a/stallion/_test_cookie_validator.pony
+++ b/stallion/_test_cookie_validator.pony
@@ -1,0 +1,444 @@
+use "collections"
+use "pony_check"
+
+class \nodoc\ iso _PropertyValidCookieNameAccepted
+  is Property1[String val]
+  """
+  Strings composed entirely of RFC 2616 token characters are valid
+  cookie names.
+  """
+  fun name(): String => "cookie_validator/valid_name_accepted"
+
+  fun gen(): Generator[String val] =>
+    _CookieTestGenerators.valid_name()
+
+  fun ref property(arg1: String val, ph: PropertyHelper) =>
+    ph.assert_true(_CookieValidator.valid_name(arg1),
+      "Expected valid name: " + arg1)
+
+class \nodoc\ iso _PropertyInvalidCookieNameRejected
+  is Property1[String val]
+  """
+  Strings containing at least one non-token character are rejected
+  as cookie names.
+  """
+  fun name(): String => "cookie_validator/invalid_name_rejected"
+
+  fun gen(): Generator[String val] =>
+    _CookieTestGenerators.invalid_name()
+
+  fun ref property(arg1: String val, ph: PropertyHelper) =>
+    ph.assert_false(_CookieValidator.valid_name(arg1),
+      "Expected invalid name: " + arg1)
+
+class \nodoc\ iso _PropertyCookieNameBoundary
+  is Property1[(String val, Bool)]
+  """
+  Mixed generator: valid names accepted, invalid names rejected.
+  """
+  fun name(): String => "cookie_validator/name_boundary"
+
+  fun gen(): Generator[(String val, Bool)] =>
+    _CookieTestGenerators.name_boundary()
+
+  fun ref property(arg1: (String val, Bool), ph: PropertyHelper) =>
+    (let s, let expect_valid) = arg1
+    let result = _CookieValidator.valid_name(s)
+    ph.assert_eq[Bool](expect_valid, result,
+      "Name '" + s + "' expected " +
+        if expect_valid then "valid" else "invalid" end)
+
+class \nodoc\ iso _PropertyValidCookieValueAccepted
+  is Property1[String val]
+  """
+  Strings composed entirely of RFC 6265 cookie-octets are valid
+  cookie values.
+  """
+  fun name(): String => "cookie_validator/valid_value_accepted"
+
+  fun gen(): Generator[String val] =>
+    _CookieTestGenerators.valid_value()
+
+  fun ref property(arg1: String val, ph: PropertyHelper) =>
+    ph.assert_true(_CookieValidator.valid_value(arg1),
+      "Expected valid value: " + arg1)
+
+class \nodoc\ iso _PropertyInvalidCookieValueRejected
+  is Property1[String val]
+  """
+  Strings containing at least one non-cookie-octet are rejected
+  as cookie values.
+  """
+  fun name(): String => "cookie_validator/invalid_value_rejected"
+
+  fun gen(): Generator[String val] =>
+    _CookieTestGenerators.invalid_value()
+
+  fun ref property(arg1: String val, ph: PropertyHelper) =>
+    ph.assert_false(_CookieValidator.valid_value(arg1),
+      "Expected invalid value: " + arg1)
+
+class \nodoc\ iso _PropertyCookieValueBoundary
+  is Property1[(String val, Bool)]
+  """
+  Mixed generator: valid values accepted, invalid values rejected.
+  """
+  fun name(): String => "cookie_validator/value_boundary"
+
+  fun gen(): Generator[(String val, Bool)] =>
+    _CookieTestGenerators.value_boundary()
+
+  fun ref property(arg1: (String val, Bool), ph: PropertyHelper) =>
+    (let s, let expect_valid) = arg1
+    let result = _CookieValidator.valid_value(s)
+    ph.assert_eq[Bool](expect_valid, result,
+      "Value '" + s + "' expected " +
+        if expect_valid then "valid" else "invalid" end)
+
+class \nodoc\ iso _PropertyValidAttrValueAccepted
+  is Property1[String val]
+  """
+  US-ASCII strings (0x20–0x7E) with no semicolons are valid attribute values.
+  """
+  fun name(): String => "cookie_validator/valid_attr_value_accepted"
+
+  fun gen(): Generator[String val] =>
+    _CookieTestGenerators.valid_attr_value()
+
+  fun ref property(arg1: String val, ph: PropertyHelper) =>
+    ph.assert_true(_CookieValidator.valid_attr_value(arg1),
+      "Expected valid attr value: " + arg1)
+
+class \nodoc\ iso _PropertyInvalidAttrValueRejected
+  is Property1[String val]
+  """
+  Strings containing CTLs, non-ASCII bytes, or semicolons are rejected
+  as attribute values.
+  """
+  fun name(): String => "cookie_validator/invalid_attr_value_rejected"
+
+  fun gen(): Generator[String val] =>
+    _CookieTestGenerators.invalid_attr_value()
+
+  fun ref property(arg1: String val, ph: PropertyHelper) =>
+    ph.assert_false(_CookieValidator.valid_attr_value(arg1),
+      "Expected invalid attr value: " + arg1)
+
+class \nodoc\ iso _PropertyAttrValueBoundary
+  is Property1[(String val, Bool)]
+  """
+  Mixed generator: valid attr values accepted, invalid attr values rejected.
+  """
+  fun name(): String => "cookie_validator/attr_value_boundary"
+
+  fun gen(): Generator[(String val, Bool)] =>
+    _CookieTestGenerators.attr_value_boundary()
+
+  fun ref property(arg1: (String val, Bool), ph: PropertyHelper) =>
+    (let s, let expect_valid) = arg1
+    let result = _CookieValidator.valid_attr_value(s)
+    ph.assert_eq[Bool](expect_valid, result,
+      "Attr value '" + s + "' expected " +
+        if expect_valid then "valid" else "invalid" end)
+
+primitive \nodoc\ _CookieTestGenerators
+  """Generators derived from the same character sets the validator uses."""
+
+  fun _token_chars(): String val =>
+    """RFC 2616 token characters: ASCII 33-126 minus separators."""
+    recover val
+      let s = String
+      var b: U8 = 33
+      while b <= 126 do
+        if _CookieValidator._is_token_char(b) then s.push(b) end
+        b = b + 1
+      end
+      s
+    end
+
+  fun _cookie_octets(): String val =>
+    """RFC 6265 cookie-octet characters."""
+    recover val
+      let s = String
+      var b: U8 = 0
+      while b < 255 do
+        if _CookieValidator._is_cookie_octet(b) then s.push(b) end
+        b = b + 1
+      end
+      if _CookieValidator._is_cookie_octet(255) then s.push(255) end
+      s
+    end
+
+  fun valid_name(): Generator[String val] =>
+    """Generate valid cookie names (1+ token chars)."""
+    let chars = _token_chars()
+    Generators.map2[USize, U64, String val](
+      Generators.usize(1, 20),
+      Generators.u64(),
+      {(len: USize, seed: U64)(chars): String val =>
+        recover val
+          let s = String(len)
+          var h: U64 = seed
+          for i in Range(0, len) do
+            h = (h * 6364136223846793005) + 1442695040888963407
+            try s.push(chars((h.usize() >> 16) % chars.size())?) end
+          end
+          s
+        end
+      })
+
+  fun invalid_name(): Generator[String val] =>
+    """Generate invalid cookie names containing at least one non-token char."""
+    Generators.frequency[String val]([
+      as WeightedGenerator[String val]:
+      // Empty string (always invalid)
+      (1, Generators.repeatedly[String val]({(): String val^ => ""}))
+      // Valid prefix + separator char + valid suffix
+      (3, Generators.map2[USize, USize, String val](
+        Generators.usize(0, 10),
+        Generators.usize(0, 10),
+        {(prefix_len: USize, suffix_len: USize): String val =>
+          recover val
+            let s = String
+            for i in Range(0, prefix_len) do s.push('a') end
+            s.push(' ') // space is a separator
+            for i in Range(0, suffix_len) do s.push('b') end
+            s
+          end
+        }))
+      // Contains control character
+      (1, Generators.map2[USize, USize, String val](
+        Generators.usize(0, 5),
+        Generators.usize(0, 5),
+        {(prefix_len: USize, suffix_len: USize): String val =>
+          recover val
+            let s = String
+            for i in Range(0, prefix_len) do s.push('x') end
+            s.push(0x01) // control character
+            for i in Range(0, suffix_len) do s.push('y') end
+            s
+          end
+        }))
+      // Contains comma
+      (1, Generators.repeatedly[String val](
+        {(): String val^ => "name,bad"}))
+      // Contains non-ASCII byte (0x80+)
+      (1, Generators.map2[USize, USize, String val](
+        Generators.usize(0, 5),
+        Generators.usize(0, 5),
+        {(prefix_len: USize, suffix_len: USize): String val =>
+          recover val
+            let s = String
+            for i in Range(0, prefix_len) do s.push('x') end
+            s.push(0x80)
+            for i in Range(0, suffix_len) do s.push('y') end
+            s
+          end
+        }))
+    ])
+
+  fun name_boundary(): Generator[(String val, Bool)] =>
+    """Mixed valid/invalid cookie names with expected validity."""
+    Generators.frequency[(String val, Bool)]([
+      as WeightedGenerator[(String val, Bool)]:
+      (1, valid_name().map[(String val, Bool)](
+        {(s: String val): (String val, Bool) => (s, true)}))
+      (1, invalid_name().map[(String val, Bool)](
+        {(s: String val): (String val, Bool) => (s, false)}))
+    ])
+
+  fun valid_value(): Generator[String val] =>
+    """Generate valid cookie values (0+ cookie-octets)."""
+    let chars = _cookie_octets()
+    Generators.map2[USize, U64, String val](
+      Generators.usize(0, 20),
+      Generators.u64(),
+      {(len: USize, seed: U64)(chars): String val =>
+        recover val
+          let s = String(len)
+          var h: U64 = seed
+          for i in Range(0, len) do
+            h = (h * 6364136223846793005) + 1442695040888963407
+            try s.push(chars((h.usize() >> 16) % chars.size())?) end
+          end
+          s
+        end
+      })
+
+  fun invalid_value(): Generator[String val] =>
+    """Generate invalid cookie values with at least one non-cookie-octet."""
+    Generators.frequency[String val]([
+      as WeightedGenerator[String val]:
+      // Contains space (0x20)
+      (2, Generators.map2[USize, USize, String val](
+        Generators.usize(0, 10),
+        Generators.usize(0, 10),
+        {(prefix_len: USize, suffix_len: USize): String val =>
+          recover val
+            let s = String
+            for i in Range(0, prefix_len) do s.push('a') end
+            s.push(' ')
+            for i in Range(0, suffix_len) do s.push('b') end
+            s
+          end
+        }))
+      // Contains double-quote (0x22)
+      (1, Generators.map2[USize, USize, String val](
+        Generators.usize(0, 10),
+        Generators.usize(0, 10),
+        {(prefix_len: USize, suffix_len: USize): String val =>
+          recover val
+            let s = String
+            for i in Range(0, prefix_len) do s.push('a') end
+            s.push('"')
+            for i in Range(0, suffix_len) do s.push('b') end
+            s
+          end
+        }))
+      // Contains comma (0x2C)
+      (1, Generators.repeatedly[String val](
+        {(): String val^ => "value,bad"}))
+      // Contains backslash (0x5C)
+      (1, Generators.repeatedly[String val](
+        {(): String val^ => "value\\bad"}))
+      // Contains control character
+      (1, Generators.map2[USize, USize, String val](
+        Generators.usize(0, 5),
+        Generators.usize(0, 5),
+        {(prefix_len: USize, suffix_len: USize): String val =>
+          recover val
+            let s = String
+            for i in Range(0, prefix_len) do s.push('x') end
+            s.push(0x01)
+            for i in Range(0, suffix_len) do s.push('y') end
+            s
+          end
+        }))
+      // Contains DEL (0x7F)
+      (1, Generators.repeatedly[String val](
+        {(): String val^ => "value\x7Fbad"}))
+      // Contains non-ASCII byte (0x80+)
+      (1, Generators.map2[USize, USize, String val](
+        Generators.usize(0, 5),
+        Generators.usize(0, 5),
+        {(prefix_len: USize, suffix_len: USize): String val =>
+          recover val
+            let s = String
+            for i in Range(0, prefix_len) do s.push('x') end
+            s.push(0x80)
+            for i in Range(0, suffix_len) do s.push('y') end
+            s
+          end
+        }))
+    ])
+
+  fun value_boundary(): Generator[(String val, Bool)] =>
+    """Mixed valid/invalid cookie values with expected validity."""
+    Generators.frequency[(String val, Bool)]([
+      as WeightedGenerator[(String val, Bool)]:
+      (1, valid_value().map[(String val, Bool)](
+        {(s: String val): (String val, Bool) => (s, true)}))
+      (1, invalid_value().map[(String val, Bool)](
+        {(s: String val): (String val, Bool) => (s, false)}))
+    ])
+
+  fun _attr_value_chars(): String val =>
+    """Valid attribute value characters: 0x20–0x7E minus semicolon."""
+    recover val
+      let s = String
+      var b: U8 = 0x20
+      while b <= 0x7E do
+        if b != ';' then s.push(b) end
+        b = b + 1
+      end
+      s
+    end
+
+  fun valid_attr_value(): Generator[String val] =>
+    """Generate valid attribute values (0+ safe chars, no CTLs or ';')."""
+    let chars = _attr_value_chars()
+    Generators.map2[USize, U64, String val](
+      Generators.usize(0, 30),
+      Generators.u64(),
+      {(len: USize, seed: U64)(chars): String val =>
+        recover val
+          let s = String(len)
+          var h: U64 = seed
+          for i in Range(0, len) do
+            h = (h * 6364136223846793005) + 1442695040888963407
+            try s.push(chars((h.usize() >> 16) % chars.size())?) end
+          end
+          s
+        end
+      })
+
+  fun invalid_attr_value(): Generator[String val] =>
+    """Generate invalid attribute values with a CTL, non-ASCII byte, or ';'."""
+    Generators.frequency[String val]([
+      as WeightedGenerator[String val]:
+      // Contains semicolon
+      (2, Generators.map2[USize, USize, String val](
+        Generators.usize(0, 10),
+        Generators.usize(0, 10),
+        {(prefix_len: USize, suffix_len: USize): String val =>
+          recover val
+            let s = String
+            for i in Range(0, prefix_len) do s.push('a') end
+            s.push(';')
+            for i in Range(0, suffix_len) do s.push('b') end
+            s
+          end
+        }))
+      // Contains control character
+      (1, Generators.map2[USize, USize, String val](
+        Generators.usize(0, 5),
+        Generators.usize(0, 5),
+        {(prefix_len: USize, suffix_len: USize): String val =>
+          recover val
+            let s = String
+            for i in Range(0, prefix_len) do s.push('x') end
+            s.push(0x01)
+            for i in Range(0, suffix_len) do s.push('y') end
+            s
+          end
+        }))
+      // Contains DEL (0x7F)
+      (1, Generators.map2[USize, USize, String val](
+        Generators.usize(0, 5),
+        Generators.usize(0, 5),
+        {(prefix_len: USize, suffix_len: USize): String val =>
+          recover val
+            let s = String
+            for i in Range(0, prefix_len) do s.push('x') end
+            s.push(0x7F)
+            for i in Range(0, suffix_len) do s.push('y') end
+            s
+          end
+        }))
+      // Contains CRLF
+      (1, Generators.repeatedly[String val](
+        {(): String val^ => "/path\r\nHeader: evil"}))
+      // Contains non-ASCII byte (0x80+)
+      (1, Generators.map2[USize, USize, String val](
+        Generators.usize(0, 5),
+        Generators.usize(0, 5),
+        {(prefix_len: USize, suffix_len: USize): String val =>
+          recover val
+            let s = String
+            for i in Range(0, prefix_len) do s.push('x') end
+            s.push(0x80)
+            for i in Range(0, suffix_len) do s.push('y') end
+            s
+          end
+        }))
+    ])
+
+  fun attr_value_boundary(): Generator[(String val, Bool)] =>
+    """Mixed valid/invalid attribute values with expected validity."""
+    Generators.frequency[(String val, Bool)]([
+      as WeightedGenerator[(String val, Bool)]:
+      (1, valid_attr_value().map[(String val, Bool)](
+        {(s: String val): (String val, Bool) => (s, true)}))
+      (1, invalid_attr_value().map[(String val, Bool)](
+        {(s: String val): (String val, Bool) => (s, false)}))
+    ])

--- a/stallion/_test_http_date.pony
+++ b/stallion/_test_http_date.pony
@@ -1,0 +1,70 @@
+use "pony_check"
+use "pony_test"
+
+class \nodoc\ iso _TestHTTPDateKnownGood is UnitTest
+  """
+  Verify exact output for known epoch values.
+  """
+  fun name(): String => "http_date/known_good"
+
+  fun apply(h: TestHelper) =>
+    // Epoch 0 = Thursday, 01 Jan 1970 00:00:00 GMT
+    h.assert_eq[String val](
+      "Thu, 01 Jan 1970 00:00:00 GMT",
+      _HTTPDate(0),
+      "epoch 0")
+
+    // Known RFC date: Mon, 01 Dec 2025 12:30:45 GMT
+    h.assert_eq[String val](
+      "Mon, 01 Dec 2025 12:30:45 GMT",
+      _HTTPDate(1764592245),
+      "2025-12-01 12:30:45")
+
+    // Leap year: Sat, 29 Feb 2020 00:00:00 GMT
+    // 2020-02-29 00:00:00 UTC = 1582934400
+    h.assert_eq[String val](
+      "Sat, 29 Feb 2020 00:00:00 GMT",
+      _HTTPDate(1582934400),
+      "leap year 2020-02-29")
+
+class \nodoc\ iso _PropertyHTTPDateFormat is Property1[I64]
+  """
+  Every formatted date has the correct structure:
+  3-char day, comma, space, 2-digit day, space, 3-char month, space,
+  4-digit year, space, HH:MM:SS, space, "GMT".
+  """
+  fun name(): String => "http_date/format_structure"
+
+  fun gen(): Generator[I64] =>
+    // Generate dates between 1970 and 2099
+    Generators.i64(0, 4_102_444_800)
+
+  fun ref property(arg1: I64, ph: PropertyHelper) =>
+    let result = _HTTPDate(arg1)
+
+    // Length should be 29 characters: "Thu, 01 Jan 1970 00:00:00 GMT"
+    ph.assert_eq[USize](29, result.size(),
+      "Expected 29 chars, got " + result.size().string() +
+        ": '" + result + "'")
+
+    // Ends with " GMT"
+    ph.assert_true(result.contains(" GMT"),
+      "Should end with GMT: " + result)
+
+    // Has comma at position 3
+    try
+      ph.assert_eq[U8](',', result(3)?,
+        "Position 3 should be comma: " + result)
+    else
+      ph.fail("Result too short: " + result)
+    end
+
+    // Has colons at positions 19 and 22 (time separators)
+    try
+      ph.assert_eq[U8](':', result(19)?,
+        "Position 19 should be colon: " + result)
+      ph.assert_eq[U8](':', result(22)?,
+        "Position 22 should be colon: " + result)
+    else
+      ph.fail("Result too short for time check: " + result)
+    end

--- a/stallion/_test_response_builder.pony
+++ b/stallion/_test_response_builder.pony
@@ -63,8 +63,8 @@ class \nodoc\ iso _PropertyBuilderMatchesSerializer
     // Build with ResponseBuilder
     var builder: ResponseHeadersBuilder =
       ResponseBuilder(status where version = version)
-    for (hdr_name, hdr_value) in headers.values() do
-      builder = builder.add_header(hdr_name, hdr_value)
+    for hdr in headers.values() do
+      builder = builder.add_header(hdr.name, hdr.value)
     end
     var body_builder: ResponseBodyBuilder = builder.finish_headers()
     match body

--- a/stallion/_test_server.pony
+++ b/stallion/_test_server.pony
@@ -1599,6 +1599,81 @@ class \nodoc\ iso _TestPipelinedBodies is UnitTest
     h.dispose_when_done(listener)
 
 // ---------------------------------------------------------------------------
+// Cookie parsing integration test
+// ---------------------------------------------------------------------------
+
+class \nodoc\ iso _TestServerCookieParsing is UnitTest
+  """
+  Send a request with a Cookie header, verify the server reads the cookies
+  from request'.cookies and includes the values in the response body.
+  """
+  fun name(): String => "server/cookie parsing"
+
+  fun apply(h: TestHelper) =>
+    h.long_test(5_000_000_000)
+    let port = "45910"
+    let host = ifdef linux then "127.0.0.2" else "localhost" end
+    let config = ServerConfig(host, port)
+    let listener = _TestServerListener(h, port,
+      _TestCookieServerFactory, config,
+      {(h': TestHelper, port': String) =>
+        let request: String val =
+          "GET / HTTP/1.1\r\nHost: localhost\r\n" +
+          "Cookie: session=abc123; theme=dark\r\n\r\n"
+        let client = _TestHTTPClient(h', port', request, "200 OK",
+          "session=abc123,theme=dark")
+        h'.dispose_when_done(client)
+      })
+    h.dispose_when_done(listener)
+
+class \nodoc\ val _TestCookieServerFactory is _TestConnectionFactory
+  fun apply(
+    auth: lori.TCPServerAuth,
+    fd: U32,
+    config: ServerConfig,
+    ssl_ctx: (ssl_net.SSLContext val | None)
+  ): lori.TCPConnectionActor =>
+    _TestCookieServer(auth, fd, config, ssl_ctx)
+
+actor \nodoc\ _TestCookieServer is HTTPServerActor
+  var _http: HTTPServer = HTTPServer.none()
+
+  new create(
+    auth: lori.TCPServerAuth,
+    fd: U32,
+    config: ServerConfig,
+    ssl_ctx: (ssl_net.SSLContext val | None))
+  =>
+    _http = match ssl_ctx
+    | let ctx: ssl_net.SSLContext val =>
+      HTTPServer.ssl(auth, ctx, fd, this, config)
+    else
+      HTTPServer(auth, fd, this, config)
+    end
+
+  fun ref _http_connection(): HTTPServer => _http
+
+  fun ref on_request_complete(request': Request val, responder: Responder) =>
+    // Build response body from parsed cookies
+    let session = match request'.cookies.get("session")
+    | let s: String val => s
+    else "missing"
+    end
+    let theme = match request'.cookies.get("theme")
+    | let s: String val => s
+    else "missing"
+    end
+    let resp_body: String val =
+      "session=" + session + ",theme=" + theme
+    let response = ResponseBuilder(StatusOK)
+      .add_header("Content-Type", "text/plain")
+      .add_header("Content-Length", resp_body.size().string())
+      .finish_headers()
+      .add_chunk(resp_body)
+      .build()
+    responder.respond(response)
+
+// ---------------------------------------------------------------------------
 // Pipelined bodies client: verifies each response has the correct body
 // ---------------------------------------------------------------------------
 

--- a/stallion/_test_set_cookie.pony
+++ b/stallion/_test_set_cookie.pony
@@ -1,0 +1,363 @@
+use "pony_check"
+use "pony_test"
+
+class \nodoc\ iso _TestSetCookieKnownGood is UnitTest
+  """
+  Verify exact output for known SetCookieBuilder configurations.
+  """
+  fun name(): String => "set_cookie/known_good"
+
+  fun apply(h: TestHelper) =>
+    _test_defaults(h)
+    _test_all_attributes(h)
+    _test_same_site_none(h)
+    _test_same_site_strict(h)
+    _test_no_secure(h)
+    _test_no_http_only(h)
+    _test_host_prefix(h)
+    _test_secure_prefix(h)
+    _test_omit_same_site(h)
+
+  fun _test_defaults(h: TestHelper) =>
+    match SetCookieBuilder("session", "abc123").build()
+    | let sc: SetCookie val =>
+      let hv = sc.header_value()
+      h.assert_true(hv.contains("session=abc123"), "defaults: name=value")
+      h.assert_true(hv.contains("Secure"), "defaults: Secure")
+      h.assert_true(hv.contains("HttpOnly"), "defaults: HttpOnly")
+      h.assert_true(hv.contains("SameSite=Lax"), "defaults: SameSite=Lax")
+    | let e: SetCookieBuildError =>
+      h.fail("defaults: unexpected error: " + e.string())
+    end
+
+  fun _test_all_attributes(h: TestHelper) =>
+    match SetCookieBuilder("id", "xyz")
+      .with_path("/app")
+      .with_domain("example.com")
+      .with_max_age(3600)
+      .with_expires(0)
+      .build()
+    | let sc: SetCookie val =>
+      let hv = sc.header_value()
+      h.assert_true(hv.contains("id=xyz"), "all: name=value")
+      h.assert_true(hv.contains("Path=/app"), "all: Path")
+      h.assert_true(hv.contains("Domain=example.com"), "all: Domain")
+      h.assert_true(hv.contains("Secure"), "all: Secure")
+      h.assert_true(hv.contains("HttpOnly"), "all: HttpOnly")
+      h.assert_true(hv.contains("SameSite=Lax"), "all: SameSite")
+      h.assert_true(hv.contains("Max-Age=3600"), "all: Max-Age")
+      h.assert_true(hv.contains("Expires=Thu, 01 Jan 1970 00:00:00 GMT"),
+        "all: Expires")
+      // Verify attribute order: name=value comes first
+      try
+        let nv_pos = hv.find("id=xyz")?
+        let path_pos = hv.find("Path=")?
+        let domain_pos = hv.find("Domain=")?
+        let secure_pos = hv.find("; Secure")?
+        let http_only_pos = hv.find("HttpOnly")?
+        let same_site_pos = hv.find("SameSite=")?
+        let max_age_pos = hv.find("Max-Age=")?
+        let expires_pos = hv.find("Expires=")?
+        h.assert_true(nv_pos < path_pos, "all: name=value before Path")
+        h.assert_true(path_pos < domain_pos, "all: Path before Domain")
+        h.assert_true(domain_pos < secure_pos, "all: Domain before Secure")
+        h.assert_true(secure_pos < http_only_pos,
+          "all: Secure before HttpOnly")
+        h.assert_true(http_only_pos < same_site_pos,
+          "all: HttpOnly before SameSite")
+        h.assert_true(same_site_pos < max_age_pos,
+          "all: SameSite before Max-Age")
+        h.assert_true(max_age_pos < expires_pos,
+          "all: Max-Age before Expires")
+      else
+        h.fail("all: could not find expected attributes in: " + hv)
+      end
+    | let e: SetCookieBuildError =>
+      h.fail("all: unexpected error: " + e.string())
+    end
+
+  fun _test_same_site_none(h: TestHelper) =>
+    match SetCookieBuilder("a", "b")
+      .with_same_site(SameSiteNone)
+      .build()
+    | let sc: SetCookie val =>
+      h.assert_true(sc.header_value().contains("SameSite=None"),
+        "SameSite=None")
+    | let e: SetCookieBuildError =>
+      h.fail("SameSite=None: unexpected error: " + e.string())
+    end
+
+  fun _test_same_site_strict(h: TestHelper) =>
+    match SetCookieBuilder("a", "b")
+      .with_same_site(SameSiteStrict)
+      .build()
+    | let sc: SetCookie val =>
+      h.assert_true(sc.header_value().contains("SameSite=Strict"),
+        "SameSite=Strict")
+    | let e: SetCookieBuildError =>
+      h.fail("SameSite=Strict: unexpected error: " + e.string())
+    end
+
+  fun _test_no_secure(h: TestHelper) =>
+    match SetCookieBuilder("a", "b")
+      .with_secure(false)
+      .with_same_site(SameSiteLax)
+      .build()
+    | let sc: SetCookie val =>
+      h.assert_false(sc.header_value().contains("Secure"),
+        "no secure: should not contain Secure")
+    | let e: SetCookieBuildError =>
+      h.fail("no secure: unexpected error: " + e.string())
+    end
+
+  fun _test_no_http_only(h: TestHelper) =>
+    match SetCookieBuilder("a", "b")
+      .with_http_only(false)
+      .build()
+    | let sc: SetCookie val =>
+      h.assert_false(sc.header_value().contains("HttpOnly"),
+        "no http_only: should not contain HttpOnly")
+    | let e: SetCookieBuildError =>
+      h.fail("no http_only: unexpected error: " + e.string())
+    end
+
+  fun _test_host_prefix(h: TestHelper) =>
+    // Valid __Host- usage
+    match SetCookieBuilder("__Host-session", "abc")
+      .with_path("/")
+      .build()
+    | let sc: SetCookie val =>
+      h.assert_true(sc.header_value().contains("__Host-session=abc"),
+        "__Host-: valid")
+    | let e: SetCookieBuildError =>
+      h.fail("__Host-: unexpected error: " + e.string())
+    end
+
+    // Invalid: __Host- with Domain
+    match SetCookieBuilder("__Host-session", "abc")
+      .with_path("/")
+      .with_domain("example.com")
+      .build()
+    | let sc: SetCookie val =>
+      h.fail("__Host- with Domain: expected CookiePrefixViolation")
+    | let e: CookiePrefixViolation => None // expected
+    | let e: SetCookieBuildError =>
+      h.fail("__Host- with Domain: expected CookiePrefixViolation, got "
+        + e.string())
+    end
+
+    // Invalid: __Host- without Path="/"
+    match SetCookieBuilder("__Host-session", "abc")
+      .with_path("/app")
+      .build()
+    | let sc: SetCookie val =>
+      h.fail("__Host- with Path=/app: expected CookiePrefixViolation")
+    | let e: CookiePrefixViolation => None
+    | let e: SetCookieBuildError =>
+      h.fail("__Host- with Path=/app: expected CookiePrefixViolation, got "
+        + e.string())
+    end
+
+    // Invalid: __Host- without Secure
+    match SetCookieBuilder("__Host-session", "abc")
+      .with_path("/")
+      .with_secure(false)
+      .build()
+    | let sc: SetCookie val =>
+      h.fail("__Host- without Secure: expected CookiePrefixViolation")
+    | let e: CookiePrefixViolation => None
+    | let e: SetCookieBuildError =>
+      h.fail("__Host- without Secure: expected CookiePrefixViolation, got "
+        + e.string())
+    end
+
+    // Invalid: __Host- without any Path set (defaults to None)
+    match SetCookieBuilder("__Host-session", "abc").build()
+    | let sc: SetCookie val =>
+      h.fail("__Host- no path: expected CookiePrefixViolation")
+    | let e: CookiePrefixViolation => None
+    | let e: SetCookieBuildError =>
+      h.fail("__Host- no path: expected CookiePrefixViolation, got "
+        + e.string())
+    end
+
+  fun _test_secure_prefix(h: TestHelper) =>
+    // Valid __Secure- usage
+    match SetCookieBuilder("__Secure-token", "xyz").build()
+    | let sc: SetCookie val =>
+      h.assert_true(sc.header_value().contains("__Secure-token=xyz"),
+        "__Secure-: valid")
+    | let e: SetCookieBuildError =>
+      h.fail("__Secure-: unexpected error: " + e.string())
+    end
+
+    // Invalid: __Secure- without Secure
+    match SetCookieBuilder("__Secure-token", "xyz")
+      .with_secure(false)
+      .with_same_site(SameSiteLax)
+      .build()
+    | let sc: SetCookie val =>
+      h.fail("__Secure- without Secure: expected CookiePrefixViolation")
+    | let e: CookiePrefixViolation => None
+    | let e: SetCookieBuildError =>
+      h.fail("__Secure- without Secure: expected CookiePrefixViolation, got "
+        + e.string())
+    end
+
+  fun _test_omit_same_site(h: TestHelper) =>
+    match SetCookieBuilder("a", "b")
+      .with_same_site(None)
+      .build()
+    | let sc: SetCookie val =>
+      h.assert_false(sc.header_value().contains("SameSite"),
+        "omit SameSite: should not contain SameSite")
+    | let e: SetCookieBuildError =>
+      h.fail("omit SameSite: unexpected error: " + e.string())
+    end
+
+class \nodoc\ iso _TestSetCookieErrors is UnitTest
+  """
+  Verify that invalid inputs produce the correct error types.
+  """
+  fun name(): String => "set_cookie/errors"
+
+  fun apply(h: TestHelper) =>
+    // Invalid name (contains space)
+    match SetCookieBuilder("bad name", "ok").build()
+    | let _: InvalidCookieName => None // expected
+    | let sc: SetCookie val => h.fail("invalid name: expected error")
+    | let e: SetCookieBuildError =>
+      h.fail("invalid name: expected InvalidCookieName, got " + e.string())
+    end
+
+    // Invalid value (contains space)
+    match SetCookieBuilder("ok", "bad value").build()
+    | let _: InvalidCookieValue => None // expected
+    | let sc: SetCookie val => h.fail("invalid value: expected error")
+    | let e: SetCookieBuildError =>
+      h.fail("invalid value: expected InvalidCookieValue, got " + e.string())
+    end
+
+    // Invalid path (semicolon injection)
+    match SetCookieBuilder("ok", "ok")
+      .with_path("/; Domain=.evil.com")
+      .build()
+    | let _: InvalidCookiePath => None // expected
+    | let sc: SetCookie val => h.fail("invalid path: expected error")
+    | let e: SetCookieBuildError =>
+      h.fail("invalid path: expected InvalidCookiePath, got " + e.string())
+    end
+
+    // Invalid path (CRLF injection)
+    match SetCookieBuilder("ok", "ok")
+      .with_path("/\r\nEvil-Header: value")
+      .build()
+    | let _: InvalidCookiePath => None // expected
+    | let sc: SetCookie val => h.fail("invalid path CRLF: expected error")
+    | let e: SetCookieBuildError =>
+      h.fail("invalid path CRLF: expected InvalidCookiePath, got "
+        + e.string())
+    end
+
+    // Invalid domain (semicolon injection)
+    match SetCookieBuilder("ok", "ok")
+      .with_domain("evil.com; Path=/")
+      .build()
+    | let _: InvalidCookieDomain => None // expected
+    | let sc: SetCookie val => h.fail("invalid domain: expected error")
+    | let e: SetCookieBuildError =>
+      h.fail("invalid domain: expected InvalidCookieDomain, got "
+        + e.string())
+    end
+
+    // Invalid domain (control character)
+    match SetCookieBuilder("ok", "ok")
+      .with_domain("evil.com\x01")
+      .build()
+    | let _: InvalidCookieDomain => None // expected
+    | let sc: SetCookie val => h.fail("invalid domain CTL: expected error")
+    | let e: SetCookieBuildError =>
+      h.fail("invalid domain CTL: expected InvalidCookieDomain, got "
+        + e.string())
+    end
+
+    // SameSite=None without Secure
+    match SetCookieBuilder("a", "b")
+      .with_secure(false)
+      .with_same_site(SameSiteNone)
+      .build()
+    | let _: SameSiteRequiresSecure => None // expected
+    | let sc: SetCookie val =>
+      h.fail("SameSite=None no Secure: expected error")
+    | let e: SetCookieBuildError =>
+      h.fail("SameSite=None no Secure: expected SameSiteRequiresSecure, got "
+        + e.string())
+    end
+
+class \nodoc\ iso _PropertySetCookieValidBuild
+  is Property1[(String val, String val)]
+  """
+  Valid names and values always build successfully.
+  """
+  fun name(): String => "set_cookie/valid_build"
+
+  fun gen(): Generator[(String val, String val)] =>
+    Generators.zip2[String val, String val](
+      _CookieTestGenerators.valid_name(),
+      _CookieTestGenerators.valid_value())
+
+  fun ref property(
+    arg1: (String val, String val),
+    ph: PropertyHelper)
+  =>
+    (let n, let v) = arg1
+    match SetCookieBuilder(n, v).build()
+    | let sc: SetCookie val =>
+      ph.assert_eq[String val](n, sc.name, "name matches")
+      ph.assert_eq[String val](v, sc.value, "value matches")
+      ph.assert_true(sc.header_value().contains(n + "=" + v),
+        "header_value contains name=value")
+    | let e: SetCookieBuildError =>
+      ph.fail("Expected success for '" + n + "'='" + v +
+        "', got: " + e.string())
+    end
+
+class \nodoc\ iso _PropertySetCookieInvalidNameErrors
+  is Property1[String val]
+  """
+  Invalid names always produce InvalidCookieName.
+  """
+  fun name(): String => "set_cookie/invalid_name_errors"
+
+  fun gen(): Generator[String val] =>
+    _CookieTestGenerators.invalid_name()
+
+  fun ref property(arg1: String val, ph: PropertyHelper) =>
+    match SetCookieBuilder(arg1, "ok").build()
+    | let _: InvalidCookieName => None // expected
+    | let sc: SetCookie val =>
+      ph.fail("Expected InvalidCookieName for '" + arg1 + "', got success")
+    | let e: SetCookieBuildError =>
+      ph.fail("Expected InvalidCookieName for '" + arg1 +
+        "', got: " + e.string())
+    end
+
+class \nodoc\ iso _PropertySetCookieInvalidValueErrors
+  is Property1[String val]
+  """
+  Invalid values always produce InvalidCookieValue.
+  """
+  fun name(): String => "set_cookie/invalid_value_errors"
+
+  fun gen(): Generator[String val] =>
+    _CookieTestGenerators.invalid_value()
+
+  fun ref property(arg1: String val, ph: PropertyHelper) =>
+    match SetCookieBuilder("validname", arg1).build()
+    | let _: InvalidCookieValue => None // expected
+    | let sc: SetCookie val =>
+      ph.fail("Expected InvalidCookieValue for '" + arg1 + "', got success")
+    | let e: SetCookieBuildError =>
+      ph.fail("Expected InvalidCookieValue for '" + arg1 +
+        "', got: " + e.string())
+    end

--- a/stallion/header.pony
+++ b/stallion/header.pony
@@ -1,0 +1,14 @@
+class val Header
+  """
+  A single HTTP header name-value pair.
+
+  Used by `Headers.values()` to iterate over header entries. Names are
+  lowercased by `Headers` on storage, so `name` will always be lowercase.
+  """
+  let name: String val
+  let value: String val
+
+  new val create(name': String val, value': String val) =>
+    """Create a header with the given name and value."""
+    name = name'
+    value = value'

--- a/stallion/headers.pony
+++ b/stallion/headers.pony
@@ -6,11 +6,11 @@ class Headers
   name, or `add()` to append an additional value (appropriate for multi-value
   headers like Set-Cookie).
   """
-  embed _headers: Array[(String, String)]
+  embed _headers: Array[Header val]
 
   new create() =>
     """Create an empty header collection."""
-    _headers = Array[(String, String)]
+    _headers = Array[Header val]
 
   fun ref set(name: String, value: String) =>
     """
@@ -23,7 +23,7 @@ class Headers
     var i: USize = 0
     while i < _headers.size() do
       try
-        if _headers(i)?._1 == lower_name then
+        if _headers(i)?.name == lower_name then
           _headers.delete(i)?
         else
           i = i + 1
@@ -32,7 +32,7 @@ class Headers
         i = i + 1
       end
     end
-    _headers.push((lower_name, value))
+    _headers.push(Header(lower_name, value))
 
   fun ref add(name: String, value: String) =>
     """
@@ -41,7 +41,7 @@ class Headers
     This is appropriate for headers that can appear multiple times
     (e.g., Set-Cookie). Use `set()` when you want to replace.
     """
-    _headers.push((name.lower(), value))
+    _headers.push(Header(name.lower(), value))
 
   fun get(name: String): (String | None) =>
     """
@@ -50,8 +50,8 @@ class Headers
     Returns `None` if no header with that name exists.
     """
     let lower_name: String val = name.lower()
-    for (n, v) in _headers.values() do
-      if n == lower_name then return v end
+    for hdr in _headers.values() do
+      if hdr.name == lower_name then return hdr.value end
     end
     None
 
@@ -59,6 +59,6 @@ class Headers
     """Return the number of header entries."""
     _headers.size()
 
-  fun values(): ArrayValues[(String, String), this->Array[(String, String)]] =>
-    """Iterate over all header entries as (name, value) pairs."""
+  fun values(): ArrayValues[Header val, this->Array[Header val]] =>
+    """Iterate over all header entries as `Header val` objects."""
     _headers.values()

--- a/stallion/http_server.pony
+++ b/stallion/http_server.pony
@@ -170,7 +170,8 @@ class HTTPServer is
       end
 
     let keep_alive = _KeepAliveDecision(version, headers.get("connection"))
-    let req = Request(method, parsed_uri, version, headers)
+    let cookies = ParseCookies.from_headers(headers)
+    let req = Request(method, parsed_uri, version, headers, cookies)
     _current_request = req
     match _queue
     | let q: _ResponseQueue =>

--- a/stallion/parse_cookies.pony
+++ b/stallion/parse_cookies.pony
@@ -1,0 +1,118 @@
+primitive ParseCookies
+  """
+  Parse cookies from HTTP request headers.
+
+  Implements lenient parsing per RFC 6265 §5.4: splits on `;`, uses the
+  first `=` as the name-value delimiter, trims whitespace, strips surrounding
+  double quotes from values, and skips entries with empty names or missing `=`.
+
+  This is a total function — it never errors. Malformed cookie strings produce
+  an empty or partial `RequestCookies` collection rather than an error.
+
+  Two entry points:
+
+  * `from_headers()` — extracts and parses all `Cookie` headers from a
+    `Headers val` collection. This is what `HTTPServer` uses internally.
+  * `apply()` — parses a single `Cookie` header value string. Useful for
+    testing or when you already have the raw header value.
+  """
+
+  fun from_headers(headers: Headers val): RequestCookies val =>
+    """
+    Parse all `Cookie` headers from the given header collection.
+
+    Multiple `Cookie` headers are concatenated per RFC 6265 §5.4.
+    """
+    let cookies: Array[RequestCookie val] val = recover val
+      let arr = Array[RequestCookie val]
+      for hdr in headers.values() do
+        if hdr.name == "cookie" then
+          _parse_into(hdr.value, arr)
+        end
+      end
+      arr
+    end
+    RequestCookies._create(cookies)
+
+  fun apply(header_value: String val): RequestCookies val =>
+    """Parse a single `Cookie` header value string."""
+    let cookies: Array[RequestCookie val] val = recover val
+      let arr = Array[RequestCookie val]
+      _parse_into(header_value, arr)
+      arr
+    end
+    RequestCookies._create(cookies)
+
+  fun _parse_into(
+    header_value: String val,
+    cookies: Array[RequestCookie val] ref)
+  =>
+    """Parse cookie pairs from a header value and append to the array."""
+    // Split on ";"
+    var start: USize = 0
+    let size = header_value.size()
+
+    while start < size do
+      // Find next ";"
+      var semi: USize = start
+      while (semi < size) and try header_value(semi)? != ';' else false end do
+        semi = semi + 1
+      end
+
+      // Extract the segment and trim whitespace
+      let segment = header_value.trim(start, semi)
+      let trimmed = _trim_whitespace(segment)
+
+      if trimmed.size() > 0 then
+        // Find first "="
+        var eq: USize = 0
+        let tsize = trimmed.size()
+        while (eq < tsize) and
+          try trimmed(eq)? != '=' else false end
+        do
+          eq = eq + 1
+        end
+
+        if eq < tsize then
+          let name = _trim_whitespace(trimmed.trim(0, eq))
+          var value = _trim_whitespace(trimmed.trim(eq + 1))
+
+          // Strip surrounding double quotes
+          if (value.size() >= 2) and
+            try (value(0)? == '"') and
+              (value(value.size() - 1)? == '"')
+            else false end
+          then
+            value = value.trim(1, value.size() - 1)
+          end
+
+          if name.size() > 0 then
+            cookies.push(RequestCookie._create(name, value))
+          end
+        end
+      end
+
+      start = semi + 1
+    end
+
+  fun _trim_whitespace(s: String val): String val =>
+    """Trim leading and trailing spaces and tabs."""
+    var first: USize = 0
+    var last: USize = s.size()
+    while (first < last) and
+      try
+        let b = s(first)?
+        (b == ' ') or (b == '\t')
+      else false end
+    do
+      first = first + 1
+    end
+    while (last > first) and
+      try
+        let b = s(last - 1)?
+        (b == ' ') or (b == '\t')
+      else false end
+    do
+      last = last - 1
+    end
+    s.trim(first, last)

--- a/stallion/request.pony
+++ b/stallion/request.pony
@@ -5,9 +5,13 @@ class val Request
   Immutable bundle of HTTP request metadata delivered to the server actor.
 
   Constructed by `HTTPServer` after parsing the request line, headers,
-  and URI. Delivered to the actor via the
+  URI, and cookies. Delivered to the actor via the
   `HTTPServerLifecycleEventReceiver.on_request()` callback, making it easy to
   pass request metadata to helper functions or store it for later use.
+
+  Cookies are automatically parsed from `Cookie` request headers during
+  construction. Access them via `request'.cookies.get("name")` or iterate
+  with `request'.cookies.values()`.
 
   All components are pre-validated before construction: the method is a known
   HTTP method, the URI is a parsed RFC 3986 structure, and the version is
@@ -18,14 +22,17 @@ class val Request
   let uri: URI val
   let version: Version
   let headers: Headers val
+  let cookies: RequestCookies val
 
   new val create(
     method': Method,
     uri': URI val,
     version': Version,
-    headers': Headers val)
+    headers': Headers val,
+    cookies': RequestCookies val)
   =>
     method = method'
     uri = uri'
     version = version'
     headers = headers'
+    cookies = cookies'

--- a/stallion/request_cookie.pony
+++ b/stallion/request_cookie.pony
@@ -1,0 +1,15 @@
+class val RequestCookie
+  """
+  A single name-value pair parsed from a `Cookie` request header.
+
+  Created internally by `ParseCookies`. Use `RequestCookies.values()` to
+  iterate over parsed cookies, or `RequestCookies.get()` to look up a
+  cookie by name.
+  """
+  let name: String val
+  let value: String val
+
+  new val _create(name': String val, value': String val) =>
+    """Create a request cookie. Package-private."""
+    name = name'
+    value = value'

--- a/stallion/request_cookies.pony
+++ b/stallion/request_cookies.pony
@@ -1,0 +1,36 @@
+class val RequestCookies
+  """
+  An immutable collection of cookies parsed from request `Cookie` headers.
+
+  Use `get()` to look up a cookie value by name (case-sensitive, returns
+  the first match) or `values()` to iterate over all parsed cookies.
+
+  Created by `ParseCookies` — application code does not construct this
+  directly.
+  """
+  let _cookies: Array[RequestCookie val] val
+
+  new val _create(cookies: Array[RequestCookie val] val) =>
+    """Create a cookie collection. Package-private."""
+    _cookies = cookies
+
+  fun get(name: String): (String val | None) =>
+    """
+    Get the value of the first cookie with the given name (case-sensitive).
+
+    Returns `None` if no cookie with that name exists.
+    """
+    for cookie in _cookies.values() do
+      if cookie.name == name then return cookie.value end
+    end
+    None
+
+  fun values(): ArrayValues[RequestCookie val,
+    Array[RequestCookie val] val]
+  =>
+    """Iterate over all parsed cookies."""
+    _cookies.values()
+
+  fun size(): USize =>
+    """Return the number of parsed cookies."""
+    _cookies.size()

--- a/stallion/responder.pony
+++ b/stallion/responder.pony
@@ -111,8 +111,8 @@ class ref Responder
         let new_h = Headers
         match headers
         | let existing: Headers val =>
-          for (name, value) in existing.values() do
-            new_h.set(name, value)
+          for hdr in existing.values() do
+            new_h.set(hdr.name, hdr.value)
           end
         end
         new_h.set("Transfer-Encoding", "chunked")

--- a/stallion/same_site.pony
+++ b/stallion/same_site.pony
@@ -1,0 +1,16 @@
+interface val _SameSite is Stringable
+
+primitive SameSiteStrict is _SameSite
+  """The cookie is only sent with same-site requests."""
+  fun string(): String iso^ => "Strict".clone()
+
+primitive SameSiteLax is _SameSite
+  """The cookie is sent with same-site requests and top-level navigations."""
+  fun string(): String iso^ => "Lax".clone()
+
+primitive SameSiteNone is _SameSite
+  """The cookie is sent with all requests. Requires `Secure`."""
+  fun string(): String iso^ => "None".clone()
+
+// The SameSite attribute for Set-Cookie headers.
+type SameSite is ((SameSiteStrict | SameSiteLax | SameSiteNone) & _SameSite)

--- a/stallion/set_cookie.pony
+++ b/stallion/set_cookie.pony
@@ -1,0 +1,30 @@
+class val SetCookie
+  """
+  A validated, pre-serialized `Set-Cookie` response header.
+
+  Created by `SetCookieBuilder.build()`. The `header_value()` method returns
+  the complete header value string ready to be added to a response via
+  `ResponseBuilder.add_header("Set-Cookie", set_cookie.header_value())`.
+  """
+  let name: String val
+  let value: String val
+  let _header_value: String val
+
+  new val _create(
+    name': String val,
+    value': String val,
+    header_value': String val)
+  =>
+    """Create a set-cookie. Package-private."""
+    name = name'
+    value = value'
+    _header_value = header_value'
+
+  fun header_value(): String val =>
+    """
+    Return the pre-serialized `Set-Cookie` header value.
+
+    This is the complete string to use as the value of a `Set-Cookie`
+    header, including all attributes.
+    """
+    _header_value

--- a/stallion/set_cookie_build_error.pony
+++ b/stallion/set_cookie_build_error.pony
@@ -1,0 +1,34 @@
+interface val _SetCookieBuildError is Stringable
+
+primitive InvalidCookieName is _SetCookieBuildError
+  """Cookie name contains invalid characters (not an RFC 2616 token)."""
+  fun string(): String iso^ => "InvalidCookieName".clone()
+
+primitive InvalidCookieValue is _SetCookieBuildError
+  """Cookie value contains invalid characters (not RFC 6265 cookie-octets)."""
+  fun string(): String iso^ => "InvalidCookieValue".clone()
+
+primitive CookiePrefixViolation is _SetCookieBuildError
+  """
+  Cookie uses a `__Host-` or `__Secure-` prefix without meeting the required
+  constraints (Secure flag, Path, Domain restrictions).
+  """
+  fun string(): String iso^ => "CookiePrefixViolation".clone()
+
+primitive InvalidCookiePath is _SetCookieBuildError
+  """Cookie path contains invalid characters (CTLs or semicolons)."""
+  fun string(): String iso^ => "InvalidCookiePath".clone()
+
+primitive InvalidCookieDomain is _SetCookieBuildError
+  """Cookie domain contains invalid characters (CTLs or semicolons)."""
+  fun string(): String iso^ => "InvalidCookieDomain".clone()
+
+primitive SameSiteRequiresSecure is _SetCookieBuildError
+  """`SameSite=None` requires the `Secure` attribute."""
+  fun string(): String iso^ => "SameSiteRequiresSecure".clone()
+
+// SetCookieBuildError union type alias.
+type SetCookieBuildError is
+  ((InvalidCookieName | InvalidCookieValue | InvalidCookiePath
+  | InvalidCookieDomain | CookiePrefixViolation
+  | SameSiteRequiresSecure) & _SetCookieBuildError)

--- a/stallion/set_cookie_builder.pony
+++ b/stallion/set_cookie_builder.pony
@@ -1,0 +1,185 @@
+class ref SetCookieBuilder
+  """
+  Build a validated `Set-Cookie` response header with secure defaults.
+
+  Defaults: `Secure=true`, `HttpOnly=true`, `SameSite=Lax`. These defaults
+  follow current security best practices — override them explicitly when
+  needed.
+
+  All `with_*` methods return `this` for chaining:
+
+  ```pony
+  match SetCookieBuilder("session", token)
+    .with_path("/")
+    .with_max_age(3600)
+    .build()
+  | let sc: SetCookie val =>
+    // Use sc.header_value() with ResponseBuilder
+  | let err: SetCookieBuildError =>
+    // Handle validation error
+  end
+  ```
+
+  `build()` validates the name, value, path, and domain, checks prefix rules
+  (`__Host-`, `__Secure-`), and verifies `SameSite=None` + `Secure` consistency.
+  Returns `SetCookie val` on success or `SetCookieBuildError` on failure.
+  """
+  let _name: String val
+  let _value: String val
+  var _path: (String val | None) = None
+  var _domain: (String val | None) = None
+  var _max_age: (I64 | None) = None
+  var _expires: (I64 | None) = None
+  var _secure: Bool = true
+  var _http_only: Bool = true
+  var _same_site: (SameSite | None) = SameSiteLax
+
+  new create(name: String val, value: String val) =>
+    """
+    Create a builder for a `Set-Cookie` header with the given name and value.
+
+    Defaults to `Secure`, `HttpOnly`, and `SameSite=Lax`.
+    """
+    _name = name
+    _value = value
+
+  fun ref with_path(path: String val): SetCookieBuilder ref =>
+    """Set the `Path` attribute."""
+    _path = path
+    this
+
+  fun ref with_domain(domain: String val): SetCookieBuilder ref =>
+    """Set the `Domain` attribute."""
+    _domain = domain
+    this
+
+  fun ref with_max_age(seconds: I64): SetCookieBuilder ref =>
+    """Set the `Max-Age` attribute in seconds."""
+    _max_age = seconds
+    this
+
+  fun ref with_expires(epoch_seconds: I64): SetCookieBuilder ref =>
+    """Set the `Expires` attribute from epoch seconds."""
+    _expires = epoch_seconds
+    this
+
+  fun ref with_secure(secure': Bool = true): SetCookieBuilder ref =>
+    """Set or clear the `Secure` attribute."""
+    _secure = secure'
+    this
+
+  fun ref with_http_only(http_only': Bool = true): SetCookieBuilder ref =>
+    """Set or clear the `HttpOnly` attribute."""
+    _http_only = http_only'
+    this
+
+  fun ref with_same_site(same_site: (SameSite | None)): SetCookieBuilder ref =>
+    """
+    Set the `SameSite` attribute.
+
+    Pass a `SameSite` value to emit the attribute, or Pony's `None` to omit
+    it entirely. Note that `SameSiteNone` emits `SameSite=None` (which
+    requires `Secure`), while Pony's `None` omits the attribute.
+    """
+    _same_site = same_site
+    this
+
+  fun build(): (SetCookie val | SetCookieBuildError) =>
+    """
+    Validate and serialize the `Set-Cookie` header.
+
+    Returns `SetCookie val` on success. Returns a `SetCookieBuildError`
+    describing the first validation failure:
+    - `InvalidCookieName` — name is not an RFC 2616 token
+    - `InvalidCookieValue` — value contains non-cookie-octets
+    - `InvalidCookiePath` — path contains CTLs or semicolons
+    - `InvalidCookieDomain` — domain contains CTLs or semicolons
+    - `CookiePrefixViolation` — `__Host-`/`__Secure-` prefix constraints
+      not met
+    - `SameSiteRequiresSecure` — `SameSite=None` without `Secure`
+    """
+    // Validate name
+    if not _CookieValidator.valid_name(_name) then
+      return InvalidCookieName
+    end
+
+    // Validate value
+    if not _CookieValidator.valid_value(_value) then
+      return InvalidCookieValue
+    end
+
+    // Validate path (no CTLs or semicolons per RFC 6265 §4.1.1)
+    match _path
+    | let p: String =>
+      if not _CookieValidator.valid_attr_value(p) then
+        return InvalidCookiePath
+      end
+    end
+
+    // Validate domain (no CTLs or semicolons)
+    match _domain
+    | let d: String =>
+      if not _CookieValidator.valid_attr_value(d) then
+        return InvalidCookieDomain
+      end
+    end
+
+    // Prefix rules
+    if _name.compare_sub("__Host-", 7) is Equal then
+      // __Host- requires: Secure, Path="/", no Domain
+      if (not _secure)
+        or (match _path | let p: String => p != "/" else true end)
+        or (_domain isnt None)
+      then
+        return CookiePrefixViolation
+      end
+    elseif _name.compare_sub("__Secure-", 9) is Equal then
+      // __Secure- requires: Secure
+      if not _secure then
+        return CookiePrefixViolation
+      end
+    end
+
+    // SameSite=None requires Secure
+    match _same_site
+    | let _: SameSiteNone =>
+      if not _secure then return SameSiteRequiresSecure end
+    end
+
+    // Serialize in fixed order:
+    // name=value[; Path=...][; Domain=...][; Secure][; HttpOnly]
+    //   [; SameSite=...][; Max-Age=...][; Expires=...]
+    let header_value = recover val
+      let buf = String
+      buf.>append(_name)
+        .>push('=')
+        .>append(_value)
+
+      match _path
+      | let p: String => buf.>append("; Path=").>append(p)
+      end
+
+      match _domain
+      | let d: String => buf.>append("; Domain=").>append(d)
+      end
+
+      if _secure then buf.append("; Secure") end
+      if _http_only then buf.append("; HttpOnly") end
+
+      match _same_site
+      | let ss: SameSite =>
+        buf.>append("; SameSite=").>append(ss.string())
+      end
+
+      match _max_age
+      | let ma: I64 => buf.>append("; Max-Age=").>append(ma.string())
+      end
+
+      match _expires
+      | let e: I64 => buf.>append("; Expires=").>append(_HTTPDate(e))
+      end
+
+      buf
+    end
+
+    SetCookie._create(_name, _value, header_value)

--- a/stallion/stallion.pony
+++ b/stallion/stallion.pony
@@ -122,4 +122,39 @@ The actor explicitly chooses `stallion.HTTPServer` (plain HTTP) or
 the HTTPS example would use
 `stallion.HTTPServer.ssl(auth, ssl_ctx, fd, this, config)` instead of
 `stallion.HTTPServer(auth, fd, this, config)`.
+
+Cookies are automatically parsed from `Cookie` request headers and available
+via `request'.cookies`. Use `stallion.ParseCookies` for direct parsing, and
+`stallion.SetCookieBuilder` to construct validated `Set-Cookie` response headers
+with secure defaults:
+
+```pony
+fun ref on_request_complete(request': stallion.Request val,
+  responder: stallion.Responder)
+=>
+  // Read a cookie from the request
+  let session = match request'.cookies.get("session")
+  | let s: String val => s
+  else "anonymous"
+  end
+
+  // Build a Set-Cookie header (defaults: Secure, HttpOnly, SameSite=Lax)
+  match stallion.SetCookieBuilder("session", "new-token")
+    .with_path("/")
+    .with_max_age(3600)
+    .build()
+  | let sc: stallion.SetCookie val =>
+    let body: String val = "Hello, " + session + "!"
+    let response = stallion.ResponseBuilder(stallion.StatusOK)
+      .add_header("Content-Length", body.size().string())
+      .add_header("Set-Cookie", sc.header_value())
+      .finish_headers()
+      .add_chunk(body)
+      .build()
+    responder.respond(response)
+  | let err: stallion.SetCookieBuildError =>
+    // Handle validation error
+    None
+  end
+```
 """


### PR DESCRIPTION
Stallion users can now read cookies from requests and build validated Set-Cookie response headers without pulling in a web framework.

Request cookies are automatically parsed from Cookie headers and available via `request'.cookies.get("name")` or `.values()`. `ParseCookies` provides direct parsing for use outside the request lifecycle.

`SetCookieBuilder` constructs Set-Cookie headers with secure defaults (Secure, HttpOnly, SameSite=Lax). It validates names (RFC 2616 token), values (RFC 6265 cookie-octets), `__Host-`/`__Secure-` prefix rules, and SameSite=None + Secure consistency, returning typed errors on failure.

`Headers.values()` now yields `Header val` objects instead of `(String, String)` tuples — a breaking change for code that destructures header values.

Design: #74