### PR TITLE
Reject requests vulnerable to HTTP request smuggling

### DIFF
--- a/.release-notes/reject-requests-vulnerable-to-request-smuggling.md
+++ b/.release-notes/reject-requests-vulnerable-to-request-smuggling.md
@@ -1,0 +1,9 @@
+## Reject requests vulnerable to HTTP request smuggling
+
+Stallion accepted two kinds of malformed request that are recognized HTTP request-smuggling vectors. When Stallion sits behind or in front of another HTTP intermediary that interprets the malformed request differently, the two can desynchronize about where one request ends and the next begins, letting a smuggled request slip past.
+
+The first is a request carrying both a `Content-Length` and a `Transfer-Encoding` header. Stallion previously let the chunked framing win and processed the request; it now rejects any request carrying both headers, regardless of their values, per RFC 9112 §6.3.
+
+The second is a request whose header field name is not a valid token — for example a name with whitespace before the colon (`Content-Length : 100`), whitespace inside the name (`Content -Length: 100`), or other characters RFC 9110 §5.6.2 does not permit. Stallion previously treated such a line as a header with an unusual, unrecognized name; it now requires every field name to be a valid token. This also satisfies RFC 9112 §5.1, which requires rejecting whitespace between a field name and its colon.
+
+In both cases Stallion now responds with `400 Bad Request` and closes the connection.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,14 @@ make clean           # clean build artifacts
 
 The `ssl` option is required because this library and lori depend on the `ssl` package.
 
+## RFC conformance
+
+Stallion conforms to the HTTP RFCs. We reject what the RFCs say to reject and accept what they say to accept — and we stop there. We do not add non-conformant behavior to compensate for an intermediary that mishandles a conformant message.
+
+A proxy that normalizes a message in a way the spec forbids — mapping `_` to `-` in a field name, trimming whitespace a recipient is required to reject, splitting on a bare LF — can desynchronize from us. That is the intermediary's bug, and it is outside our control. It is not a reason for us to deviate from the spec, because the deviation would break conformant clients to chase a misbehaving party we cannot fix.
+
+This is why our request-smuggling defenses go exactly as far as the RFCs do and no further. We reject `Content-Length` together with `Transfer-Encoding` (RFC 9112 §6.3) and reject a field name that is not a valid token (RFC 9110 §5.6.2, RFC 9112 §5.1) because the RFCs say to. We do *not* reject a field name like `X_Custom` to defend against an upstream that might rewrite the underscore — the underscore is a valid token character, so we accept it.
+
 ## Architecture
 
 Package: `stallion` (repo name is `stallion`, Pony package name is `stallion`)
@@ -83,8 +91,9 @@ Follow the standard ponylang release notes conventions. Create individual `.md` 
   - `_response_serializer.pony` — Response wire-format serializer (package-private)
   - `_mort.pony` — Runtime enforcement primitives (`_IllegalState`, `_Unreachable`)
   - `_ows.pony` — RFC 9110 §5.6.3 optional whitespace (SP/HTAB) — single source for the OWS predicate, zero-copy trim, and strip charset (`_OWS` primitive)
+  - `_token.pony` — RFC 9110 §5.6.2 token (`tchar`) — single source for the token-character predicate and whole-string validity (`_Token` primitive); used to validate HTTP field names (RFC 9112 §5.1) and cookie names
   - `_quoted_split.pony` — RFC 9110 §5.6.4 quoted-string-aware delimiter split (`_QuotedSplit` primitive) — shared by the Transfer-Encoding and Accept parsers so a delimiter inside a quoted parameter value (including `quoted-pair` escapes) does not split an element; returns `(segments, unterminated)` so the framing path can reject a malformed (unterminated-quote) value while Accept ignores it
-  - `parse_error.pony` — Parse error types (`ParseError` union, 10 error primitives)
+  - `parse_error.pony` — Parse error types (`ParseError` union, 11 error primitives)
   - `_parser_config.pony` — Parser size limit configuration
   - `_request_parser_notify.pony` — Parser callback trait (synchronous `ref` methods)
   - `_transfer_encoding.pony` — Transfer-Encoding tokenizer and RFC 9112 §6.1/§6.3 coding decision (`_TransferEncoding` primitive, `_ChunkedFraming` sentinel)
