### PR TITLE
Fix parsing of quoted parameter values in Transfer-Encoding and Accept headers

### DIFF
--- a/.release-notes/fix-quoted-parameter-values.md
+++ b/.release-notes/fix-quoted-parameter-values.md
@@ -1,0 +1,3 @@
+## Fix parsing of quoted parameter values in Transfer-Encoding and Accept headers
+
+Fixed several bugs in how quoted parameter values are parsed in `Transfer-Encoding` and `Accept` header fields.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,7 @@ Follow the standard ponylang release notes conventions. Create individual `.md` 
   - `_response_serializer.pony` — Response wire-format serializer (package-private)
   - `_mort.pony` — Runtime enforcement primitives (`_IllegalState`, `_Unreachable`)
   - `_ows.pony` — RFC 9110 §5.6.3 optional whitespace (SP/HTAB) — single source for the OWS predicate, zero-copy trim, and strip charset (`_OWS` primitive)
+  - `_quoted_split.pony` — RFC 9110 §5.6.4 quoted-string-aware delimiter split (`_QuotedSplit` primitive) — shared by the Transfer-Encoding and Accept parsers so a delimiter inside a quoted parameter value (including `quoted-pair` escapes) does not split an element; returns `(segments, unterminated)` so the framing path can reject a malformed (unterminated-quote) value while Accept ignores it
   - `parse_error.pony` — Parse error types (`ParseError` union, 10 error primitives)
   - `_parser_config.pony` — Parser size limit configuration
   - `_request_parser_notify.pony` — Parser callback trait (synchronous `ref` methods)

--- a/stallion/_accept_parser.pony
+++ b/stallion/_accept_parser.pony
@@ -12,7 +12,7 @@ primitive _AcceptParser
   fun apply(header_value: String val): Array[_AcceptRange val] val =>
     """Parse a single Accept header value string."""
     let ranges = recover iso Array[_AcceptRange val] end
-    let segments = _split_on_comma(header_value)
+    (let segments, _) = _QuotedSplit(header_value, ',')
     for segment in segments.values() do
       let trimmed = _OWS.trim(segment)
       if trimmed.size() > 0 then
@@ -22,34 +22,6 @@ primitive _AcceptParser
       end
     end
     consume ranges
-
-  fun _split_on_comma(s: String val): Array[String val] val =>
-    """
-    Split on commas, respecting quoted strings.
-
-    Commas inside double-quoted parameter values are not treated as
-    separators.
-    """
-    let result = recover iso Array[String val] end
-    var start: USize = 0
-    var i: USize = 0
-    var in_quotes: Bool = false
-    let size = s.size()
-
-    while i < size do
-      try
-        let b = s(i)?
-        if b == '"' then
-          in_quotes = not in_quotes
-        elseif (b == ',') and (not in_quotes) then
-          result.push(s.trim(start, i))
-          start = i + 1
-        end
-      end
-      i = i + 1
-    end
-    result.push(s.trim(start, size))
-    consume result
 
   fun _parse_range(segment: String val): (_AcceptRange val | None) =>
     """
@@ -107,7 +79,7 @@ primitive _AcceptParser
 
     if semi < size then
       let param_str = segment.trim(semi + 1)
-      let param_parts = _split_params(param_str)
+      (let param_parts, _) = _QuotedSplit(param_str, ';')
       for part in param_parts.values() do
         let trimmed = _OWS.trim(part)
         if trimmed.size() == 0 then continue end
@@ -147,29 +119,6 @@ primitive _AcceptParser
       // Quality out of range — skip this entry
       None
     end
-
-  fun _split_params(s: String val): Array[String val] val =>
-    """Split parameter string on semicolons, respecting quoted strings."""
-    let result = recover iso Array[String val] end
-    var start: USize = 0
-    var i: USize = 0
-    var in_quotes: Bool = false
-    let size = s.size()
-
-    while i < size do
-      try
-        let b = s(i)?
-        if b == '"' then
-          in_quotes = not in_quotes
-        elseif (b == ';') and (not in_quotes) then
-          result.push(s.trim(start, i))
-          start = i + 1
-        end
-      end
-      i = i + 1
-    end
-    result.push(s.trim(start, size))
-    consume result
 
   fun _parse_quality(s: String val): U16 =>
     """

