### PR TITLE
Remove unnecessary _ParseError marker interface

### DIFF
--- a/stallion/parse_error.pony
+++ b/stallion/parse_error.pony
@@ -1,14 +1,12 @@
-interface val _ParseError is Stringable
-
-primitive TooLarge is _ParseError
+primitive TooLarge
   """Request line or headers exceed the configured size limit."""
   fun string(): String iso^ => "TooLarge".clone()
 
-primitive UnknownMethod is _ParseError
+primitive UnknownMethod
   """HTTP method string not recognized."""
   fun string(): String iso^ => "UnknownMethod".clone()
 
-primitive InvalidURI is _ParseError
+primitive InvalidURI
   """
   Request URI is invalid.
 
@@ -18,27 +16,27 @@ primitive InvalidURI is _ParseError
   """
   fun string(): String iso^ => "InvalidURI".clone()
 
-primitive InvalidVersion is _ParseError
+primitive InvalidVersion
   """HTTP version is not HTTP/1.0 or HTTP/1.1."""
   fun string(): String iso^ => "InvalidVersion".clone()
 
-primitive MalformedHeaders is _ParseError
+primitive MalformedHeaders
   """Header syntax is invalid (missing colon, obs-fold continuation line)."""
   fun string(): String iso^ => "MalformedHeaders".clone()
 
-primitive InvalidContentLength is _ParseError
+primitive InvalidContentLength
   """Content-Length is non-numeric, negative, or has conflicting values."""
   fun string(): String iso^ => "InvalidContentLength".clone()
 
-primitive InvalidChunk is _ParseError
+primitive InvalidChunk
   """Chunked transfer encoding error: bad chunk size or missing CRLF."""
   fun string(): String iso^ => "InvalidChunk".clone()
 
-primitive BodyTooLarge is _ParseError
+primitive BodyTooLarge
   """Request body exceeds the configured maximum body size."""
   fun string(): String iso^ => "BodyTooLarge".clone()
 
 type ParseError is
-  ((TooLarge | UnknownMethod | InvalidURI | InvalidVersion | MalformedHeaders
-  | InvalidContentLength | InvalidChunk | BodyTooLarge) & _ParseError)
+  (TooLarge | UnknownMethod | InvalidURI | InvalidVersion | MalformedHeaders
+  | InvalidContentLength | InvalidChunk | BodyTooLarge)
   """Parse error encountered during HTTP request parsing."""


### PR DESCRIPTION
The `_ParseError` interface is a marker trait that serves no purpose. The `ParseError` union type already provides the closed set of error variants with exhaustive matching via `match \exhaustive\`. The marker trait was open (anyone could implement it), which defeats the purpose of a closed error set.

Removed the `interface val _ParseError is Stringable` declaration, dropped `is _ParseError` from all eight error primitives, and removed the `& _ParseError` intersection from the union type.

Closes #83