@@ -113,7 +122,7 @@ Follow the standard ponylang release notes conventions. Create individual `.md` 
   - `set_cookie_build_error.pony` — Build error types (`InvalidCookieName`, `InvalidCookieValue`, `InvalidCookiePath`, `InvalidCookieDomain`, `CookiePrefixViolation`, `SameSiteRequiresSecure`, `SetCookieBuildError` union)
   - `set_cookie.pony` — Validated, pre-serialized `Set-Cookie` header (`SetCookie val`, `header_value()`, private constructor)
   - `set_cookie_builder.pony` — `Set-Cookie` header builder (`SetCookieBuilder ref`, secure defaults, chaining, prefix rules)
-  - `_cookie_validator.pony` — Cookie name/value/attribute validation (RFC 2616 token, RFC 6265 cookie-octet, path/domain safety)
+  - `_cookie_validator.pony` — Cookie name/value/attribute validation (cookie names via `_Token`, RFC 6265 cookie-octet, path/domain safety)
   - `_http_date.pony` — IMF-fixdate formatter for `Expires` attribute (`_HTTPDate` primitive)
   - `media_type.pony` — HTTP media type (`MediaType val` class, `Equatable & Stringable`)
   - `no_acceptable_type.pony` — Content negotiation failure (`NoAcceptableType` primitive)

--- a/stallion/_cookie_validator.pony
+++ b/stallion/_cookie_validator.pony
@@ -11,11 +11,7 @@ primitive _CookieValidator
 
   fun valid_name(name: String box): Bool =>
     """Return true if `name` is a valid cookie name (RFC 2616 token)."""
-    if name.size() == 0 then return false end
-    for byte in name.values() do
-      if not _is_token_char(byte) then return false end
-    end
-    true
+    _Token.valid(name)
 
   fun valid_value(value: String box): Bool =>
     """Return true if `value` contains only valid cookie-octets."""
@@ -23,23 +19,6 @@ primitive _CookieValidator
       if not _is_cookie_octet(byte) then return false end
     end
     true
