### PR TITLE
Fix dispose() hanging when peer FIN is missed

### DIFF
--- a/.release-notes/fix-dispose-hang.md
+++ b/.release-notes/fix-dispose-hang.md
@@ -1,0 +1,3 @@
+## Fix dispose() hanging when peer FIN is missed
+
+Calling `dispose()` on a connection actor could hang indefinitely if the remote peer's FIN packet was missed due to edge-triggered event notification. This left the connection stuck in CLOSE_WAIT, which typically surfaced as test timeouts or connections that never cleaned up. The connection now performs an immediate teardown on `dispose()`, preventing the hang.

--- a/corral.json
+++ b/corral.json
@@ -13,7 +13,7 @@
   "deps": [
     {
       "locator": "github.com/ponylang/lori.git",
-      "version": "0.10.0"
+      "version": "0.11.0"
     },
     {
       "locator": "github.com/ponylang/ssl.git",


### PR DESCRIPTION
Upstream lori 0.11.0 fixes an issue where edge-triggered oneshot events could miss peer FIN, leaving connections stuck in CLOSE_WAIT and causing dispose() to hang indefinitely. This typically surfaced as test timeouts or connections that never cleaned up.