### PR TITLE
Handle timer ASIO subscription failures

### DIFF
--- a/.release-notes/next-release.md
+++ b/.release-notes/next-release.md
@@ -1,0 +1,20 @@
+## Auto-rearm idle timer after ASIO subscription failure
+
+Previously, when the idle timer's ASIO event subscription failed (e.g. `ENOMEM` from the kernel's `kevent` or `epoll_ctl`), the timer would be silently cancelled with no recovery. Idle connections would stop being reaped for the remainder of that connection's lifetime, letting stale connections accumulate under sustained kernel pressure.
+
+The idle timer is now automatically re-armed using the originally configured duration, so idle-timeout protection resumes on the next ASIO turn. If the re-armed subscription also fails, re-arm attempts continue until one succeeds.
+
+## Add `on_timer_failure` callback
+
+User timers created with `HTTPServer.set_timer()` can fail asynchronously if their ASIO event subscription is lost (typically under kernel resource pressure). Previously, such failures were silent — the timer simply never fired.
+
+The new `on_timer_failure()` callback on `HTTPServerLifecycleEventReceiver` reports these failures so applications can decide how to recover. The timer has already been cancelled before the callback fires — any `TimerToken` your actor was tracking from the originating `set_timer()` call is now stale. The application may call `set_timer()` again to retry, close the connection, or do nothing if the deadline no longer matters. The default is a no-op.
+
+```pony
+actor MyServer is HTTPServerActor
+  // ...
+
+  fun ref on_timer_failure() =>
+    // The request deadline timer never armed. Abandon this request.
+    _http.close()
+```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,11 @@ All notable changes to this project will be documented in this file. This projec
 
 ### Fixed
 