--- a/stallion/_parser_state.pony
+++ b/stallion/_parser_state.pony
@@ -208,6 +208,9 @@ class _ExpectHeaders is _ParserState
   var _content_length: (USize | None) = None
   var _has_transfer_encoding: Bool = false
   embed _te_codings: Array[String] = Array[String]
+  // Conjunction of every `append_codings` result; false once any
+  // Transfer-Encoding line is malformed (an unterminated quoted-string).
+  var _te_well_formed: Bool = true
   var _total_header_bytes: USize = 0
 
   new create(
@@ -243,7 +246,8 @@ class _ExpectHeaders is _ParserState
           // body (RFC 9112 §6.1/§6.3).
           let use_chunked: Bool =
             if _has_transfer_encoding then
-              match \exhaustive\ _TransferEncoding.evaluate(_te_codings)
+              match \exhaustive\
+                _TransferEncoding.evaluate(_te_codings, _te_well_formed)
               | _ChunkedFraming => true
               | let e: ParseError => return e
               end
@@ -351,7 +355,9 @@ class _ExpectHeaders is _ParserState
           end
         elseif lower_name == "transfer-encoding" then
           _has_transfer_encoding = true
-          _TransferEncoding.append_codings(value, _te_codings)
+          _te_well_formed =
+            _TransferEncoding.append_codings(value, _te_codings)
+              and _te_well_formed
         end
 
         _headers.add(name, value)

--- a/stallion/_quoted_split.pony
+++ b/stallion/_quoted_split.pony
@@ -1,0 +1,56 @@
+primitive _QuotedSplit
+  """
+  Split a header field value on a delimiter byte, respecting quoted strings.
+
+  HTTP list-valued fields (RFC 9110 §5.6.1) and parameterized fields separate
+  elements with a delimiter — `,` between list members, `;` between
+  parameters. A `quoted-string` parameter value (RFC 9110 §5.6.4) may itself
+  contain that delimiter, so a naive byte split tears a legal value in half:
+  `chunked;ext="a,b"` is one coding with one parameter, not two codings.
+
+  This splitter tracks whether the scan is inside a double-quoted string and
+  only treats a delimiter as a separator when it occurs outside one. Within a
+  quoted string a `\` begins a `quoted-pair` (RFC 9110 §5.6.4): the next octet
+  is literal data, so an escaped quote (`\"`) does not close the string and an
+  escaped delimiter is not a separator.
+
+  Segments are returned as zero-copy views, with the quotes, escapes, and any
+  surrounding whitespace preserved — callers own trimming and normalization.
+  An unterminated quoted string yields the remainder as a final segment rather
+  than erroring; the second tuple element reports whether the scan ended
+  inside an open quote, so a caller that needs to reject malformed input (the
+  Transfer-Encoding framing path) can, while a lenient caller (Accept) ignores
+  it.
+  """
+
+  fun apply(s: String val, delimiter: U8): (Array[String val] val, Bool) =>
+    """
+    Split `s` on `delimiter`, ignoring delimiters inside quoted strings.
+
+    Returns the segments and `unterminated`: `true` when the scan ended inside
+    an unclosed quoted string (the value is malformed).
+    """
+    let result = recover iso Array[String val] end
+    var start: USize = 0
+    var i: USize = 0
+    var in_quotes: Bool = false
+    let size = s.size()
+
+    while i < size do
+      try
+        let b = s(i)?
+        if in_quotes and (b == '\\') then
+          // quoted-pair: skip the escaped octet so it can neither close the
+          // quoted string nor act as a separator.
+          i = i + 1
+        elseif b == '"' then
+          in_quotes = not in_quotes
+        elseif (b == delimiter) and (not in_quotes) then
+          result.push(s.trim(start, i))
+          start = i + 1
+        end
+      end
+      i = i + 1
+    end
+    result.push(s.trim(start, size))
+    (consume result, in_quotes)

--- a/stallion/_test.pony
+++ b/stallion/_test.pony
@@ -15,6 +15,9 @@ actor \nodoc\ Main is TestList
     // OWS tests
     test(_TestOWS)
 
+    // Quoted-split tokenizer tests
+    test(_TestQuotedSplit)
+
     // Headers tests
     test(Property1UnitTest[(String val, String val)](
       _PropertyHeadersCaseInsensitive))
@@ -89,6 +92,8 @@ actor \nodoc\ Main is TestList
     test(_TestTransferEncodingEmpty)
     test(_TestTransferEncodingUppercase)
     test(_TestTransferEncodingWithParams)
+    test(_TestTransferEncodingQuotedComma)
+    test(_TestTransferEncodingUnterminatedQuote)
     test(_TestTransferEncodingTrailingComma)
     test(_TestTransferEncodingMultiLine)
     test(_TestTransferEncodingEvaluate)

--- a/stallion/_test_content_negotiation.pony
+++ b/stallion/_test_content_negotiation.pony
@@ -573,6 +573,8 @@ class \nodoc\ iso _TestAcceptParserKnownGood is UnitTest
     _test_malformed_skipped(h)
     _test_empty_string(h)
     _test_quoted_comma_not_split(h)
+    _test_quoted_pair_comma_not_split(h)
+    _test_quoted_semicolon_not_split(h)
     _test_wildcard_subtype_only_skipped(h)
     _test_accept_extension_not_in_params(h)
     _test_duplicate_range_first_wins(h)
@@ -671,10 +673,12 @@ class \nodoc\ iso _TestAcceptParserKnownGood is UnitTest
     h.assert_eq[USize](0, ranges.size(), "empty: count")
 
   fun _test_quoted_comma_not_split(h: TestHelper) =>
-    // Comma inside a quoted parameter value must not split entries.
-    // Without quote awareness, "a,b" would split into two entries.
+    // Comma inside a quoted parameter value must not split entries. The
+    // quoted value embeds a slash so that a mis-split would not just mangle
+    // the entry but produce a spurious extra range (`x/y"`), making the
+    // count assertion discriminating.
     let ranges = _AcceptParser(
-      "text/html;param=\"a,b\", application/json")
+      "text/html;param=\"a,x/y\", application/json")
     h.assert_eq[USize](2, ranges.size(), "quoted comma: count")
     try
       h.assert_eq[String val]("text", ranges(0)?.type_name,
@@ -687,6 +691,43 @@ class \nodoc\ iso _TestAcceptParserKnownGood is UnitTest
         "quoted comma: 1 subtype")
     else
       h.fail("quoted comma: index error")