-
-  fun _is_token_char(b: U8): Bool =>
-    """
-    RFC 2616 token character: ASCII 33–126 minus separators.
-
-    Separators: ( ) < > @ , ; : \\ " / [ ] ? = { }
-    """
-    if (b < 33) or (b > 126) then return false end
-    // Check separators
-    match b
-    | '(' | ')' | '<' | '>' | '@'
-    | ',' | ';' | ':' | '\\' | '"'
-    | '/' | '[' | ']' | '?' | '='
-    | '{' | '}' => false
-    else
-      true
-    end
 
   fun _is_cookie_octet(b: U8): Bool =>
     """

--- a/stallion/_parser_state.pony
+++ b/stallion/_parser_state.pony
@@ -233,6 +233,16 @@ class _ExpectHeaders is _ParserState
           // Empty line: end of headers
           p.pos = crlf + 2
 
+          // A request carrying both Content-Length and Transfer-Encoding is a
+          // request-smuggling vector (RFC 9112 §6.3). Reject it before any
+          // other framing decision: a smuggled request turns precisely on the
+          // Content-Length value being untrustworthy, so we neither trust it
+          // for framing (chunked/fixed) nor report it as too large (413) —
+          // the presence of both headers is itself the fault, so 400.
+          if _has_transfer_encoding and (_content_length isnt None) then
+            return ContentLengthWithTransferEncoding
+          end
+
           // Check body size limit before delivering the request. The actor
           // can now respond in on_request(), so rejections must precede delivery.
           match _content_length
@@ -262,8 +272,10 @@ class _ExpectHeaders is _ParserState
           // Deliver the request metadata
           p.handler.request_received(_method, _uri, _version, headers)
 
-          // Determine body handling: Transfer-Encoding takes precedence
-          // over Content-Length per RFC 9112 §6.3
+          // Determine body handling. Content-Length and Transfer-Encoding are
+          // mutually exclusive here — the both-present case was rejected above
+          // (RFC 9112 §6.3) — so chunked framing and a fixed Content-Length
+          // body can never both apply.
           if use_chunked then
             p.state = _ExpectChunkHeader(0, _config)
             return _ParseContinue
@@ -304,13 +316,18 @@ class _ExpectHeaders is _ParserState
           | None => return MalformedHeaders
           end
 
-        // Header name must not be empty
-        if colon_pos == p.pos then
+        // Extract the field name (lowercasing happens in Headers.add) and
+        // require it to be a valid RFC 9110 §5.6.2 token. This rejects an
+        // empty name, whitespace before the colon (RFC 9112 §5.1), interior
+        // whitespace ("Content -Length"), control bytes, and other delimiters.
+        // Rejecting non-token names closes a request-smuggling vector: an
+        // intermediary that normalizes such a name would recognize a framing
+        // header (Content-Length / Transfer-Encoding) that Stallion does not,
+        // desynchronizing the two about how the message is framed.
+        let name: String val = p.extract_string(p.pos, colon_pos)
+        if not _Token.valid(name) then
           return MalformedHeaders
         end
-
-        // Extract header name (lowercasing happens in Headers.add)
-        let name: String val = p.extract_string(p.pos, colon_pos)
 
         // Extract header value, skipping optional whitespace (OWS)
         var val_start = colon_pos + 1

--- a/stallion/_test.pony
+++ b/stallion/_test.pony
@@ -15,6 +15,9 @@ actor \nodoc\ Main is TestList
     // OWS tests
     test(_TestOWS)
 
+    // Token tests
+    test(_TestToken)
+
     // Quoted-split tokenizer tests
     test(_TestQuotedSplit)
 
@@ -84,6 +87,12 @@ actor \nodoc\ Main is TestList
     test(_TestNoBody)
     test(_TestContentLengthZero)
     test(_TestContentLengthAndChunked)
+    test(_TestContentLengthAndUnsupportedTE)
+    test(_TestZeroContentLengthAndChunked)
+    test(_TestWhitespaceBeforeColon)
+    test(_TestWhitespaceBeforeColonSmuggling)
+    test(_TestInteriorWhitespaceInNameSmuggling)
+    test(_TestNonTokenHeaderName)
     test(_TestTransferEncodingUnknownNoBody)
     test(_TestTransferEncodingUnknownWithChunkedBody)
     test(_TestTransferEncodingGzipChunked)

--- a/stallion/_test_cookie_validator.pony
+++ b/stallion/_test_cookie_validator.pony
@@ -150,7 +150,7 @@ primitive \nodoc\ _CookieTestGenerators
       let s = String
       var b: U8 = 33
       while b <= 126 do
-        if _CookieValidator._is_token_char(b) then s.push(b) end
+        if _Token(b) then s.push(b) end
         b = b + 1
       end
       s

--- a/stallion/_test_request_parser.pony
+++ b/stallion/_test_request_parser.pony
@@ -763,8 +763,8 @@ class \nodoc\ iso _TestContentLengthZero is UnitTest
 
 class \nodoc\ iso _TestContentLengthAndChunked is UnitTest
   """
