### PR TITLE
Extract OWS handling into a single `_OWS` primitive

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,6 +82,7 @@ Follow the standard ponylang release notes conventions. Create individual `.md` 
   - `_list_valued_headers.pony` — Allowlist of comma-separated list header fields and documented deny list (`_ListValuedHeaders` primitive)
   - `_response_serializer.pony` — Response wire-format serializer (package-private)
   - `_mort.pony` — Runtime enforcement primitives (`_IllegalState`, `_Unreachable`)
+  - `_ows.pony` — RFC 9110 §5.6.3 optional whitespace (SP/HTAB) — single source for the OWS predicate, zero-copy trim, and strip charset (`_OWS` primitive)
   - `parse_error.pony` — Parse error types (`ParseError` union, 10 error primitives)
   - `_parser_config.pony` — Parser size limit configuration
   - `_request_parser_notify.pony` — Parser callback trait (synchronous `ref` methods)

--- a/stallion/_accept_parser.pony
+++ b/stallion/_accept_parser.pony
@@ -14,7 +14,7 @@ primitive _AcceptParser
     let ranges = recover iso Array[_AcceptRange val] end
     let segments = _split_on_comma(header_value)
     for segment in segments.values() do
-      let trimmed = _trim_whitespace(segment)
+      let trimmed = _OWS.trim(segment)
       if trimmed.size() > 0 then
         match _parse_range(trimmed)
         | let r: _AcceptRange val => ranges.push(r)
@@ -70,7 +70,7 @@ primitive _AcceptParser
       semi = semi + 1
     end
 
-    let media_part = _trim_whitespace(segment.trim(0, semi))
+    let media_part = _OWS.trim(segment.trim(0, semi))
 
     // Find the slash in type/subtype
     var slash: USize = 0
@@ -87,9 +87,9 @@ primitive _AcceptParser
     end
 
     let type_name: String val =
-      _trim_whitespace(media_part.trim(0, slash)).lower()
+      _OWS.trim(media_part.trim(0, slash)).lower()
     let subtype: String val =
-      _trim_whitespace(media_part.trim(slash + 1)).lower()
+      _OWS.trim(media_part.trim(slash + 1)).lower()
 
     if (type_name.size() == 0) or (subtype.size() == 0) then
       return None
@@ -109,7 +109,7 @@ primitive _AcceptParser
       let param_str = segment.trim(semi + 1)
       let param_parts = _split_params(param_str)
       for part in param_parts.values() do
-        let trimmed = _trim_whitespace(part)
+        let trimmed = _OWS.trim(part)
         if trimmed.size() == 0 then continue end
 
         // Find the = in param
@@ -123,8 +123,8 @@ primitive _AcceptParser
 
         if eq < psize then
           let pname: String val =
-            _trim_whitespace(trimmed.trim(0, eq)).lower()
-          let pval = _trim_whitespace(trimmed.trim(eq + 1))
+            _OWS.trim(trimmed.trim(0, eq)).lower()
+          let pval = _OWS.trim(trimmed.trim(eq + 1))
 
           if (pname == "q") and (not found_q) then
             found_q = true
@@ -254,25 +254,3 @@ primitive _AcceptParser
     else
       s
     end
-
-  fun _trim_whitespace(s: String val): String val =>
-    """Trim leading and trailing spaces and tabs."""
-    var first: USize = 0
-    var last: USize = s.size()
-    while (first < last) and
-      try
-        let b = s(first)?
-        (b == ' ') or (b == '\t')
-      else false end
-    do
-      first = first + 1
-    end
-    while (last > first) and
-      try
-        let b = s(last - 1)?
-        (b == ' ') or (b == '\t')
-      else false end
-    do
-      last = last - 1
-    end
-    s.trim(first, last)

--- a/stallion/_keep_alive_decision.pony
+++ b/stallion/_keep_alive_decision.pony
@@ -36,11 +36,10 @@ primitive _KeepAliveDecision
 
   fun _normalize(raw: String box): String iso^ =>
     """
-    Strip optional whitespace from one connection option, then lowercase
-    it. RFC 9110 OWS is only SP and HTAB. Mirrors
-    `_TransferEncoding._normalize`; see the comment there on why two
+    Strip surrounding OWS from one connection option, then lowercase it.
+    Mirrors `_TransferEncoding._normalize`; see the comment there on why two
     near-identical normalizers exist.
     """
     let token: String ref = raw.clone()
