### PR TITLE
Add content negotiation

### DIFF
--- a/.release-notes/add-content-negotiation.md
+++ b/.release-notes/add-content-negotiation.md
@@ -1,0 +1,24 @@
+## Add content negotiation
+
+Stallion now provides opt-in content negotiation for selecting a response content type based on the client's `Accept` header (RFC 7231 §5.3.2). This is useful for endpoints that support multiple formats — most endpoints serve a single content type and don't need this.
+
+Use `ContentNegotiation.from_request()` to negotiate against a list of supported media types:
+
+```pony
+let supported = [as stallion.MediaType val:
+  stallion.MediaType("application", "json")
+  stallion.MediaType("text", "plain")
+]
+match stallion.ContentNegotiation.from_request(request', supported)
+| let mt: stallion.MediaType val =>
+  // Respond with the negotiated type (mt.string() gives "application/json" etc.)
+| stallion.NoAcceptableType =>
+  // Respond with 406 Not Acceptable
+end
+```
+
+The algorithm follows RFC 7231 precedence rules: exact types beat wildcards, higher quality values win, ties go to the first type in the server's supported list, and `q=0` explicitly excludes a type. An absent `Accept` header means "accept anything" — the first supported type is returned.
+
+`ContentNegotiation.apply()` accepts a raw Accept header value string directly, for testing or when you already have the header value.
+
+New types: `MediaType`, `NoAcceptableType`, `ContentNegotiationResult`, `ContentNegotiation`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,12 +89,20 @@ Follow the standard ponylang release notes conventions. Create individual `.md` 
   - `set_cookie_builder.pony` — `Set-Cookie` header builder (`SetCookieBuilder ref`, secure defaults, chaining, prefix rules)
   - `_cookie_validator.pony` — Cookie name/value/attribute validation (RFC 2616 token, RFC 6265 cookie-octet, path/domain safety)
   - `_http_date.pony` — IMF-fixdate formatter for `Expires` attribute (`_HTTPDate` primitive)
+  - `media_type.pony` — HTTP media type (`MediaType val` class, `Equatable & Stringable`)
+  - `no_acceptable_type.pony` — Content negotiation failure (`NoAcceptableType` primitive)
+  - `content_negotiation_result.pony` — Result type alias (`MediaType val | NoAcceptableType`)
+  - `_quality.pony` — Constrained quality factor 0–1000 (`_Quality`, `_MakeQuality`, `_QualityValidator`)
+  - `_accept_range.pony` — Parsed Accept header media range (`_AcceptRange val`, specificity scoring)
+  - `_accept_parser.pony` — Accept header parser (`_AcceptParser` primitive, lenient, quoted-string-aware)
+  - `content_negotiation.pony` — Content negotiation (`ContentNegotiation` primitive: `from_request()`, `apply()`, RFC 7231 §5.3.2)
 - `assets/` — test assets
   - `cert.pem` — Self-signed test certificate for SSL examples
   - `key.pem` — Test private key for SSL examples
 - `examples/` — example programs
   - `cookies/main.pony` — Visit counter demonstrating `Request.cookies` and `SetCookieBuilder`
   - `hello/main.pony` — Greeting server with URI parsing and query parameter extraction
+  - `negotiate/main.pony` — Content negotiation server responding with JSON or plain text based on Accept header
   - `ssl/main.pony` — HTTPS server using SSL/TLS
   - `streaming/main.pony` — Flow-controlled chunked transfer encoding streaming response using `on_chunk_sent()` callbacks
   - `yield/main.pony` — Scheduler fairness via `HTTPServer.yield_read()` with a request-count-based yield policy

--- a/examples/README.md
+++ b/examples/README.md
@@ -10,6 +10,10 @@ Greeting server that responds with "Hello, World!" by default, or "Hello, {name}
 
 Visit counter that reads the `visits` cookie from incoming requests, increments it, and sets it back via `Set-Cookie`. Demonstrates both `Request.cookies` for reading cookies parsed from request headers and `SetCookieBuilder` for building validated `Set-Cookie` response headers with secure defaults.
 
+## [negotiate](negotiate/)
+
+Content negotiation server that responds with JSON or plain text based on the client's `Accept` header. Returns 406 Not Acceptable when the client doesn't accept either format. Demonstrates `ContentNegotiation.from_request()` for selecting a response content type and matching on `ContentNegotiationResult`.
+
 ## [ssl](ssl/)
 
 HTTPS server using SSL/TLS. Demonstrates creating an `SSLContext`, loading certificate and key files, and passing the context to connection actors via `_on_accept`. Actors use `HTTPServer.ssl` instead of `HTTPServer` to create an HTTPS connection.