+    end
+
+  fun _test_quoted_pair_comma_not_split(h: TestHelper) =>
+    // An escaped quote inside a quoted parameter value must not be mistaken
+    // for the closing quote, so the comma that follows still belongs to the
+    // first entry. Without quoted-pair handling the entry is torn apart and
+    // the second range parses with a garbage type name.
+    let ranges = _AcceptParser(
+      "text/html;param=\"a\\\",b\", application/json")
+    h.assert_eq[USize](2, ranges.size(), "quoted pair: count")
+    try
+      h.assert_eq[String val]("text", ranges(0)?.type_name,
+        "quoted pair: 0 type")
+      h.assert_eq[String val]("html", ranges(0)?.subtype,
+        "quoted pair: 0 subtype")
+      h.assert_eq[String val]("application", ranges(1)?.type_name,
+        "quoted pair: 1 type")
+      h.assert_eq[String val]("json", ranges(1)?.subtype,
+        "quoted pair: 1 subtype")
+    else
+      h.fail("quoted pair: index error")
+    end
+
+  fun _test_quoted_semicolon_not_split(h: TestHelper) =>
+    // A semicolon inside a quoted parameter value must not split parameters.
+    // The quoted value here hides a decoy `q=0.1`; if the `;` split ignored
+    // quotes, that decoy would be read as the quality (100) instead of the
+    // real `q=0.5` (500) that follows the quoted value.
+    let ranges = _AcceptParser("text/html;param=\"x;q=0.1\";q=0.5")
+    h.assert_eq[USize](1, ranges.size(), "quoted semicolon: count")
+    try
+      h.assert_eq[String val]("text", ranges(0)?.type_name,
+        "quoted semicolon: type")
+      h.assert_eq[U16](500, ranges(0)?.quality(),
+        "quoted semicolon: quality")
+    else
+      h.fail("quoted semicolon: index error")
     end
 
   fun _test_wildcard_subtype_only_skipped(h: TestHelper) =>