-  Both Content-Length and Transfer-Encoding: chunked → chunked takes
-  precedence per RFC 7230 §3.3.3.
+  Both Content-Length and Transfer-Encoding present → rejected as a
+  request-smuggling vector (RFC 9112 §6.3), before any request is delivered.
   """
   fun name(): String => "parser/content_length_and_chunked"
 
@@ -779,12 +779,169 @@ class \nodoc\ iso _TestContentLengthAndChunked is UnitTest
     let parser = _RequestParser(notify)
     parser.parse(recover raw.array().clone() end)
 
-    h.assert_eq[USize](1, notify.requests.size(), "1 request")
-    h.assert_eq[USize](1, notify.completed, "1 completion")
-    h.assert_eq[USize](0, notify.errors.size(), "0 errors")
-    // Body is 5 bytes (chunked), not 100 (Content-Length)
-    h.assert_eq[String val](
-      "Hello", notify.collected_body_string())
+    h.assert_eq[USize](0, notify.requests.size(), "0 requests")
+    h.assert_eq[USize](0, notify.completed, "0 completions")
+    h.assert_eq[USize](1, notify.errors.size(), "1 error")
+    try
+      h.assert_true(notify.errors(0)? is ContentLengthWithTransferEncoding,
+        "should be ContentLengthWithTransferEncoding")
+    end
+
+class \nodoc\ iso _TestContentLengthAndUnsupportedTE is UnitTest
+  """
+  Content-Length with an unsupported Transfer-Encoding coding → rejected as a
+  smuggling vector (ContentLengthWithTransferEncoding), not as an unsupported
+  coding (UnsupportedTransferEncoding/501). The presence of both headers is
+  checked before the Transfer-Encoding value is evaluated, so the smuggling
+  rejection takes precedence (RFC 9112 §6.3).
+  """
+  fun name(): String => "parser/content_length_and_unsupported_te"
+
+  fun apply(h: TestHelper) =>
+    let raw: String val =
+      "POST / HTTP/1.1\r\n" +
+      "Content-Length: 100\r\n" +
+      "Transfer-Encoding: gzip\r\n" +
+      "\r\n"
+    let notify: _TestParserNotify ref = _TestParserNotify
+    let parser = _RequestParser(notify)
+    parser.parse(recover raw.array().clone() end)
+
+    h.assert_eq[USize](0, notify.requests.size(), "0 requests")
+    h.assert_eq[USize](1, notify.errors.size(), "1 error")
+    try
+      h.assert_true(notify.errors(0)? is ContentLengthWithTransferEncoding,
+        "should be ContentLengthWithTransferEncoding, not 501")
+    end
+
+class \nodoc\ iso _TestZeroContentLengthAndChunked is UnitTest
+  """
+  Content-Length: 0 with Transfer-Encoding → still rejected. RFC 9112 §6.3
+  forbids Content-Length in any message with Transfer-Encoding, regardless of
+  the Content-Length value.
+  """
+  fun name(): String => "parser/zero_content_length_and_chunked"
+
+  fun apply(h: TestHelper) =>
+    let raw: String val =
+      "POST / HTTP/1.1\r\n" +
+      "Content-Length: 0\r\n" +
+      "Transfer-Encoding: chunked\r\n" +
+      "\r\n" +
+      "0\r\n\r\n"
+    let notify: _TestParserNotify ref = _TestParserNotify
+    let parser = _RequestParser(notify)
+    parser.parse(recover raw.array().clone() end)
+
+    h.assert_eq[USize](0, notify.requests.size(), "0 requests")
+    h.assert_eq[USize](1, notify.errors.size(), "1 error")
+    try
+      h.assert_true(notify.errors(0)? is ContentLengthWithTransferEncoding,
+        "should be ContentLengthWithTransferEncoding")
+    end
+
+class \nodoc\ iso _TestWhitespaceBeforeColon is UnitTest
+  """
+  A header line with whitespace between the field name and the colon
+  ("Host : value") is rejected with MalformedHeaders per RFC 9112 §5.1.
+  """
+  fun name(): String => "parser/whitespace_before_colon"
+
+  fun apply(h: TestHelper) =>
+    let raw: String val =
+      "GET / HTTP/1.1\r\n" +
+      "Host : example.com\r\n" +
+      "\r\n"
+    let notify: _TestParserNotify ref = _TestParserNotify
+    let parser = _RequestParser(notify)
+    parser.parse(recover raw.array().clone() end)
+
+    h.assert_eq[USize](0, notify.requests.size(), "0 requests")
+    h.assert_eq[USize](1, notify.errors.size(), "1 error")
+    try
+      h.assert_true(notify.errors(0)? is MalformedHeaders,
+        "should be MalformedHeaders")
+    end
+
+class \nodoc\ iso _TestWhitespaceBeforeColonSmuggling is UnitTest
+  """
+  "Content-Length : 100" (whitespace before the colon) alongside
+  Transfer-Encoding must not be accepted as a Transfer-Encoding-only request.
+  An intermediary that trims the optional whitespace would see both framing
+  headers, desynchronizing the two — a request-smuggling vector. The line is
+  rejected with MalformedHeaders per RFC 9112 §5.1, so the both-headers
+  combination never reaches the framing decision.
+  """
+  fun name(): String => "parser/whitespace_before_colon_smuggling"
+
+  fun apply(h: TestHelper) =>
+    let raw: String val =
+      "POST / HTTP/1.1\r\n" +
+      "Content-Length : 100\r\n" +
+      "Transfer-Encoding: chunked\r\n" +
+      "\r\n"
+    let notify: _TestParserNotify ref = _TestParserNotify
+    let parser = _RequestParser(notify)
+    parser.parse(recover raw.array().clone() end)
+
+    h.assert_eq[USize](0, notify.requests.size(), "0 requests")
+    h.assert_eq[USize](1, notify.errors.size(), "1 error")
+    try
+      h.assert_true(notify.errors(0)? is MalformedHeaders,
+        "should be MalformedHeaders")
+    end
+
+class \nodoc\ iso _TestInteriorWhitespaceInNameSmuggling is UnitTest
+  """
+  "Content -Length: 100" (whitespace inside the field name) alongside
+  Transfer-Encoding must not be accepted as a Transfer-Encoding-only request.
+  An intermediary that normalizes the name to "Content-Length" would see both
+  framing headers, desynchronizing the two — the same request-smuggling vector
+  as whitespace before the colon, but defeating a check that only inspected
+  the byte adjacent to the colon. Rejecting non-token field names per RFC 9110
+  §5.6.2 closes it, so the request never reaches the framing decision.
+  """
+  fun name(): String => "parser/interior_whitespace_in_name_smuggling"
+
+  fun apply(h: TestHelper) =>
+    let raw: String val =
+      "POST / HTTP/1.1\r\n" +
+      "Content -Length: 100\r\n" +
+      "Transfer-Encoding: chunked\r\n" +
+      "\r\n"
+    let notify: _TestParserNotify ref = _TestParserNotify
+    let parser = _RequestParser(notify)
+    parser.parse(recover raw.array().clone() end)
+
+    h.assert_eq[USize](0, notify.requests.size(), "0 requests")
+    h.assert_eq[USize](1, notify.errors.size(), "1 error")
+    try
+      h.assert_true(notify.errors(0)? is MalformedHeaders,
+        "should be MalformedHeaders")
+    end
+
+class \nodoc\ iso _TestNonTokenHeaderName is UnitTest
+  """
+  A field name containing a non-token byte (here the delimiter "@") is
+  rejected with MalformedHeaders per RFC 9110 §5.6.2.
+  """
+  fun name(): String => "parser/non_token_header_name"
+
+  fun apply(h: TestHelper) =>
+    let raw: String val =
+      "GET / HTTP/1.1\r\n" +
+      "Foo@Bar: value\r\n" +
+      "\r\n"
+    let notify: _TestParserNotify ref = _TestParserNotify
+    let parser = _RequestParser(notify)
+    parser.parse(recover raw.array().clone() end)
+
+    h.assert_eq[USize](0, notify.requests.size(), "0 requests")
+    h.assert_eq[USize](1, notify.errors.size(), "1 error")
+    try
+      h.assert_true(notify.errors(0)? is MalformedHeaders,
+        "should be MalformedHeaders")
+    end
 
 class \nodoc\ iso _TestDuplicateContentLength is UnitTest
   """Two Content-Length headers with differing values → InvalidContentLength."""

--- a/stallion/_test_token.pony
+++ b/stallion/_test_token.pony
@@ -1,0 +1,71 @@
+use "pony_test"
+
+class \nodoc\ iso _TestToken is UnitTest
+  """
+  Verify the `_Token` predicate and whole-string validity check against the
+  RFC 9110 §5.6.2 `tchar` set and its boundaries.
+  """
+  fun name(): String => "token/predicate_and_valid"
+
+  fun apply(h: TestHelper) =>
+    // Representative tchar from the punctuation list, plus DIGIT and ALPHA.
+    h.assert_true(_Token('!'), "! is tchar")
+    h.assert_true(_Token('#'), "# is tchar")
+    h.assert_true(_Token('$'), "$ is tchar")
+    h.assert_true(_Token('%'), "% is tchar")
+    h.assert_true(_Token('&'), "& is tchar")
+    h.assert_true(_Token('\''), "apostrophe is tchar")
+    h.assert_true(_Token('*'), "* is tchar")
+    h.assert_true(_Token('+'), "+ is tchar")
+    h.assert_true(_Token('-'), "- is tchar")
+    h.assert_true(_Token('.'), ". is tchar")
+    h.assert_true(_Token('^'), "^ is tchar")
+    h.assert_true(_Token('_'), "_ is tchar")
+    h.assert_true(_Token('`'), "backtick is tchar")
+    h.assert_true(_Token('|'), "| is tchar")
+    h.assert_true(_Token('~'), "~ is tchar")
+    h.assert_true(_Token('0'), "digit is tchar")
+    h.assert_true(_Token('9'), "digit is tchar")
+    h.assert_true(_Token('A'), "uppercase letter is tchar")
+    h.assert_true(_Token('z'), "lowercase letter is tchar")
+
+    // Every RFC 9110 §5.6.2 delimiter is rejected.
+    h.assert_false(_Token('('), "( is a delimiter")
+    h.assert_false(_Token(')'), ") is a delimiter")
+    h.assert_false(_Token('<'), "< is a delimiter")
+    h.assert_false(_Token('>'), "> is a delimiter")
+    h.assert_false(_Token('@'), "@ is a delimiter")
+    h.assert_false(_Token(','), ", is a delimiter")
+    h.assert_false(_Token(';'), "; is a delimiter")
+    h.assert_false(_Token(':'), ": is a delimiter")
+    h.assert_false(_Token('\\'), "backslash is a delimiter")
+    h.assert_false(_Token('"'), "double quote is a delimiter")
+    h.assert_false(_Token('/'), "/ is a delimiter")
+    h.assert_false(_Token('['), "[ is a delimiter")
+    h.assert_false(_Token(']'), "] is a delimiter")
+    h.assert_false(_Token('?'), "? is a delimiter")
+    h.assert_false(_Token('='), "= is a delimiter")
+    h.assert_false(_Token('{'), "{ is a delimiter")
+    h.assert_false(_Token('}'), "} is a delimiter")
+
+    // Whitespace and control bytes are not tchar.
+    h.assert_false(_Token(' '), "SP is not tchar")
+    h.assert_false(_Token('\t'), "HTAB is not tchar")
+    h.assert_false(_Token('\r'), "CR is not tchar")
+    h.assert_false(_Token('\n'), "LF is not tchar")
+
+    // Range boundaries: 0x20 (SP) just below, 0x21 (!) first, 0x7E (~)
+    // last, 0x7F (DEL) just above, and 0xFF.
+    h.assert_false(_Token(0x20), "0x20 is below the visible range")
+    h.assert_true(_Token(0x21), "0x21 is the first visible char")
+    h.assert_true(_Token(0x7E), "0x7E is the last visible char")
+    h.assert_false(_Token(0x7F), "DEL is above the visible range")
+    h.assert_false(_Token(0xFF), "0xFF is not tchar")
+
+    // valid: non-empty 1*tchar, rejecting empty and any non-tchar byte.
+    h.assert_true(_Token.valid("Content-Length"), "valid token name")
+    h.assert_true(_Token.valid("X-Custom_Header"), "valid token name")
+    h.assert_false(_Token.valid(""), "empty is not a token")
+    h.assert_false(_Token.valid("Content-Length "), "trailing space")
+    h.assert_false(_Token.valid("Content -Length"), "interior space")
+    h.assert_false(_Token.valid("Foo@Bar"), "interior delimiter")

--- a/stallion/_token.pony
+++ b/stallion/_token.pony
@@ -1,0 +1,39 @@
+primitive _Token
+  """
+  RFC 9110 §5.6.2 token: a non-empty sequence of `tchar`.
+
+  ```
+  tchar = "!" / "#" / "$" / "%" / "&" / "'" / "*" / "+" / "-" / "." /
+          "^" / "_" / "`" / "|" / "~" / DIGIT / ALPHA
+  ```
+
+  Equivalently: visible ASCII (0x21–0x7E) excluding the delimiters
+  `( ) < > @ , ; : \ " / [ ] ? = { }` (and, implicitly, SP/HTAB and control
+  bytes, which fall outside 0x21–0x7E). This is the same set RFC 2616 calls a
+  token, so cookie names (RFC 6265 §4.1.1, which defers to the RFC 2616 token)
+  use it too.
+
+  Single source for "what counts as a token character" across the parser
+  (HTTP field names, RFC 9112 §5.1) and the cookie validator, mirroring how
+  `_OWS` is the single source for optional whitespace.
+  """
+
+  fun apply(b: U8): Bool =>
+    """Whether `b` is a `tchar` (a valid token character)."""
+    if (b < 0x21) or (b > 0x7E) then return false end
+    match b
+    | '(' | ')' | '<' | '>' | '@'
+    | ',' | ';' | ':' | '\\' | '"'
+    | '/' | '[' | ']' | '?' | '='
+    | '{' | '}' => false
+    else
+      true
+    end
+
+  fun valid(s: String box): Bool =>
+    """Whether `s` is a non-empty token (`1*tchar`)."""
+    if s.size() == 0 then return false end
+    for b in s.values() do
+      if not apply(b) then return false end
+    end
+    true

--- a/stallion/parse_error.pony
+++ b/stallion/parse_error.pony
@@ -21,7 +21,10 @@ primitive InvalidVersion
   fun string(): String iso^ => "InvalidVersion".clone()
 
 primitive MalformedHeaders
-  """Header syntax is invalid (missing colon, obs-fold continuation line)."""
+  """
+  Header syntax is invalid: missing colon, an obs-fold continuation line, or
+  whitespace between a field name and its colon (RFC 9112 §5.1).
+  """
   fun string(): String iso^ => "MalformedHeaders".clone()
 
 primitive InvalidContentLength
@@ -55,8 +58,23 @@ primitive UnsupportedTransferEncoding
   """
   fun string(): String iso^ => "UnsupportedTransferEncoding".clone()
 
