### PR TITLE
Update lori to 0.14.0

### DIFF
--- a/.release-notes/next-release.md
+++ b/.release-notes/next-release.md
@@ -1,0 +1,8 @@
+
+## Fix potential connection hang when timer event subscription fails
+
+On some platforms, if the operating system cannot allocate resources for a connection timer (e.g., ENOMEM on kqueue or epoll), connections could hang silently instead of reporting an error. Timer subscription failures are now detected and reported as connection failures.
+
+## Require ponyc 0.63.1 or later
+
+stallion now requires ponyc 0.63.1 or later. Older ponyc versions are no longer supported.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,6 @@ All notable changes to this project will be documented in this file. This projec
 
 - Require ponyc 0.63.1 or later ([PR #97](https://github.com/ponylang/stallion/pull/97))
 
-
 ## [0.5.5] - 2026-04-07
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,14 @@ All notable changes to this project will be documented in this file. This projec
 
 ### Fixed
 
+- Fix potential connection hang when timer event subscription fails ([PR #97](https://github.com/ponylang/stallion/pull/97))
 
 ### Added
 
 
 ### Changed
+
+- Require ponyc 0.63.1 or later ([PR #97](https://github.com/ponylang/stallion/pull/97))
 
 
 ## [0.5.5] - 2026-04-07

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ stallion is beta quality software that will change frequently. Expect breaking c
 
 ## Installation
 
+* Requires ponyc 0.63.1 or later
 * Install [corral](https://github.com/ponylang/corral)
 * `corral add github.com/ponylang/stallion.git --version 0.5.5`
 * `corral fetch` to fetch your dependencies

--- a/corral.json
+++ b/corral.json
@@ -13,7 +13,7 @@
   "deps": [
     {
       "locator": "github.com/ponylang/lori.git",
-      "version": "0.13.1"
+      "version": "0.14.0"
     },
     {
       "locator": "github.com/ponylang/ssl.git",


### PR DESCRIPTION
Picks up ASIO_ERROR handling for timer subscription failures and requires ponyc 0.63.1 or later.