### PR TITLE
Update ponylang/ssl to 2.0.1

### DIFF
--- a/.release-notes/update-ssl-to-2.0.1.md
+++ b/.release-notes/update-ssl-to-2.0.1.md
@@ -1,0 +1,3 @@
+## Update ponylang/ssl to 2.0.1
+
+Updates the ponylang/ssl dependency to 2.0.1 to pick up a bug fix.

--- a/corral.json
+++ b/corral.json
@@ -17,7 +17,7 @@
     },
     {
       "locator": "github.com/ponylang/ssl.git",
-      "version": "2.0.0"
+      "version": "2.0.1"
     },
     {
       "locator": "github.com/ponylang/uri.git",


### PR DESCRIPTION
Updates the ponylang/ssl dependency to 2.0.1 to pick up a bug fix.