--- a/stallion/_test_quoted_split.pony
+++ b/stallion/_test_quoted_split.pony
@@ -1,0 +1,62 @@
+use "pony_test"
+
+class \nodoc\ iso _TestQuotedSplit is UnitTest
+  """
+  Verify `_QuotedSplit` splits on a delimiter while treating quoted strings
+  (including `quoted-pair` backslash escapes) as opaque.
+  """
+  fun name(): String => "quoted_split/split"
+
+  fun apply(h: TestHelper) =>
+    // Plain splitting on each delimiter the package uses. `false` = the
+    // value's quotes are balanced (not unterminated).
+    _check(h, "a,b,c", ',', [as String val: "a"; "b"; "c"], false)
+    _check(h, "a;b;c", ';', [as String val: "a"; "b"; "c"], false)
+
+    // A delimiter inside a quoted string is not a separator. The quotes are
+    // preserved — callers do their own stripping.
+    _check(h, "a,\"b,c\",d", ',', [as String val: "a"; "\"b,c\""; "d"], false)
+    _check(h, "a;\"b;c\";d", ';', [as String val: "a"; "\"b;c\""; "d"], false)
+
+    // quoted-pair: an escaped quote does not close the string, so a comma
+    // that follows inside the same quoted string stays attached. Without
+    // escape handling, `ext="a\",b"` would split into `ext="a\"` and `b"`.
+    _check(h, "ext=\"a\\\",b\"", ',', [as String val: "ext=\"a\\\",b\""],
+      false)
+
+    // quoted-pair, opposite direction: the escaped quote keeps the real
+    // closing quote from being mistaken for a re-open, so the trailing comma
+    // does split. Without escape handling this collapses to one segment.
+    _check(h, "x=\"a\\\"b\",y", ',',
+      [as String val: "x=\"a\\\"b\""; "y"], false)
+
+    // Edges: empty input, leading/trailing/consecutive delimiters all yield
+    // empty segments (the caller decides whether to drop them).
+    _check(h, "", ',', [as String val: ""], false)
+    _check(h, ",a", ',', [as String val: ""; "a"], false)
+    _check(h, "a,", ',', [as String val: "a"; ""], false)
+    _check(h, "a,,b", ',', [as String val: "a"; ""; "b"], false)
+
+    // Unterminated quoted strings swallow the rest of the value rather than
+    // erroring, and report `unterminated = true` so a strict caller can
+    // reject. A trailing backslash inside the open quote is handled safely.
+    _check(h, "\"a,b", ',', [as String val: "\"a,b"], true)
+    _check(h, "a,\"b", ',', [as String val: "a"; "\"b"], true)
+    _check(h, "\"a\\", ',', [as String val: "\"a\\"], true)
+
+  fun _check(h: TestHelper, s: String val, delimiter: U8,
+    expected: Array[String val] box, unterminated: Bool)
+  =>
+    (let actual, let ended_open) = _QuotedSplit(s, delimiter)
+    h.assert_eq[Bool](unterminated, ended_open,
+      "unterminated flag for \"" + s + "\"")
+    h.assert_eq[USize](expected.size(), actual.size(),
+      "segment count for \"" + s + "\"")
+    var i: USize = 0
+    while i < expected.size() do
+      try
+        h.assert_eq[String val](expected(i)?, actual(i)?,
+          "segment " + i.string() + " of \"" + s + "\"")
+      end
+      i = i + 1
+    end

--- a/stallion/_test_request_parser.pony
+++ b/stallion/_test_request_parser.pony
@@ -1021,6 +1021,50 @@ class \nodoc\ iso _TestTransferEncodingWithParams is UnitTest
     h.assert_eq[USize](0, notify.errors.size(), "0 errors")
     h.assert_eq[String val]("Hello", notify.collected_body_string())
 