+- Auto-rearm idle timer after ASIO subscription failure ([PR #98](https://github.com/ponylang/stallion/pull/98))
 
 ### Added
 
+- Add `on_timer_failure` callback ([PR #98](https://github.com/ponylang/stallion/pull/98))
 
 ### Changed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,7 +66,7 @@ Follow the standard ponylang release notes conventions. Create individual `.md` 
   - `_request_parser.pony` — Request parser class (entry point, buffer management)
   - `request.pony` — Immutable request metadata bundle (`Request val`: method, URI, version, headers, cookies)
   - `chunk_send_token.pony` — Opaque chunk send token (`ChunkSendToken val`, `Equatable`, private constructor)
-  - `http_server_lifecycle_event_receiver.pony` — HTTP callback trait (`HTTPServerLifecycleEventReceiver`: on_request, on_body_chunk, on_request_complete, on_closed, on_start_failure, on_throttled, on_chunk_sent, on_unthrottled, on_timer)
+  - `http_server_lifecycle_event_receiver.pony` — HTTP callback trait (`HTTPServerLifecycleEventReceiver`: on_request, on_body_chunk, on_request_complete, on_closed, on_start_failure, on_throttled, on_chunk_sent, on_unthrottled, on_timer, on_timer_failure)
   - `http_server_actor.pony` — Server actor trait (`HTTPServerActor`: extends `TCPConnectionActor` and `HTTPServerLifecycleEventReceiver`, provides `_connection()` default)
   - `stallion.pony` — Package docstring
   - `http_server.pony` — Protocol class (`HTTPServer`: owns TCP connection + parser + URI parsing + response queue, implements `ServerLifecycleEventReceiver` + `_RequestParserNotify` + `_ResponseQueueNotify`)

--- a/corral.json
+++ b/corral.json
@@ -13,7 +13,7 @@
   "deps": [
     {
       "locator": "github.com/ponylang/lori.git",
-      "version": "0.14.0"
+      "version": "0.14.1"
     },
     {
       "locator": "github.com/ponylang/ssl.git",

--- a/stallion/_connection_state.pony
+++ b/stallion/_connection_state.pony
@@ -31,6 +31,12 @@ trait ref _ConnectionState
   fun ref on_timer(server: HTTPServer ref, token: lori.TimerToken)
     """Handle one-shot timer firing."""
 
+  fun ref on_idle_timer_failure(server: HTTPServer ref)
+    """Handle idle timer ASIO subscription failure."""
+
+  fun ref on_timer_failure(server: HTTPServer ref)
+    """Handle user timer ASIO subscription failure."""
+
 class ref _Active is _ConnectionState
   """
   Connection is active — parsing requests and dispatching to the receiver.
@@ -57,6 +63,12 @@ class ref _Active is _ConnectionState
   fun ref on_timer(server: HTTPServer ref, token: lori.TimerToken) =>
     server._handle_timer(token)
 
+  fun ref on_idle_timer_failure(server: HTTPServer ref) =>
+    server._handle_idle_timer_failure()
+
+  fun ref on_timer_failure(server: HTTPServer ref) =>
+    server._handle_timer_failure()
+
 class ref _Closed is _ConnectionState
   """
   Connection is closed — all operations are no-ops.
@@ -81,4 +93,10 @@ class ref _Closed is _ConnectionState
     None
 
   fun ref on_timer(server: HTTPServer ref, token: lori.TimerToken) =>
+    None
+
+  fun ref on_idle_timer_failure(server: HTTPServer ref) =>
+    None
+
+  fun ref on_timer_failure(server: HTTPServer ref) =>
     None

--- a/stallion/http_server.pony
+++ b/stallion/http_server.pony
@@ -143,6 +143,12 @@ class HTTPServer is
   fun ref _on_timer(token: lori.TimerToken) =>
     _state.on_timer(this, token)
 
+  fun ref _on_idle_timer_failure() =>
+    _state.on_idle_timer_failure(this)
+
+  fun ref _on_timer_failure() =>
+    _state.on_timer_failure(this)
+
   //
   // _RequestParserNotify — forwarding parser events to receiver
   //
@@ -365,6 +371,26 @@ class HTTPServer is
     | None => _Unreachable()
     end
 
+  fun ref _handle_idle_timer_failure() =>
+    """
+    Auto-rearm the idle timer using the originally configured duration.
+    Stallion owns the idle timer, so recovery happens silently here
+    rather than leaving the connection without idle protection or
+    surfacing a failure users can't meaningfully act on.
+    """
+    match \exhaustive\ _config
+    | let c: ServerConfig => _tcp_connection.idle_timeout(c.idle_timeout)
+    | None => _Unreachable()
+    end
+
+  fun ref _handle_timer_failure() =>
+    """Forward user timer ASIO subscription failure to the receiver."""
+    match \exhaustive\ _lifecycle_event_receiver
+    | let r: HTTPServerLifecycleEventReceiver ref =>
+      r.on_timer_failure()
+    | None => _Unreachable()
+    end
+
   fun ref close() =>
     """
     Close the connection from the server actor.
@@ -411,6 +437,9 @@ class HTTPServer is
     already active returns `SetTimerAlreadyActive` — call `cancel_timer()`
     first. Requires the connection to be open; returns `SetTimerNotOpen` if
     not.
+
+    A successfully returned `TimerToken` may still fail asynchronously if
+    the underlying ASIO subscription is lost — see `on_timer_failure()`.
 
     Use `lori.MakeTimerDuration(milliseconds)` to create the duration value.
     """

--- a/stallion/http_server_lifecycle_event_receiver.pony
+++ b/stallion/http_server_lifecycle_event_receiver.pony
@@ -127,3 +127,18 @@ trait ref HTTPServerLifecycleEventReceiver
     activity.
     """
     None
+
+  fun ref on_timer_failure() =>
+    """
+    Called when a user timer's ASIO event subscription fails (e.g., the
+    kernel returned `ENOMEM` from `kevent` or `epoll_ctl`).
+
+    Before this callback fires, the timer has been cancelled — the token
+    returned by the originating `HTTPServer.set_timer()` call will not
+    produce an `on_timer()` notification. If your actor stored that
+    `TimerToken`, it is now stale; clear or replace it before re-arming.
+    The application decides how to recover: call `set_timer()` again to
+    retry, `HTTPServer.close()` to give up on the connection, or do
+    nothing if the deadline no longer matters. The default is a no-op.
+    """
+    None


### PR DESCRIPTION
Upgrades lori to 0.14.1 and handles its two new timer ASIO subscription failure callbacks.

Stallion owns the idle timer, so `_on_idle_timer_failure` is caught internally and the idle timer is auto-rearmed using the originally configured duration — no user-facing API. User timers are the user's responsibility, so `_on_timer_failure` is surfaced as a new `on_timer_failure()` callback on `HTTPServerLifecycleEventReceiver` (no-op default).

This PR spans both Fixed (silent idle-timer cancellation) and Added (new callback), so CHANGELOG and release notes were updated manually; no changelog label.