--- a/examples/negotiate/main.pony
+++ b/examples/negotiate/main.pony
@@ -1,0 +1,112 @@
+"""
+Content negotiation server that responds with JSON or plain text based on
+the client's `Accept` header. Returns 406 Not Acceptable when the client
+doesn't accept either format.
+
+Demonstrates `ContentNegotiation.from_request()` for selecting a response
+content type, and matching on `ContentNegotiationResult` to handle both
+the matched type and the no-match case.
+
+Try it:
+  curl -H "Accept: application/json" http://localhost:8080/
+  curl -H "Accept: text/plain" http://localhost:8080/
+  curl -H "Accept: image/png" http://localhost:8080/
+"""
+use stallion = "../../stallion"
+use lori = "lori"
+
+actor Main
+  new create(env: Env) =>
+    let auth = lori.TCPListenAuth(env.root)
+    Listener(auth, "0.0.0.0", "8080", env.out)
+
+actor Listener is lori.TCPListenerActor
+  var _tcp_listener: lori.TCPListener = lori.TCPListener.none()
+  let _out: OutStream
+  let _config: stallion.ServerConfig
+  let _server_auth: lori.TCPServerAuth
+
+  new create(
+    auth: lori.TCPListenAuth,
+    host: String,
+    port: String,
+    out: OutStream)
+  =>
+    _out = out
+    _server_auth = lori.TCPServerAuth(auth)
+    _config = stallion.ServerConfig(host, port)
+    _tcp_listener = lori.TCPListener(auth, host, port, this)
+
+  fun ref _listener(): lori.TCPListener => _tcp_listener
+
+  fun ref _on_accept(fd: U32): lori.TCPConnectionActor =>
+    NegotiateServer(_server_auth, fd, _config)
+
+  fun ref _on_listening() =>
+    try
+      (let host, let port) = _tcp_listener.local_address().name()?
+      _out.print("Server listening on " + host + ":" + port)
+    else
+      _out.print("Server listening")
+    end
+
+  fun ref _on_listen_failure() =>
+    _out.print("Failed to start server")
+
+  fun ref _on_closed() =>
+    _out.print("Server closed")
+
+actor NegotiateServer is stallion.HTTPServerActor
+  var _http: stallion.HTTPServer = stallion.HTTPServer.none()
+  let _supported: Array[stallion.MediaType val] val
+
+  new create(
+    auth: lori.TCPServerAuth,
+    fd: U32,
+    config: stallion.ServerConfig)
+  =>
+    _supported = [as stallion.MediaType val:
+      stallion.MediaType("application", "json")
+      stallion.MediaType("text", "plain")
+    ]
+    _http = stallion.HTTPServer(auth, fd, this, config)
+
+  fun ref _http_connection(): stallion.HTTPServer => _http
+
+  fun ref on_request_complete(request': stallion.Request val,
+    responder: stallion.Responder)
+  =>
+    match stallion.ContentNegotiation.from_request(request', _supported)
+    | let mt: stallion.MediaType val =>
+      _respond_with(mt, responder)
+    | stallion.NoAcceptableType =>
+      _respond_not_acceptable(responder)
+    end
+
+  fun _respond_with(
+    media_type: stallion.MediaType val,
+    responder: stallion.Responder ref)
+  =>
+    let body: String val = if media_type.subtype == "json" then
+      """{"message": "Hello, World!"}"""
+    else
+      "Hello, World!"
+    end
+
+    let response = stallion.ResponseBuilder(stallion.StatusOK)
+      .add_header("Content-Type", media_type.string())
+      .add_header("Content-Length", body.size().string())
+      .finish_headers()
+      .add_chunk(body)
+      .build()
+    responder.respond(response)
+
+  fun _respond_not_acceptable(responder: stallion.Responder ref) =>
+    let body: String val = "Not Acceptable"
+    let response = stallion.ResponseBuilder(stallion.StatusNotAcceptable)
+      .add_header("Content-Type", "text/plain")
+      .add_header("Content-Length", body.size().string())
+      .finish_headers()
+      .add_chunk(body)
+      .build()
+    responder.respond(response)

--- a/stallion/_accept_parser.pony
+++ b/stallion/_accept_parser.pony
@@ -1,0 +1,278 @@
+use "constrained_types"
+
+primitive _AcceptParser
+  """
+  Parse an HTTP Accept header value into an array of `_AcceptRange` values.
+
+  Implements lenient parsing: malformed entries are silently skipped rather
+  than producing an error. Comma splitting is quoted-string-aware so that
+  commas inside quoted parameter values don't split entries.
+  """
+
+  fun apply(header_value: String val): Array[_AcceptRange val] val =>
+    """Parse a single Accept header value string."""
+    let ranges = recover iso Array[_AcceptRange val] end
+    let segments = _split_on_comma(header_value)
+    for segment in segments.values() do
+      let trimmed = _trim_whitespace(segment)
+      if trimmed.size() > 0 then
+        match _parse_range(trimmed)
+        | let r: _AcceptRange val => ranges.push(r)
+        end
+      end
+    end
+    consume ranges
+
+  fun _split_on_comma(s: String val): Array[String val] val =>
+    """
+    Split on commas, respecting quoted strings.
+
+    Commas inside double-quoted parameter values are not treated as
+    separators.
+    """
+    let result = recover iso Array[String val] end
+    var start: USize = 0
+    var i: USize = 0
+    var in_quotes: Bool = false
+    let size = s.size()
+
+    while i < size do
+      try
+        let b = s(i)?
+        if b == '"' then
+          in_quotes = not in_quotes
+        elseif (b == ',') and (not in_quotes) then
+          result.push(s.trim(start, i))
+          start = i + 1
+        end
+      end
+      i = i + 1
+    end
+    result.push(s.trim(start, size))
+    consume result
+
+  fun _parse_range(segment: String val): (_AcceptRange val | None) =>
+    """
+    Parse a single media range segment like `text/html;level=1;q=0.9;ext=1`.
+
+    Returns `None` if the segment is malformed (no slash, etc.).
+
+    Per RFC 7231 §5.3.2, parameters before `q` are media type parameters
+    (they affect matching), while parameters after `q` are accept extensions
+    (they are ignored for matching purposes).
+    """
+    // Split off parameters at first semicolon
+    var semi: USize = 0
+    let size = segment.size()
+    while (semi < size) and
+      try segment(semi)? != ';' else false end
+    do
+      semi = semi + 1
+    end
+
+    let media_part = _trim_whitespace(segment.trim(0, semi))
+
+    // Find the slash in type/subtype
+    var slash: USize = 0
+    let msize = media_part.size()
+    while (slash < msize) and
+      try media_part(slash)? != '/' else false end
+    do
+      slash = slash + 1
+    end
+
+    // Must have a slash and non-empty type and subtype
+    if (slash == 0) or (slash >= (msize - 1)) then
+      return None
+    end
+
+    let type_name: String val =
+      _trim_whitespace(media_part.trim(0, slash)).lower()
+    let subtype: String val =
+      _trim_whitespace(media_part.trim(slash + 1)).lower()
+
+    if (type_name.size() == 0) or (subtype.size() == 0) then
+      return None
+    end
+
+    // */subtype is not valid per RFC 7231 — only */* is allowed
+    if (type_name == "*") and (subtype != "*") then
+      return None
+    end
+
+    // Parse parameters
+    var quality: U16 = 1000  // default q=1.0
+    var params = recover iso Array[(String val, String val)] end
+    var found_q: Bool = false
+
+    if semi < size then
+      let param_str = segment.trim(semi + 1)
+      let param_parts = _split_params(param_str)
+      for part in param_parts.values() do
+        let trimmed = _trim_whitespace(part)
+        if trimmed.size() == 0 then continue end
+
+        // Find the = in param
+        var eq: USize = 0
+        let psize = trimmed.size()
+        while (eq < psize) and
+          try trimmed(eq)? != '=' else false end
+        do
+          eq = eq + 1
+        end
+
+        if eq < psize then
+          let pname: String val =
+            _trim_whitespace(trimmed.trim(0, eq)).lower()
+          let pval = _trim_whitespace(trimmed.trim(eq + 1))
+
+          if (pname == "q") and (not found_q) then
+            found_q = true
+            quality = _parse_quality(pval)
+          elseif not found_q then
+            // Parameters before q are media type parameters
+            params.push((pname, pval))
+          end
+          // Parameters after q are accept extensions — ignored
+        end
+      end
+    end
+
+    let params_val: Array[(String val, String val)] val = consume params
+
+    match _MakeQuality(quality)
+    | let q: _Quality =>
+      _AcceptRange(type_name, subtype, params_val, q)
+    else
+      // Quality out of range — skip this entry
+      None
+    end
+
+  fun _split_params(s: String val): Array[String val] val =>
+    """Split parameter string on semicolons, respecting quoted strings."""
+    let result = recover iso Array[String val] end
+    var start: USize = 0
+    var i: USize = 0
+    var in_quotes: Bool = false
+    let size = s.size()
+
+    while i < size do
+      try
+        let b = s(i)?
+        if b == '"' then
+          in_quotes = not in_quotes
+        elseif (b == ';') and (not in_quotes) then
+          result.push(s.trim(start, i))
+          start = i + 1
+        end
+      end
+      i = i + 1
+    end
+    result.push(s.trim(start, size))
+    consume result
+
+  fun _parse_quality(s: String val): U16 =>
+    """
+    Parse a quality value string into a 0–1000 integer.
+
+    Accepts formats like "1", "0.5", "0.99", "0.123". Values outside
+    0.000–1.000 are clamped. Malformed values return 1000 (default).
+    """
+    let stripped = _strip_quotes(s)
+    let qsize = stripped.size()
+    if qsize == 0 then return 1000 end
+
+    // Find the decimal point
+    var dot: USize = qsize
+    var i: USize = 0
+    while i < qsize do
+      try
+        if stripped(i)? == '.' then
+          dot = i
+          break
+        end
+      end
+      i = i + 1
+    end
+
+    // Parse integer part
+    let int_part = stripped.trim(0, dot)
+    var int_val: U16 = 0
+    if int_part.size() > 0 then
+      try
+        let parsed = int_part.u16()?
+        if parsed > 1 then return 1000 end
+        int_val = parsed * 1000
+      else
+        return 1000
+      end
+    end
+
+    if dot >= qsize then
+      // No decimal part
+      return int_val.min(1000)
+    end
+
+    // Parse fractional part — up to 3 digits
+    let frac_part = stripped.trim(dot + 1)
+    let fsize = frac_part.size()
+    var frac_val: U16 = 0
+    var digits: USize = 0
+    var j: USize = 0
+    while (j < fsize) and (digits < 3) do
+      try
+        let b = frac_part(j)?
+        if (b >= '0') and (b <= '9') then
+          frac_val = (frac_val * 10) + (b - '0').u16()
+          digits = digits + 1
+        else
+          break
+        end
+      end
+      j = j + 1
+    end
+
+    // No digits on either side of the dot — malformed
+    if (int_part.size() == 0) and (digits == 0) then
+      return 1000
+    end
+
+    // Scale to 3 decimal places
+    while digits < 3 do
+      frac_val = frac_val * 10
+      digits = digits + 1
+    end
+
+    (int_val + frac_val).min(1000)
+
+  fun _strip_quotes(s: String val): String val =>
+    """Strip surrounding double quotes if present."""
+    if (s.size() >= 2) and
+      try (s(0)? == '"') and (s(s.size() - 1)? == '"') else false end
+    then
+      s.trim(1, s.size() - 1)
+    else
+      s
+    end
+
+  fun _trim_whitespace(s: String val): String val =>
+    """Trim leading and trailing spaces and tabs."""
+    var first: USize = 0
+    var last: USize = s.size()
+    while (first < last) and
+      try
+        let b = s(first)?
+        (b == ' ') or (b == '\t')
+      else false end
+    do
+      first = first + 1
+    end
+    while (last > first) and
+      try
+        let b = s(last - 1)?
+        (b == ' ') or (b == '\t')
+      else false end
+    do
+      last = last - 1
+    end
+    s.trim(first, last)

--- a/stallion/_accept_range.pony
+++ b/stallion/_accept_range.pony
@@ -1,0 +1,37 @@
+class val _AcceptRange
+  """
+  A single parsed media range from an Accept header.
+
+  Stores the type/subtype, media parameters (excluding the quality factor),
+  and the quality factor scaled to 0–1000.
+  """
+  let type_name: String val
+  let subtype: String val
+  let params: Array[(String val, String val)] val
+  let quality: _Quality
+
+  new val create(
+    type_name': String val,
+    subtype': String val,
+    params': Array[(String val, String val)] val,
+    quality': _Quality)
+  =>
+    type_name = type_name'
+    subtype = subtype'
+    params = params'
+    quality = quality'
+
+  fun _specificity(): USize =>
+    """
+    Return a specificity score for precedence ordering.
+
+    0 = `*/*` (matches anything), 1 = `type/*` (matches any subtype),
+    2 = `type/subtype` (exact match).
+    """
+    if type_name == "*" then
+      0
+    elseif subtype == "*" then
+      1
+    else
+      2
+    end

--- a/stallion/_quality.pony
+++ b/stallion/_quality.pony
@@ -1,0 +1,18 @@
+use "constrained_types"
+
+type _Quality is Constrained[U16, _QualityValidator]
+  // Quality factor scaled to 0–1000 (representing 0.000–1.000).
+
+type _MakeQuality is MakeConstrained[U16, _QualityValidator]
+  // Constructs a `_Quality` from a `U16`. Returns `_Quality` on success
+  // or `ValidationFailure` if the value exceeds 1000.
+
+primitive _QualityValidator is Validator[U16]
+  fun apply(value: U16): ValidationResult =>
+    recover val
+      if value <= 1000 then
+        ValidationSuccess
+      else
+        ValidationFailure("quality must be between 0 and 1000")
+      end
+    end

--- a/stallion/_test.pony
+++ b/stallion/_test.pony
@@ -178,6 +178,20 @@ actor \nodoc\ Main is TestList
     // Cookie integration test
     test(_TestServerCookieParsing)
 
+    // Content negotiation tests
+    test(Property1UnitTest[String val](
+      _PropertyNegotiateRobustness))
+    test(Property1UnitTest[USize](
+      _PropertyNegotiateResultFromSupported))
+    test(Property1UnitTest[USize](
+      _PropertyNegotiateQZeroExcludes))
+    test(Property1UnitTest[USize](
+      _PropertyNegotiateServerPreference))
+    test(Property1UnitTest[String val](
+      _PropertyNegotiateQualityBounds))
+    test(_TestNegotiateKnownGood)
+    test(_TestAcceptParserKnownGood)
+
     // SSL integration tests
     test(_TestSSLHelloWorld)
     test(_TestSSLKeepAlive)

--- a/stallion/_test_content_negotiation.pony
+++ b/stallion/_test_content_negotiation.pony
@@ -1,0 +1,749 @@
+use "pony_check"
+use "pony_test"
+use uri_pkg = "uri"
+
+// --- Property-based tests ---
+
+class \nodoc\ iso _PropertyNegotiateRobustness
+  is Property1[String val]
+  """Arbitrary strings never crash the parser or negotiation."""
+  fun name(): String => "content_negotiation/robustness"
+
+  fun gen(): Generator[String val] =>
+    Generators.ascii_printable(0, 200)
+
+  fun ref property(arg1: String val, ph: PropertyHelper) =>
+    let supported = [as MediaType val:
+      MediaType("text", "html")
+      MediaType("application", "json")
+    ]
+    // Must not crash — result is always one of the two valid variants
+    match ContentNegotiation(arg1, supported)
+    | let mt: MediaType val =>
+      ph.assert_true(
+        (mt == MediaType("text", "html")) or
+          (mt == MediaType("application", "json")),
+        "Result must be from supported list")
+    | NoAcceptableType => None
+    end
+
+class \nodoc\ iso _PropertyNegotiateResultFromSupported
+  is Property1[USize]
+  """
+  Negotiation result is always from the supported list or NoAcceptableType.
+  """
+  fun name(): String => "content_negotiation/result_from_supported"
+
+  fun gen(): Generator[USize] =>
+    Generators.usize(0, 4)
+
+  fun ref property(arg1: USize, ph: PropertyHelper) =>
+    let all_types: Array[MediaType val] val = [as MediaType val:
+      MediaType("text", "html")
+      MediaType("text", "plain")
+      MediaType("application", "json")
+      MediaType("application", "xml")
+      MediaType("image", "png")
+    ]
+    // Build supported list of size arg1
+    let supported = recover val
+      let arr = Array[MediaType val]
+      var i: USize = 0
+      while i < arg1.min(all_types.size()) do
+        try arr.push(all_types(i)?) end
+        i = i + 1
+      end
+      arr
+    end
+
+    let result = ContentNegotiation(
+      "text/html, application/json;q=0.9, */*;q=0.1", supported)
+
+    match result
+    | let mt: MediaType val =>
+      var found = false
+      for s in supported.values() do
+        if s == mt then found = true; break end
+      end
+      ph.assert_true(found, "Result must be in supported list")
+    | NoAcceptableType =>
+      if supported.size() > 0 then
+        // */* should match anything, so this shouldn't happen
+        ph.fail("Expected a match with */* in accept header")
+      end
+    end
+
+class \nodoc\ iso _PropertyNegotiateQZeroExcludes
+  is Property1[USize]
+  """Types explicitly excluded with q=0 are never returned."""
+  fun name(): String => "content_negotiation/q_zero_excludes"
+
+  fun gen(): Generator[USize] =>
+    Generators.usize(0, 2)
+
+  fun ref property(arg1: USize, ph: PropertyHelper) =>
+    let supported = [as MediaType val:
+      MediaType("text", "html")
+      MediaType("application", "json")
+      MediaType("text", "plain")
+    ]
+    // Exclude the type at index arg1
+    let excluded = try supported(arg1)? else return end
+    let accept = excluded.string() + ";q=0, */*;q=0.1"
+    let result = ContentNegotiation(consume accept, supported)
+
+    match result
+    | let mt: MediaType val =>
+      ph.assert_false(mt == excluded,
+        "Excluded type " + excluded.string() + " should not be returned")
+    | NoAcceptableType => None
+    end
+
+class \nodoc\ iso _PropertyNegotiateServerPreference
+  is Property1[USize]
+  """Equal quality returns the first type in the supported list."""
+  fun name(): String => "content_negotiation/server_preference"
+
+  fun gen(): Generator[USize] =>
+    Generators.usize(2, 5)
+
+  fun ref property(arg1: USize, ph: PropertyHelper) =>
+    // Build a supported list of text/typeN
+    let supported = recover val
+      let arr = Array[MediaType val]
+      var i: USize = 0
+      while i < arg1 do
+        arr.push(MediaType("text", "type" + i.string()))
+        i = i + 1
+      end
+      arr
+    end
+
+    // Accept */* with default quality — all equal
+    let result = ContentNegotiation("*/*", supported)
+
+    match result
+    | let mt: MediaType val =>
+      try
+        ph.assert_true(mt == supported(0)?,
+          "Expected first supported type, got " + mt.string())
+      else
+        ph.fail("server preference: index error")
+      end
+    | NoAcceptableType =>
+      if supported.size() > 0 then
+        ph.fail("Expected a match with */*")
+      end
+    end
+
+class \nodoc\ iso _PropertyNegotiateQualityBounds
+  is Property1[String val]
+  """All parsed qualities fall in the 0–1000 range."""
+  fun name(): String => "content_negotiation/quality_bounds"
+
+  fun gen(): Generator[String val] =>
+    Generators.ascii_printable(0, 100)
+
+  fun ref property(arg1: String val, ph: PropertyHelper) =>
+    // Indirectly verify via the constrained type — if parsing produces
+    // a result, the quality was valid. This test ensures the parser
+    // never constructs an _AcceptRange with an out-of-range quality.
+    let ranges = _AcceptParser(arg1)
+    for range in ranges.values() do
+      ph.assert_true(range.quality() <= 1000,
+        "Quality out of range: " + range.quality().string())
+    end
+
+// --- Example-based tests ---
+
+class \nodoc\ iso _TestNegotiateKnownGood is UnitTest
+  """Verify negotiation for specific Accept headers."""
+  fun name(): String => "content_negotiation/known_good"
+
+  fun apply(h: TestHelper) =>
+    _test_exact_match(h)
+    _test_quality_ordering(h)
+    _test_wildcard_match(h)
+    _test_type_wildcard(h)
+    _test_q_zero_exclusion(h)
+    _test_specificity_precedence(h)
+    _test_missing_accept(h)
+    _test_empty_supported(h)
+    _test_server_preference_tiebreak(h)
+    _test_case_insensitivity(h)
+    _test_browser_accept(h)
+    _test_multiple_accept_headers(h)
+    _test_empty_accept_value(h)
+    _test_all_excluded(h)
+    _test_whitespace_tolerance(h)
+    _test_malformed_entries_skipped(h)
+    _test_quality_edge_values(h)
+    _test_bare_dot_quality_not_excluded(h)
+    _test_quoted_string_comma_protection(h)
+    _test_parameterized_range_no_match(h)
+    _test_accept_extensions_ignored(h)
+    _test_wildcard_subtype_only_rejected(h)
+    _test_specificity_overrides_wildcard_q_zero(h)
+    _test_type_wildcard_vs_exact_specificity(h)
+    _test_type_wildcard_q_zero_exclusion(h)
+
+  fun _test_exact_match(h: TestHelper) =>
+    let supported = [as MediaType val:
+      MediaType("text", "html")
+      MediaType("application", "json")
+    ]
+    match ContentNegotiation("application/json", supported)
+    | let mt: MediaType val =>
+      h.assert_true(mt == MediaType("application", "json"),
+        "exact match")
+    | NoAcceptableType =>
+      h.fail("exact match: expected json")
+    end
+
+  fun _test_quality_ordering(h: TestHelper) =>
+    let supported = [as MediaType val:
+      MediaType("text", "html")
+      MediaType("application", "json")
+    ]
+    match ContentNegotiation("text/html;q=0.5, application/json;q=0.9",
+      supported)
+    | let mt: MediaType val =>
+      h.assert_true(mt == MediaType("application", "json"),
+        "quality ordering: expected json")
+    | NoAcceptableType =>
+      h.fail("quality ordering: expected match")
+    end
+
+  fun _test_wildcard_match(h: TestHelper) =>
+    let supported = [as MediaType val:
+      MediaType("application", "json")
+    ]
+    match ContentNegotiation("*/*", supported)
+    | let mt: MediaType val =>
+      h.assert_true(mt == MediaType("application", "json"),
+        "wildcard match")
+    | NoAcceptableType =>
+      h.fail("wildcard match: expected json")
+    end
+
+  fun _test_type_wildcard(h: TestHelper) =>
+    let supported = [as MediaType val:
+      MediaType("text", "plain")
+      MediaType("application", "json")
+    ]
+    match ContentNegotiation("application/*", supported)
+    | let mt: MediaType val =>
+      h.assert_true(mt == MediaType("application", "json"),
+        "type wildcard")
+    | NoAcceptableType =>
+      h.fail("type wildcard: expected json")
+    end
+
+  fun _test_q_zero_exclusion(h: TestHelper) =>
+    let supported = [as MediaType val:
+      MediaType("text", "html")
+      MediaType("application", "json")
+    ]
+    match ContentNegotiation(
+      "text/html;q=0, application/json", supported)
+    | let mt: MediaType val =>
+      h.assert_true(mt == MediaType("application", "json"),
+        "q=0 exclusion")
+    | NoAcceptableType =>
+      h.fail("q=0 exclusion: expected json")
+    end
+
+  fun _test_specificity_precedence(h: TestHelper) =>
+    let supported = [as MediaType val:
+      MediaType("text", "html")
+      MediaType("text", "plain")
+    ]
+    // */* at q=0.1, but text/html specifically at q=0.9
+    match ContentNegotiation(
+      "*/*;q=0.1, text/html;q=0.9", supported)
+    | let mt: MediaType val =>
+      h.assert_true(mt == MediaType("text", "html"),
+        "specificity precedence: expected html")
+    | NoAcceptableType =>
+      h.fail("specificity precedence: expected match")
+    end
+
+  fun _test_missing_accept(h: TestHelper) =>
+    // from_request with no Accept header — should return first supported
+    let headers = recover val Headers end
+    let request' = _make_request(headers)
+    let supported = [as MediaType val:
+      MediaType("application", "json")
+      MediaType("text", "html")
+    ]
+    match ContentNegotiation.from_request(request', supported)
+    | let mt: MediaType val =>
+      h.assert_true(mt == MediaType("application", "json"),
+        "missing accept: expected first supported")
+    | NoAcceptableType =>
+      h.fail("missing accept: expected match")
+    end
+
+  fun _test_empty_supported(h: TestHelper) =>
+    match ContentNegotiation("text/html", Array[MediaType val])
+    | NoAcceptableType => None
+    | let mt: MediaType val =>
+      h.fail("empty supported: expected NoAcceptableType")
+    end
+
+  fun _test_server_preference_tiebreak(h: TestHelper) =>
+    let supported = [as MediaType val:
+      MediaType("text", "plain")
+      MediaType("application", "json")
+    ]
+    // Both at same quality
+    match ContentNegotiation(
+      "text/plain, application/json", supported)
+    | let mt: MediaType val =>
+      h.assert_true(mt == MediaType("text", "plain"),
+        "tiebreak: expected first supported (text/plain)")
+    | NoAcceptableType =>
+      h.fail("tiebreak: expected match")
+    end
+
+  fun _test_case_insensitivity(h: TestHelper) =>
+    let supported = [as MediaType val:
+      MediaType("Application", "JSON")
+    ]
+    match ContentNegotiation("APPLICATION/json", supported)
+    | let mt: MediaType val =>
+      h.assert_true(mt == MediaType("application", "json"),
+        "case insensitivity")
+    | NoAcceptableType =>
+      h.fail("case insensitivity: expected match")
+    end
+
+  fun _test_browser_accept(h: TestHelper) =>
+    let supported = [as MediaType val:
+      MediaType("text", "html")
+      MediaType("application", "json")
+    ]
+    // Typical browser Accept header
+    let accept =
+      "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"
+    match ContentNegotiation(accept, supported)
+    | let mt: MediaType val =>
+      h.assert_true(mt == MediaType("text", "html"),
+        "browser accept: expected html")
+    | NoAcceptableType =>
+      h.fail("browser accept: expected match")
+    end
+
+  fun _test_multiple_accept_headers(h: TestHelper) =>
+    // Multiple Accept headers should be concatenated
+    let headers = recover val
+      let h' = Headers
+      h'.add("accept", "text/plain;q=0.5")
+      h'.add("accept", "application/json")
+      h'.add("content-type", "text/html")
+      h'
+    end
+    let request' = _make_request(headers)
+    let supported = [as MediaType val:
+      MediaType("text", "plain")
+      MediaType("application", "json")
+    ]
+    match ContentNegotiation.from_request(request', supported)
+    | let mt: MediaType val =>
+      h.assert_true(mt == MediaType("application", "json"),
+        "multiple accept: expected json (higher quality)")
+    | NoAcceptableType =>
+      h.fail("multiple accept: expected match")
+    end
+
+  fun _test_empty_accept_value(h: TestHelper) =>
+    let supported = [as MediaType val:
+      MediaType("text", "html")
+    ]
+    // Empty Accept value — accept anything
+    match ContentNegotiation("", supported)
+    | let mt: MediaType val =>
+      h.assert_true(mt == MediaType("text", "html"),
+        "empty accept value: expected first supported")
+    | NoAcceptableType =>
+      h.fail("empty accept value: expected match")
+    end
+
+  fun _test_all_excluded(h: TestHelper) =>
+    let supported = [as MediaType val:
+      MediaType("text", "html")
+      MediaType("application", "json")
+    ]
+    match ContentNegotiation(
+      "text/html;q=0, application/json;q=0", supported)
+    | NoAcceptableType => None
+    | let mt: MediaType val =>
+      h.fail("all excluded: expected NoAcceptableType, got " + mt.string())
+    end
+
+  fun _test_whitespace_tolerance(h: TestHelper) =>
+    let supported = [as MediaType val:
+      MediaType("text", "html")
+      MediaType("application", "json")
+    ]
+    match ContentNegotiation(
+      "  text/html  ;  q=0.5  ,  application/json  ", supported)
+    | let mt: MediaType val =>
+      h.assert_true(mt == MediaType("application", "json"),
+        "whitespace tolerance: expected json (higher quality)")
+    | NoAcceptableType =>
+      h.fail("whitespace tolerance: expected match")
+    end
+
+  fun _test_malformed_entries_skipped(h: TestHelper) =>
+    let supported = [as MediaType val:
+      MediaType("text", "html")
+    ]
+    // "badentry" has no slash — should be skipped; text/html should match
+    match ContentNegotiation("badentry, text/html", supported)
+    | let mt: MediaType val =>
+      h.assert_true(mt == MediaType("text", "html"),
+        "malformed skipped: expected html")
+    | NoAcceptableType =>
+      h.fail("malformed skipped: expected match")
+    end
+
+  fun _test_quality_edge_values(h: TestHelper) =>
+    let supported = [as MediaType val:
+      MediaType("text", "a")
+      MediaType("text", "b")
+      MediaType("text", "c")
+    ]
+    // q=0.001 (minimum positive), q=0.999, q=1.000
+    match ContentNegotiation(
+      "text/a;q=0.001, text/b;q=0.999, text/c;q=1.000", supported)
+    | let mt: MediaType val =>
+      h.assert_true(mt == MediaType("text", "c"),
+        "quality edge: expected c (q=1.000)")
+    | NoAcceptableType =>
+      h.fail("quality edge: expected match")
+    end
+
+  fun _test_bare_dot_quality_not_excluded(h: TestHelper) =>
+    let supported = [as MediaType val:
+      MediaType("text", "html")
+    ]
+    // "q=." is malformed — bare dot with no digits. Must not be treated
+    // as q=0 (which would exclude the type). Malformed quality defaults
+    // to 1.0.
+    match ContentNegotiation("text/html;q=.", supported)
+    | let mt: MediaType val =>
+      h.assert_true(mt == MediaType("text", "html"),
+        "bare dot quality: expected match (malformed q defaults to 1.0)")
+    | NoAcceptableType =>
+      h.fail("bare dot quality: q=. must not exclude")
+    end
+
+  fun _test_quoted_string_comma_protection(h: TestHelper) =>
+    let supported = [as MediaType val:
+      MediaType("text", "html")
+    ]
+    // Comma inside a quoted accept-extension value should not split.
+    // The extension param appears after q, so it's discarded for matching
+    // but must not cause a spurious comma split.
+    match ContentNegotiation(
+      "text/html;q=0.5;ext=\"a,b\"", supported)
+    | let mt: MediaType val =>
+      h.assert_true(mt == MediaType("text", "html"),
+        "quoted comma protection")
+    | NoAcceptableType =>
+      h.fail("quoted comma protection: expected match")
+    end
+
+  fun _test_parameterized_range_no_match(h: TestHelper) =>
+    let supported = [as MediaType val:
+      MediaType("text", "html")
+    ]
+    // Range with media params doesn't match parameterless MediaType
+    match ContentNegotiation("text/html;level=1", supported)
+    | NoAcceptableType => None
+    | let mt: MediaType val =>
+      h.fail("parameterized range: expected NoAcceptableType")
+    end
+
+  fun _test_accept_extensions_ignored(h: TestHelper) =>
+    let supported = [as MediaType val:
+      MediaType("text", "html")
+    ]
+    // Extensions after q are not media parameters — they must not
+    // prevent matching (RFC 7231 §5.3.2).
+    match ContentNegotiation("text/html;q=0.9;level=1", supported)
+    | let mt: MediaType val =>
+      h.assert_true(mt == MediaType("text", "html"),
+        "accept extensions: expected match")
+    | NoAcceptableType =>
+      h.fail("accept extensions: extension after q should not block match")
+    end
+
+  fun _test_wildcard_subtype_only_rejected(h: TestHelper) =>
+    let supported = [as MediaType val:
+      MediaType("text", "html")
+      MediaType("text", "plain")
+    ]
+    // */html is not valid per RFC 7231 — only */* is a valid wildcard.
+    // Parser skips it as malformed. When combined with valid ranges,
+    // */html must not act as a wildcard match.
+    match ContentNegotiation("*/html;q=0.9, text/plain;q=0.5", supported)
+    | let mt: MediaType val =>
+      // If */html were treated as */* (the bug), text/html would match
+      // at q=0.9. With the fix, only text/plain matches at q=0.5.
+      h.assert_true(mt == MediaType("text", "plain"),
+        "wildcard subtype: */html rejected, expected plain")
+    | NoAcceptableType =>
+      h.fail("wildcard subtype: expected plain to match")
+    end
+
+  fun _test_specificity_overrides_wildcard_q_zero(h: TestHelper) =>
+    let supported = [as MediaType val:
+      MediaType("text", "html")
+      MediaType("application", "json")
+    ]
+    // */* at q=0 excludes everything, but the exact text/html range
+    // at q=0.9 is more specific and overrides the wildcard exclusion.
+    // application/json has no specific range, so it stays excluded.
+    match ContentNegotiation(
+      "*/*;q=0, text/html;q=0.9", supported)
+    | let mt: MediaType val =>
+      h.assert_true(mt == MediaType("text", "html"),
+        "specificity overrides wildcard q=0: expected html")
+    | NoAcceptableType =>
+      h.fail("specificity overrides wildcard q=0: expected match")
+    end
+
+  fun _test_type_wildcard_vs_exact_specificity(h: TestHelper) =>
+    let supported = [as MediaType val:
+      MediaType("text", "html")
+      MediaType("text", "plain")
+    ]
+    // text/* at q=0.9 matches both, but text/html has a more specific
+    // exact range at q=0.5. The exact match wins for text/html (q=0.5),
+    // while text/plain uses the wildcard (q=0.9). So text/plain wins.
+    match ContentNegotiation(
+      "text/*;q=0.9, text/html;q=0.5", supported)
+    | let mt: MediaType val =>
+      h.assert_true(mt == MediaType("text", "plain"),
+        "type wildcard vs exact: expected plain (q=0.9 > q=0.5)")
+    | NoAcceptableType =>
+      h.fail("type wildcard vs exact: expected match")
+    end
+
+  fun _test_type_wildcard_q_zero_exclusion(h: TestHelper) =>
+    let supported = [as MediaType val:
+      MediaType("text", "html")
+      MediaType("application", "json")
+    ]
+    // text/* at q=0 excludes all text/* types.
+    // application/json has an exact match at default quality.
+    match ContentNegotiation(
+      "text/*;q=0, application/json", supported)
+    | let mt: MediaType val =>
+      h.assert_true(mt == MediaType("application", "json"),
+        "type wildcard q=0: expected json")
+    | NoAcceptableType =>
+      h.fail("type wildcard q=0: expected match")
+    end
+
+  fun _make_request(headers: Headers val): Request val =>
+    """Build a minimal Request for testing."""
+    let parsed_uri: uri_pkg.URI val =
+      match uri_pkg.ParseURI("/")
+      | let u: uri_pkg.URI val => u
+      | let _: uri_pkg.URIParseError val =>
+        // "/" always parses — use a fallback to satisfy the compiler
+        uri_pkg.URI(None, None, "/", None, None)
+      end
+    Request(GET, parsed_uri, HTTP11, headers,
+      ParseCookies.from_headers(headers))
+
+class \nodoc\ iso _TestAcceptParserKnownGood is UnitTest
+  """Verify parsing of specific Accept header strings."""
+  fun name(): String => "content_negotiation/parser_known_good"
+
+  fun apply(h: TestHelper) =>
+    _test_single_type(h)
+    _test_multiple_types(h)
+    _test_quality_values(h)
+    _test_wildcards(h)
+    _test_whitespace(h)
+    _test_malformed_skipped(h)
+    _test_empty_string(h)
+    _test_quoted_comma_not_split(h)
+    _test_wildcard_subtype_only_skipped(h)
+    _test_accept_extension_not_in_params(h)
+    _test_duplicate_range_first_wins(h)
+
+  fun _test_single_type(h: TestHelper) =>
+    let ranges = _AcceptParser("text/html")
+    h.assert_eq[USize](1, ranges.size(), "single: count")
+    try
+      h.assert_eq[String val]("text", ranges(0)?.type_name,
+        "single: type")
+      h.assert_eq[String val]("html", ranges(0)?.subtype,
+        "single: subtype")
+      h.assert_eq[U16](1000, ranges(0)?.quality(),
+        "single: quality")
+    else
+      h.fail("single: index error")
+    end
+
+  fun _test_multiple_types(h: TestHelper) =>
+    let ranges = _AcceptParser("text/html, application/json, text/plain")
+    h.assert_eq[USize](3, ranges.size(), "multiple: count")
+    try
+      h.assert_eq[String val]("text", ranges(0)?.type_name,
+        "multiple: 0 type")
+      h.assert_eq[String val]("html", ranges(0)?.subtype,
+        "multiple: 0 subtype")
+      h.assert_eq[String val]("application", ranges(1)?.type_name,
+        "multiple: 1 type")
+      h.assert_eq[String val]("json", ranges(1)?.subtype,
+        "multiple: 1 subtype")
+      h.assert_eq[String val]("text", ranges(2)?.type_name,
+        "multiple: 2 type")
+      h.assert_eq[String val]("plain", ranges(2)?.subtype,
+        "multiple: 2 subtype")
+    else
+      h.fail("multiple: index error")
+    end
+
+  fun _test_quality_values(h: TestHelper) =>
+    let ranges = _AcceptParser(
+      "text/html;q=0.9, application/json;q=0.5, text/*;q=0.1")
+    h.assert_eq[USize](3, ranges.size(), "quality: count")
+    try
+      h.assert_eq[U16](900, ranges(0)?.quality(), "quality: html")
+      h.assert_eq[U16](500, ranges(1)?.quality(), "quality: json")
+      h.assert_eq[U16](100, ranges(2)?.quality(), "quality: text/*")
+    else
+      h.fail("quality: index error")
+    end
+
+  fun _test_wildcards(h: TestHelper) =>
+    let ranges = _AcceptParser("*/*;q=0.1, text/*;q=0.5")
+    h.assert_eq[USize](2, ranges.size(), "wildcards: count")
+    try
+      h.assert_eq[String val]("*", ranges(0)?.type_name,
+        "wildcards: 0 type")
+      h.assert_eq[String val]("*", ranges(0)?.subtype,
+        "wildcards: 0 subtype")
+      h.assert_eq[String val]("text", ranges(1)?.type_name,
+        "wildcards: 1 type")
+      h.assert_eq[String val]("*", ranges(1)?.subtype,
+        "wildcards: 1 subtype")
+    else
+      h.fail("wildcards: index error")
+    end
+
+  fun _test_whitespace(h: TestHelper) =>
+    let ranges = _AcceptParser(
+      "  text/html  ;  q=0.9  ,  application/json  ")
+    h.assert_eq[USize](2, ranges.size(), "whitespace: count")
+    try
+      h.assert_eq[String val]("text", ranges(0)?.type_name,
+        "whitespace: 0 type")
+      h.assert_eq[U16](900, ranges(0)?.quality(),
+        "whitespace: 0 quality")
+      h.assert_eq[String val]("application", ranges(1)?.type_name,
+        "whitespace: 1 type")
+      h.assert_eq[U16](1000, ranges(1)?.quality(),
+        "whitespace: 1 quality")
+    else
+      h.fail("whitespace: index error")
+    end
+
+  fun _test_malformed_skipped(h: TestHelper) =>
+    let ranges = _AcceptParser("badentry, /bad, text/html, /")
+    h.assert_eq[USize](1, ranges.size(), "malformed: count")
+    try
+      h.assert_eq[String val]("text", ranges(0)?.type_name,
+        "malformed: type")
+    else
+      h.fail("malformed: index error")
+    end
+
+  fun _test_empty_string(h: TestHelper) =>
+    let ranges = _AcceptParser("")
+    h.assert_eq[USize](0, ranges.size(), "empty: count")
+
+  fun _test_quoted_comma_not_split(h: TestHelper) =>
+    // Comma inside a quoted parameter value must not split entries.
+    // Without quote awareness, "a,b" would split into two entries.
+    let ranges = _AcceptParser(
+      "text/html;param=\"a,b\", application/json")
+    h.assert_eq[USize](2, ranges.size(), "quoted comma: count")
+    try
+      h.assert_eq[String val]("text", ranges(0)?.type_name,
+        "quoted comma: 0 type")
+      h.assert_eq[String val]("html", ranges(0)?.subtype,
+        "quoted comma: 0 subtype")
+      h.assert_eq[String val]("application", ranges(1)?.type_name,
+        "quoted comma: 1 type")
+      h.assert_eq[String val]("json", ranges(1)?.subtype,
+        "quoted comma: 1 subtype")
+    else
+      h.fail("quoted comma: index error")
+    end
+
+  fun _test_wildcard_subtype_only_skipped(h: TestHelper) =>
+    // */html is malformed — only */* is valid. Parser should skip it.
+    let ranges = _AcceptParser("*/html, text/plain")
+    h.assert_eq[USize](1, ranges.size(), "*/html skipped: count")
+    try
+      h.assert_eq[String val]("text", ranges(0)?.type_name,
+        "*/html skipped: type")
+      h.assert_eq[String val]("plain", ranges(0)?.subtype,
+        "*/html skipped: subtype")
+    else
+      h.fail("*/html skipped: index error")
+    end
+
+  fun _test_accept_extension_not_in_params(h: TestHelper) =>
+    // Parameters after q are accept extensions, not media parameters.
+    // They should not appear in the range's params array.
+    let ranges = _AcceptParser("text/html;level=1;q=0.9;ext=2")
+    h.assert_eq[USize](1, ranges.size(), "extension params: count")
+    try
+      // level=1 is before q — it's a media parameter
+      h.assert_eq[USize](1, ranges(0)?.params.size(),
+        "extension params: only media param, not extension")
+      h.assert_eq[String val]("level",
+        ranges(0)?.params(0)?._1, "extension params: param name")
+      h.assert_eq[U16](900, ranges(0)?.quality(),
+        "extension params: quality")
+    else
+      h.fail("extension params: index error")
+    end
+
+  fun _test_duplicate_range_first_wins(h: TestHelper) =>
+    // When the same type appears twice with different qualities,
+    // the first occurrence wins (equal specificity, first in header order).
+    let ranges = _AcceptParser("text/html;q=0.5, text/html;q=0.9")
+    h.assert_eq[USize](2, ranges.size(), "duplicate: count")
+    // Both parse correctly
+    try
+      h.assert_eq[U16](500, ranges(0)?.quality(), "duplicate: first q")
+      h.assert_eq[U16](900, ranges(1)?.quality(), "duplicate: second q")
+    else
+      h.fail("duplicate: index error")
+    end
+    // Negotiation uses the first matching range for text/html (q=0.5).
+    // text/plain at q=0.7 should win because 0.7 > 0.5.
+    // If the code incorrectly used the second range (q=0.9), text/html
+    // would win instead.
+    let supported = [as MediaType val:
+      MediaType("text", "html")
+      MediaType("text", "plain")
+    ]
+    match ContentNegotiation(
+      "text/html;q=0.5, text/html;q=0.9, text/plain;q=0.7", supported)
+    | let mt: MediaType val =>
+      h.assert_true(mt == MediaType("text", "plain"),
+        "duplicate: expected plain (q=0.7 > first html q=0.5)")
+    | NoAcceptableType =>
+      h.fail("duplicate: expected match")
+    end

--- a/stallion/content_negotiation.pony
+++ b/stallion/content_negotiation.pony
@@ -1,0 +1,187 @@
+primitive ContentNegotiation
+  """
+  Select the best response content type based on the client's `Accept`
+  header preferences (RFC 7231 §5.3.2).
+
+  This is an opt-in utility — most endpoints serve a single content type, so
+  automatic parsing of every request's Accept header would waste CPU. Call
+  `from_request()` or `apply()` only in handlers that support multiple
+  content types.
+
+  Two entry points:
+
+  * `from_request()` — extracts all `Accept` headers from a `Request val`
+    and negotiates against the server's supported types.
+  * `apply()` — negotiates directly from a raw Accept header value string.
+    Useful for testing or when you already have the header value.
+
+  The algorithm follows RFC 7231 §5.3.2 precedence rules:
+
+  1. An absent Accept header means "accept anything" — the first supported
+     type is returned.
+  2. Each supported type is matched against the most specific compatible
+     range in the Accept header. Ranges with media parameters only match
+     types with matching parameters (but `MediaType` has no parameters, so
+     parameterized ranges don't match).
+  3. The supported type with the highest quality wins. Ties go to the first
+     type in the `supported` list (server preference).
+  4. Types matched only by `q=0` ranges are excluded.
+  5. If no supported type has quality > 0, `NoAcceptableType` is returned.
+  """
+
+  fun from_request(
+    request': Request val,
+    supported: ReadSeq[MediaType val] box)
+    : ContentNegotiationResult
+  =>
+    """
+    Negotiate content type from a request's Accept headers.
+
+    Multiple Accept headers are concatenated, matching RFC 7230 §3.2.2
+    semantics for list-based header fields.
+    """
+    if supported.size() == 0 then
+      return NoAcceptableType
+    end
+
+    // Collect all Accept header values
+    var header_value: String val = ""
+    var found: Bool = false
+    for hdr in request'.headers.values() do
+      if hdr.name == "accept" then
+        if found then
+          header_value = header_value + ", " + hdr.value
+        else
+          header_value = hdr.value
+          found = true
+        end
+      end
+    end
+
+    if not found then
+      // No Accept header — accept anything, return first supported
+      try
+        return supported(0)?
+      else
+        _Unreachable()
+        return NoAcceptableType
+      end
+    end
+
+    apply(header_value, supported)
+
+  fun apply(
+    header_value: String val,
+    supported: ReadSeq[MediaType val] box)
+    : ContentNegotiationResult
+  =>
+    """
+    Negotiate content type from a raw Accept header value string.
+
+    Empty `supported` always returns `NoAcceptableType`. An empty
+    `header_value` means "accept anything" — the first supported type
+    is returned.
+    """
+    if supported.size() == 0 then
+      return NoAcceptableType
+    end
+
+    let ranges = _AcceptParser(header_value)
+
+    // Empty ranges (empty Accept value) — accept anything
+    if ranges.size() == 0 then
+      try
+        return supported(0)?
+      else
+        _Unreachable()
+        return NoAcceptableType
+      end
+    end
+
+    // For each supported type, find the best matching range
+    var best_type: (MediaType val | None) = None
+    var best_quality: U16 = 0
+
+    try
+      var i: USize = 0
+      while i < supported.size() do
+        let media_type = supported(i)?
+        let q = _best_quality_for(media_type, ranges)
+
+        if q > best_quality then
+          best_quality = q
+          best_type = media_type
+        end
+        i = i + 1
+      end
+    else
+      _Unreachable()
+    end
+
+    if best_quality > 0 then
+      match best_type
+      | let mt: MediaType val => mt
+      else
+        NoAcceptableType
+      end
+    else
+      NoAcceptableType
+    end
+
+  fun _best_quality_for(
+    media_type: MediaType val,
+    ranges: Array[_AcceptRange val] val)
+    : U16
+  =>
+    """
+    Find the quality of the most specific matching range for a media type.
+
+    Returns 0 if no range matches or the best match has q=0.
+    """
+    var best_specificity: USize = 0
+    var best_quality: U16 = 0
+    var found: Bool = false
+
+    for range in ranges.values() do
+      if not _range_matches(media_type, range) then
+        continue
+      end
+
+      let specificity = range._specificity()
+
+      if (not found) or (specificity > best_specificity) then
+        best_specificity = specificity
+        best_quality = range.quality()
+        found = true
+      end
+    end
+
+    if found then best_quality else 0 end
+
+  fun _range_matches(
+    media_type: MediaType val,
+    range: _AcceptRange val)
+    : Bool
+  =>
+    """
+    Check whether a media type matches an Accept range.
+
+    Ranges with media parameters (excluding q) don't match parameterless
+    `MediaType` values, since `MediaType` carries no parameters.
+    """
+    // Parameterized ranges don't match our parameterless MediaType
+    if range.params.size() > 0 then
+      return false
+    end
+
+    if range.type_name == "*" then
+      // */* matches everything
+      true
+    elseif range.subtype == "*" then
+      // type/* matches if type matches
+      media_type.type_name == range.type_name
+    else
+      // Exact match
+      (media_type.type_name == range.type_name) and
+        (media_type.subtype == range.subtype)
+    end

--- a/stallion/content_negotiation_result.pony
+++ b/stallion/content_negotiation_result.pony
@@ -1,0 +1,3 @@
+// Result of content negotiation: either the best matching `MediaType` from
+// the server's supported types, or `NoAcceptableType` if no match was found.
+type ContentNegotiationResult is (MediaType val | NoAcceptableType)

--- a/stallion/media_type.pony
+++ b/stallion/media_type.pony
@@ -1,0 +1,26 @@
+class val MediaType is (Equatable[MediaType] & Stringable)
+  """
+  An HTTP media type consisting of a top-level type and subtype.
+
+  Both components are lowercased at construction for case-insensitive
+  comparison. No validation is performed on the values — this is consistent
+  with `Header`, which stores names and values as-is.
+
+  Use `ContentNegotiation` to match media types against an `Accept` header.
+  """
+  let type_name: String val
+  let subtype: String val
+
+  new val create(type_name': String val, subtype': String val) =>
+    """Create a media type with the given type and subtype, lowercased."""
+    type_name = type_name'.lower()
+    subtype = subtype'.lower()
+
+  fun eq(that: box->MediaType): Bool =>
+    (type_name == that.type_name) and (subtype == that.subtype)
+
+  fun ne(that: box->MediaType): Bool =>
+    not eq(that)
+
+  fun string(): String iso^ =>
+    (type_name + "/" + subtype).clone()

--- a/stallion/no_acceptable_type.pony
+++ b/stallion/no_acceptable_type.pony
@@ -1,0 +1,9 @@
+primitive NoAcceptableType is Stringable
+  """
+  Returned by `ContentNegotiation` when none of the server's supported
+  media types match the client's `Accept` header preferences.
+
+  Servers should respond with 406 Not Acceptable when they receive this
+  result.
+  """
+  fun string(): String iso^ => "NoAcceptableType".clone()

--- a/stallion/stallion.pony
+++ b/stallion/stallion.pony
@@ -157,4 +157,41 @@ fun ref on_request_complete(request': stallion.Request val,
     None
   end
 ```
+
+For content negotiation, use `stallion.ContentNegotiation` to select a
+response content type based on the client's `Accept` header. This is opt-in —
+most endpoints serve a single content type, so automatic parsing would waste
+CPU. Call it only in handlers that support multiple formats:
+
+```pony
+fun ref on_request_complete(request': stallion.Request val,
+  responder: stallion.Responder)
+=>
+  let supported = [as stallion.MediaType val:
+    stallion.MediaType("application", "json")
+    stallion.MediaType("text", "plain")
+  ]
+  match stallion.ContentNegotiation.from_request(request', supported)
+  | let mt: stallion.MediaType val =>
+    // Respond with the negotiated content type
+    let body: String val = "Hello!"
+    let response = stallion.ResponseBuilder(stallion.StatusOK)
+      .add_header("Content-Type", mt.string())
+      .add_header("Content-Length", body.size().string())
+      .finish_headers()
+      .add_chunk(body)
+      .build()
+    responder.respond(response)
+  | stallion.NoAcceptableType =>
+    // 406 Not Acceptable
+    let body: String val = "Not Acceptable"
+    let response = stallion.ResponseBuilder(
+        stallion.StatusNotAcceptable)
+      .add_header("Content-Length", body.size().string())
+      .finish_headers()
+      .add_chunk(body)
+      .build()
+    responder.respond(response)
+  end
+```
 """


### PR DESCRIPTION
Opt-in content type selection based on the client's `Accept` header (RFC 7231 §5.3.2). Most endpoints serve one content type so this is never automatic — call `ContentNegotiation.from_request()` when you actually need it.

The algorithm follows RFC 7231 precedence: exact types beat wildcards, higher quality values win, ties go to first in the server's supported list, and `q=0` excludes. An absent `Accept` header means "accept anything" so the first supported type is returned.

New public types: `MediaType`, `NoAcceptableType`, `ContentNegotiationResult`, `ContentNegotiation`.

Design: #81