+class \nodoc\ iso _TestTransferEncodingQuotedComma is UnitTest
+  """
+  `chunked;ext="a,b"` → comma inside the quoted parameter value does not
+  split the coding (RFC 9112 §7) → chunked framing, body parsed.
+  """
+  fun name(): String => "parser/transfer_encoding_quoted_comma"
+
+  fun apply(h: TestHelper) =>
+    let raw: String val =
+      "POST / HTTP/1.1\r\n" +
+      "Transfer-Encoding: chunked;ext=\"a,b\"\r\n\r\n" +
+      "5\r\nHello\r\n0\r\n\r\n"
+    let notify: _TestParserNotify ref = _TestParserNotify
+    let parser = _RequestParser(notify)
+    parser.parse(recover raw.array().clone() end)
+
+    h.assert_eq[USize](1, notify.requests.size(), "1 request")
+    h.assert_eq[USize](1, notify.completed, "1 completion")
+    h.assert_eq[USize](0, notify.errors.size(), "0 errors")
+    h.assert_eq[String val]("Hello", notify.collected_body_string())
+
+class \nodoc\ iso _TestTransferEncodingUnterminatedQuote is UnitTest
+  """
+  `chunked;x=",identity` → unterminated quoted-string parameter value is
+  malformed → rejected as InvalidTransferEncoding (400), not framed as chunked.
+  """
+  fun name(): String => "parser/transfer_encoding_unterminated_quote"
+
+  fun apply(h: TestHelper) =>
+    let raw: String val =
+      "POST / HTTP/1.1\r\n" +
+      "Transfer-Encoding: chunked;x=\",identity\r\n\r\n"
+    let notify: _TestParserNotify ref = _TestParserNotify
+    let parser = _RequestParser(notify)
+    parser.parse(recover raw.array().clone() end)
+
+    h.assert_eq[USize](0, notify.requests.size(), "no request delivered")
+    h.assert_eq[USize](0, notify.completed, "no completion")
+    h.assert_eq[USize](1, notify.errors.size(), "1 error")
+    try
+      h.assert_true(notify.errors(0)? is InvalidTransferEncoding,
+        "should be InvalidTransferEncoding")
+    end
+
 class \nodoc\ iso _TestTransferEncodingTrailingComma is UnitTest
   """`chunked,` → empty element ignored → chunked framing."""
   fun name(): String => "parser/transfer_encoding_trailing_comma"
@@ -1067,12 +1111,27 @@ class \nodoc\ iso _TestTransferEncodingEvaluate is UnitTest
       String.>push(0x0b).>append("chunked").>push(0x0b)
     end
     _check(h, vtab, "unsupported")
+    // A comma inside a quoted transfer-parameter value (RFC 9112 §7) must
+    // not split the coding. Before the quoted-string-aware tokenizer these
+    // were torn in half and rejected as invalid/unsupported.
+    _check(h, "chunked;ext=\"a,b\"", "chunked")
+    _check(h, "chunked; ext=\"a, b\"", "chunked")
+    // quoted-pair: the escaped quote keeps the comma inside the still-open
+    // (then closed) quoted string, so it remains a single `chunked` coding.
+    _check(h, "chunked;ext=\"a\\\",b\"", "chunked")
+    // An unterminated quoted-string is malformed: the value cannot be parsed
+    // into a reliable coding list, so it is rejected (400) rather than framed
+    // on a guess — regardless of whether the swallowed tail contains a comma.
+    _check(h, "chunked;ext=\"a", "invalid")
+    _check(h, "chunked;x=\",identity", "invalid")
+    _check(h, "chunked;x=\",gzip", "invalid")
+    _check(h, "chunked;x=\"", "invalid")
 
   fun _check(h: TestHelper, value: String val, expected: String) =>
     let tokens = Array[String]
-    _TransferEncoding.append_codings(value, tokens)
+    let well_formed = _TransferEncoding.append_codings(value, tokens)
     let actual =
-      match \exhaustive\ _TransferEncoding.evaluate(tokens)
+      match \exhaustive\ _TransferEncoding.evaluate(tokens, well_formed)
       | _ChunkedFraming => "chunked"
       | UnsupportedTransferEncoding => "unsupported"
       | InvalidTransferEncoding => "invalid"