-    token.strip(" \t")
+    token.strip(_OWS.chars())
     token.lower()

--- a/stallion/_ows.pony
+++ b/stallion/_ows.pony
@@ -1,0 +1,36 @@
+primitive _OWS
+  """
+  RFC 9110 §5.6.3 optional whitespace (OWS): only SP and HTAB.
+
+  Single source for "what counts as OWS" across the parser and the
+  list-field handlers, in the three forms the code actually needs: a byte
+  predicate, a zero-copy trim over a `String val`, and the character set
+  for stdlib `String.strip`.
+
+  This is OWS specifically — SP *or* HTAB. The request line's mandatory
+  single-SP delimiters (RFC 9112 §3) are a different thing and must not
+  use this; a delimiter that accepted HTAB would be wrong.
+  """
+
+  fun apply(b: U8): Bool =>
+    """Whether `b` is an OWS byte (SP or HTAB)."""
+    (b == ' ') or (b == '\t')
+
+  fun trim(s: String val): String val =>
+    """
+    Return `s` with leading and trailing OWS removed, as a zero-copy view
+    (no allocation).
+    """
+    var first: USize = 0
+    var last: USize = s.size()
+    while (first < last) and try apply(s(first)?) else false end do
+      first = first + 1
+    end
+    while (last > first) and try apply(s(last - 1)?) else false end do
+      last = last - 1
+    end
+    s.trim(first, last)
+
+  fun chars(): String =>
+    """The OWS character set, for use with stdlib `String.strip`."""
+    " \t"

--- a/stallion/_parser_state.pony
+++ b/stallion/_parser_state.pony
@@ -287,7 +287,7 @@ class _ExpectHeaders is _ParserState
         // Check for obs-fold (continuation line): reject per RFC 7230
         try
           let first_byte = p.buf(p.pos)?
-          if (first_byte == ' ') or (first_byte == '\t') then
+          if _OWS(first_byte) then
             return MalformedHeaders
           end
         else
@@ -313,7 +313,7 @@ class _ExpectHeaders is _ParserState
         try
           while val_start < crlf do
             let ch = p.buf(val_start)?
-            if (ch != ' ') and (ch != '\t') then break end
+            if not _OWS(ch) then break end
             val_start = val_start + 1
           end
         else
@@ -325,7 +325,7 @@ class _ExpectHeaders is _ParserState
         try
           while val_end > val_start do
             let ch = p.buf(val_end - 1)?
-            if (ch != ' ') and (ch != '\t') then break end
+            if not _OWS(ch) then break end
             val_end = val_end - 1
           end
         else

--- a/stallion/_test.pony
+++ b/stallion/_test.pony
@@ -12,6 +12,9 @@ actor \nodoc\ Main is TestList
     test(Property1UnitTest[(String val, Bool)](
       _PropertyMethodParseBoundary))
 
+    // OWS tests
+    test(_TestOWS)
+
     // Headers tests
     test(Property1UnitTest[(String val, String val)](
       _PropertyHeadersCaseInsensitive))