+primitive ContentLengthWithTransferEncoding
+  """
+  A request carries both Content-Length and Transfer-Encoding header fields.
+
+  RFC 9112 §6.3 forbids this combination ("A sender MUST NOT send a
+  Content-Length header field in any message that contains a
+  Transfer-Encoding header field") because it is a request-smuggling vector:
+  an intermediary that honors one header while Stallion honors the other can
+  be desynchronized, letting a smuggled request slip past. Rather than pick a
+  framing, Stallion rejects the message — the presence of both headers is
+  itself the fault, regardless of what either header's value resolves to.
+  """
+  fun string(): String iso^ => "ContentLengthWithTransferEncoding".clone()
+
 type ParseError is
   (TooLarge | UnknownMethod | InvalidURI | InvalidVersion | MalformedHeaders
   | InvalidContentLength | InvalidChunk | BodyTooLarge
-  | InvalidTransferEncoding | UnsupportedTransferEncoding)
+  | InvalidTransferEncoding | UnsupportedTransferEncoding
+  | ContentLengthWithTransferEncoding)
   """Parse error encountered during HTTP request parsing."""


### PR DESCRIPTION
Closes two HTTP request-smuggling vectors. Both are cases where Stallion accepted a malformed request that another HTTP intermediary might interpret differently, letting the two desynchronize about request framing.

- A request carrying both `Content-Length` and `Transfer-Encoding` is now rejected with `400` and the connection closed, regardless of the header values (RFC 9112 §6.3). Previously chunked framing won and the request was processed (issue #114).
- A header field name that is not a valid RFC 9110 §5.6.2 token is now rejected with `400`. This covers whitespace before the colon (`Content-Length : 100`, RFC 9112 §5.1), whitespace inside the name (`Content -Length: 100`), and any other non-token byte. Field-name validation is full token validation, not a narrow whitespace check, so interior whitespace can't slip a framing header past the parser.

The token predicate is extracted into a single `_Token` primitive (mirroring `_OWS`); the cookie validator now uses it instead of duplicating the identical RFC 2616 token set.

`AGENTS.md` gains an RFC-conformance principle: Stallion goes exactly as far as the RFCs say and no further, rather than adding non-conformant rejections to compensate for intermediaries that mishandle conformant messages. This is why a field name like `X_Custom` is still accepted — the underscore is a valid token character.

Closes #114