--- a/stallion/_transfer_encoding.pony
+++ b/stallion/_transfer_encoding.pony
@@ -16,24 +16,30 @@ primitive _TransferEncoding
   (case-insensitively) — never by substring.
   """
 
-  fun append_codings(value: String val, tokens: Array[String] ref) =>
+  fun append_codings(value: String val, tokens: Array[String] ref): Bool =>
     """
     Tokenize one Transfer-Encoding field value and append each normalized
-    coding name to `tokens`.
+    coding name to `tokens`. Returns `false` if the value was malformed
+    (an unterminated quoted-string), in which case the caller must treat the
+    whole Transfer-Encoding as invalid rather than trust the tokens.
 
-    Each token is normalized by removing any `;`-delimited parameters,
-    stripping surrounding optional whitespace, and lowercasing. Empty
-    list elements are ignored per RFC 9110 §5.6.1. Tokens are appended in
-    order so a caller can determine which coding is final across multiple
+    The value is split on `,` with `_QuotedSplit`, which respects quoted
+    strings so a comma inside a `quoted-string` transfer-parameter value
+    (RFC 9112 §7) does not tear a coding apart. Each token is then
+    normalized by removing any `;`-delimited parameters, stripping
+    surrounding optional whitespace, and lowercasing. Empty list elements
+    are ignored per RFC 9110 §5.6.1. Tokens are appended in order so a
+    caller can determine which coding is final across multiple
     Transfer-Encoding header lines.
     """
-    let parts: Array[String] = value.split(",")
+    (let parts, let unterminated) = _QuotedSplit(value, ',')
     for raw in parts.values() do
       let coding: String = _normalize(raw)
       if coding.size() > 0 then
         tokens.push(coding)
       end
     end
+    not unterminated
 
   fun _normalize(raw: String box): String iso^ =>
     """
@@ -44,8 +50,10 @@ primitive _TransferEncoding
     resolved during parsing, before the body, so it accumulates per line and
     cannot wait for a complete `Headers`), `ContentNegotiation.from_request`
     (Accept), and `Headers.get` (everything in `_ListValuedHeaders`,
-    including Connection). Unifying them is tracked in issue #117; until
-    then, this normalizer stays local. `_KeepAliveDecision._normalize` is the
+    including Connection). Issue #117 examined unifying these and concluded
+    they differ by policy — separator, per-token normalization, and when
+    combining must happen — so the combining stays per site; this normalizer
+    is Transfer-Encoding's own. `_KeepAliveDecision._normalize` is the
     near-identical sibling (it omits the `;`-parameter cut, as connection
     options have none).
     """
@@ -54,7 +62,7 @@ primitive _TransferEncoding
     coding.strip(_OWS.chars())
     coding.lower()
 
-  fun evaluate(tokens: Array[String] box)
+  fun evaluate(tokens: Array[String] box, well_formed: Bool)
     : (_ChunkedFraming | UnsupportedTransferEncoding | InvalidTransferEncoding)
   =>
     """
@@ -63,7 +71,16 @@ primitive _TransferEncoding
     Only `chunked`, as the sole/final coding, is supported. Any other
     coding is unsupported (501). A list that cannot frame the message —
     empty, `chunked` repeated, or `chunked` not final — is invalid (400).
+
+    `well_formed` is the conjunction of every contributing `append_codings`
+    result; a malformed value (an unterminated quoted-string) cannot be
+    parsed into a reliable coding list, so the message is invalid (400)
+    rather than framed on a guess.
     """
+    if not well_formed then
+      return InvalidTransferEncoding
+    end
+
     if tokens.size() == 0 then
       // Header present but no usable codings (empty or all-empty value).
       return InvalidTransferEncoding


### PR DESCRIPTION
The Transfer-Encoding and Accept parsers split header field values on `,`
(and Accept's parameters on `;`) without respecting quoted strings, so a
delimiter inside a quoted parameter value tore a legal value in half — a
valid `Transfer-Encoding: chunked;ext="a,b"` was rejected as a bad request.

This extracts a single quoted-string-aware delimiter splitter, `_QuotedSplit`,
shared by both parsers, that also honors RFC 9110 quoted-pair backslash
escapes. The Transfer-Encoding framing path additionally rejects a value
whose quoted string is unterminated, since malformed framing metadata should
be refused rather than framed on a guess.

Closes #120