--- a/stallion/_test_ows.pony
+++ b/stallion/_test_ows.pony
@@ -1,0 +1,46 @@
+use "pony_test"
+
+class \nodoc\ iso _TestOWS is UnitTest
+  """
+  Verify the `_OWS` predicate, zero-copy trim, and strip-charset.
+  """
+  fun name(): String => "ows/predicate_and_trim"
+
+  fun apply(h: TestHelper) =>
+    // Predicate: only SP and HTAB are OWS.
+    h.assert_true(_OWS(' '), "SP is OWS")
+    h.assert_true(_OWS('\t'), "HTAB is OWS")
+    h.assert_false(_OWS('a'), "letter is not OWS")
+    h.assert_false(_OWS('\r'), "CR is not OWS")
+    h.assert_false(_OWS('\n'), "LF is not OWS")
+    h.assert_false(_OWS('\v'), "vertical tab is not OWS")
+    h.assert_false(_OWS('\f'), "form feed is not OWS")
+    h.assert_false(_OWS(0), "NUL is not OWS")
+    h.assert_false(_OWS(0xFF), "0xFF is not OWS")
+
+    // trim: leading, trailing, both, none, all-OWS, empty.
+    h.assert_eq[String val]("x", _OWS.trim("  \tx"), "leading OWS")
+    h.assert_eq[String val]("x", _OWS.trim("x\t  "), "trailing OWS")
+    h.assert_eq[String val]("x y", _OWS.trim(" \tx y\t "), "both ends")
+    h.assert_eq[String val]("x y", _OWS.trim("x y"), "no OWS")
+    h.assert_eq[String val]("", _OWS.trim(" \t \t"), "all OWS")
+    h.assert_eq[String val]("", _OWS.trim(""), "empty string")
+
+    // trim does not touch interior OWS or non-OWS whitespace at the edges.
+    h.assert_eq[String val]("a\tb", _OWS.trim(" a\tb "), "interior HTAB kept")
+    h.assert_eq[String val]("\nx\n", _OWS.trim(" \nx\n "),
+      "CR/LF are not trimmed")
+
+    // trim returns a zero-copy view into the source — not a fresh
+    // allocation. This is the reason the helper exists in this form
+    // rather than cloning; a non-empty result must alias the source
+    // buffer. Source has two leading OWS bytes, so the view starts at
+    // offset 2.
+    let src: String val = "  x y "
+    h.assert_eq[USize](
+      src.cpointer(2).usize(),
+      _OWS.trim(src).cpointer().usize(),
+      "trim returns a zero-copy view aliasing the source")
+
+    // chars: the set passed to stdlib String.strip.
+    h.assert_eq[String val](" \t", _OWS.chars(), "OWS charset")

--- a/stallion/_transfer_encoding.pony
+++ b/stallion/_transfer_encoding.pony
@@ -51,7 +51,7 @@ primitive _TransferEncoding
     """
     let cut_at: ISize = try raw.find(";")? else raw.size().isize() end
     let coding: String ref = raw.substring(0, cut_at)
-    coding.strip(" \t") // RFC 9110 OWS is only SP and HTAB
+    coding.strip(_OWS.chars())
     coding.lower()
 
   fun evaluate(tokens: Array[String] box)

--- a/stallion/parse_cookies.pony
+++ b/stallion/parse_cookies.pony
@@ -61,7 +61,7 @@ primitive ParseCookies
 
       // Extract the segment and trim whitespace
       let segment = header_value.trim(start, semi)
-      let trimmed = _trim_whitespace(segment)
+      let trimmed = _OWS.trim(segment)
 
       if trimmed.size() > 0 then
         // Find first "="
@@ -74,8 +74,8 @@ primitive ParseCookies
         end
 
         if eq < tsize then
-          let name = _trim_whitespace(trimmed.trim(0, eq))
-          var value = _trim_whitespace(trimmed.trim(eq + 1))
+          let name = _OWS.trim(trimmed.trim(0, eq))
+          var value = _OWS.trim(trimmed.trim(eq + 1))
 
           // Strip surrounding double quotes
           if (value.size() >= 2) and
@@ -94,25 +94,3 @@ primitive ParseCookies
 
       start = semi + 1
     end
-
-  fun _trim_whitespace(s: String val): String val =>
-    """Trim leading and trailing spaces and tabs."""
-    var first: USize = 0
-    var last: USize = s.size()
-    while (first < last) and
-      try
-        let b = s(first)?
-        (b == ' ') or (b == '\t')
-      else false end
-    do
-      first = first + 1
-    end
-    while (last > first) and
-      try
-        let b = s(last - 1)?
-        (b == ' ') or (b == '\t')
-      else false end
-    do
-      last = last - 1
-    end
-    s.trim(first, last)


### PR DESCRIPTION
The RFC 9110 definition of optional whitespace, SP or HTAB, was written
seven ways across the package: two byte-identical `_trim_whitespace`
functions, two `strip(" \t")` calls, and three inline byte checks in the
parser. One fact, seven copies, where a change to any one should change all
seven. This pulls it into a single `_OWS` primitive holding the predicate, a
zero-copy trim, and the strip charset.

This is the real duplication behind #117. The header combining the issue set
out to unify isn't duplication: those sites differ by policy or are
architecturally separate (Transfer-Encoding combines during parsing, before
`Headers` exists), so unifying them would change behavior rather than remove
repetition. The issue has the full rationale.

The change is behavior-preserving; every replacement is an exact identity.

Closes #117
