### PR TITLE
Reject HTTP request smuggling vectors and tighten request conformance

### DIFF
--- a/.release-notes/conformant-request-parser.md
+++ b/.release-notes/conformant-request-parser.md
@@ -1,0 +1,18 @@
+## Reject HTTP request smuggling vectors and tighten request conformance
+
+Stallion's HTTP/1.1 request parser previously accepted a range of malformed requests that are recognized request-smuggling vectors. When Stallion sits behind or in front of another HTTP processor that disagrees about where one request ends and the next begins, an attacker can use these to slip a hidden request past one of them. The parser now rejects them and closes the connection.
+
+A request is now rejected when it contains any of:
+
+- both a `Content-Length` and a `Transfer-Encoding` header field
+- a bare CR or bare LF where a CRLF is required (the request line, a header or trailer field, or chunk framing)
+- a NUL byte in a header or trailer field value
+- a field name that is not a valid token, or whitespace between the field name and its colon
+- an obsolete line-folded header
+- a malformed chunk size or an invalid chunk extension
+- a `Transfer-Encoding` that is not a single, final `chunked` coding
+- a framing, routing, or control field (such as `Transfer-Encoding`, `Content-Length`, or `Host`) in the trailer section
+
+Trailer fields are now held to the same standard as header fields.
+
+The parser is also stricter about request conformance. An HTTP/1.1 request must carry exactly one `Host` header field: a request missing `Host`, or carrying more than one `Host` line (on any HTTP version), is rejected with `400 Bad Request`. A request whose method is well-formed but not one Stallion implements now receives `501 Not Implemented` instead of `400 Bad Request`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,14 @@ make clean           # clean build artifacts
 
 The `ssl` option is required because this library and lori depend on the `ssl` package.
 
+## RFC conformance
+
+Stallion conforms to the HTTP RFCs. We reject what the RFCs say to reject and accept what they say to accept — and we stop there. We do not add non-conformant behavior to compensate for an intermediary that mishandles a *conformant* message.
+
+The distinction matters for request-smuggling defenses. A malformed message the RFCs themselves say to reject — `Content-Length` together with `Transfer-Encoding` (RFC 9112 §6.3), an invalid field name (RFC 9110 §5.6.2, RFC 9112 §5.1), or a field value containing CR, LF, or NUL (RFC 9110 §5.5) — we reject, because rejecting it *is* conformance. But a conformant message that some intermediary might still mishandle is not ours to pre-empt: refusing it would break conformant clients to chase a misbehaving party we cannot fix.
+
+Concretely: a field name containing `_` is a valid RFC 9110 §5.6.2 token, so we accept it — even though an upstream that rewrites `_` to `-` could confuse `X_Forwarded_For` with `X-Forwarded-For`. That rewrite is the upstream's bug, not ours, and refusing a valid token to defend against it would be the wrong trade.
+
 ## Architecture
 
 Package: `stallion` (repo name is `stallion`, Pony package name is `stallion`)
@@ -83,12 +91,19 @@ Follow the standard ponylang release notes conventions. Create individual `.md` 
   - `_response_serializer.pony` — Response wire-format serializer (package-private)
   - `_mort.pony` — Runtime enforcement primitives (`_IllegalState`, `_Unreachable`)
   - `_ows.pony` — RFC 9110 §5.6.3 optional whitespace (SP/HTAB) — single source for the OWS predicate, zero-copy trim, and strip charset (`_OWS` primitive)
+  - `_token.pony` — RFC 9110 §5.6.2 token (`tchar`) — single source for the token-character predicate and whole-string validity (`_Token` primitive); used to validate HTTP field names (RFC 9112 §5.1) and cookie names
+  - `_field_value.pony` — RFC 9110 §5.5 field-value validity (`_FieldValue` primitive) — rejects the MUST-reject set (CR, LF, NUL) inside a header value
   - `_quoted_split.pony` — RFC 9110 §5.6.4 quoted-string-aware delimiter split (`_QuotedSplit` primitive) — shared by the Transfer-Encoding and Accept parsers so a delimiter inside a quoted parameter value (including `quoted-pair` escapes) does not split an element; returns `(segments, unterminated)` so the framing path can reject a malformed (unterminated-quote) value while Accept ignores it
-  - `parse_error.pony` — Parse error types (`ParseError` union, 10 error primitives)
+  - `parse_error.pony` — Parse error types (`ParseError` union, 18 error primitives; grammar-aligned per the conformant-by-construction parser. The old overloaded `MalformedHeaders` was retired and removed)
   - `_parser_config.pony` — Parser size limit configuration
   - `_request_parser_notify.pony` — Parser callback trait (synchronous `ref` methods)
-  - `_transfer_encoding.pony` — Transfer-Encoding tokenizer and RFC 9112 §6.1/§6.3 coding decision (`_TransferEncoding` primitive, `_ChunkedFraming` sentinel)
-  - `_parser_state.pony` — Parser state machine (state interface, 6 state classes, `_BufferScan`)
+  - `_transfer_encoding.pony` — Transfer-Encoding tokenizer and RFC 9112 §6.1/§6.3 coding decision (`_TransferEncoding` primitive, `_ChunkedFraming` sentinel); validates each coding is a `token` so an obfuscated coding name is a 400, not a 501
+  - `_line_scan.pony` — RFC 9112 §2.2 line policy (`_LineScan` primitive, `_Line` + `_ScannedLine` classes) — THE single place CR/LF is interpreted, for every line type; rejects bare CR/LF (`BareCRLF`), treats a CR at the buffer edge as need-more (resumability). Replaces the old `find_crlf`, the root cause of the smuggling-bug class. `_ScannedLine` is the typed token (built only via `_RequestParser.scanned_line` from a `_Line`) that the gates require, so a caller cannot feed them un-scanned bytes
+  - `_field_line.pony` — RFC 9112 §5 field-line gate (`_FieldLine` primitive, `_Field` class) — THE single field-line grammar gate (token name, OWS, NUL-in-value, obs-fold), shared verbatim by the header and trailer states so a fix reaches both by construction
+  - `_request_line.pony` — RFC 9112 §3 request line (`_RequestLine` primitive) — exactly-one-SP framing (`InvalidRequestLine`), method/version parse, request-target byte gate (non-empty, VCHAR-only → `InvalidURI`); target delivered raw for the protocol layer to parse into a URI
+  - `_chunk_header.pony` — RFC 9112 §7.1 chunk header (`_ChunkHeader` primitive) — strict `1*HEXDIG` chunk-size (`InvalidChunk`) and validated chunk-ext (token names, token/quoted-string values → `InvalidChunkExtension`), the previously-unvalidated chunk position
+  - `_forbidden_trailers.pony` — RFC 9110 §6.5.1 trailer denylist (`_ForbiddenTrailers` primitive) — framing/routing/control/auth field names rejected in a trailer section (`ForbiddenTrailer`)
+  - `_parser_state.pony` — Parser state machine (state interface, 6 thin state classes that drive `_LineScan`/`_FieldLine`/the gates; no state interprets CR/LF or field-line grammar itself)
   - `_request_parser.pony` — Request parser class (entry point, buffer management)
   - `request.pony` — Immutable request metadata bundle (`Request val`: method, URI, version, headers, cookies)
   - `chunk_send_token.pony` — Opaque chunk send token (`ChunkSendToken val`, `Equatable`, private constructor)
@@ -113,7 +128,7 @@ Follow the standard ponylang release notes conventions. Create individual `.md` 
   - `set_cookie_build_error.pony` — Build error types (`InvalidCookieName`, `InvalidCookieValue`, `InvalidCookiePath`, `InvalidCookieDomain`, `CookiePrefixViolation`, `SameSiteRequiresSecure`, `SetCookieBuildError` union)
   - `set_cookie.pony` — Validated, pre-serialized `Set-Cookie` header (`SetCookie val`, `header_value()`, private constructor)
   - `set_cookie_builder.pony` — `Set-Cookie` header builder (`SetCookieBuilder ref`, secure defaults, chaining, prefix rules)
-  - `_cookie_validator.pony` — Cookie name/value/attribute validation (RFC 2616 token, RFC 6265 cookie-octet, path/domain safety)
+  - `_cookie_validator.pony` — Cookie name/value/attribute validation (cookie names via `_Token`, RFC 6265 cookie-octet, path/domain safety)
   - `_http_date.pony` — IMF-fixdate formatter for `Expires` attribute (`_HTTPDate` primitive)
   - `media_type.pony` — HTTP media type (`MediaType val` class, `Equatable & Stringable`)
   - `no_acceptable_type.pony` — Content negotiation failure (`NoAcceptableType` primitive)

--- a/stallion/_chunk_header.pony
+++ b/stallion/_chunk_header.pony
@@ -1,0 +1,118 @@
+type _ChunkHeaderResult is (USize | InvalidChunk | InvalidChunkExtension)
+
+primitive _ChunkHeader
+  """
+  RFC 9112 §7.1 chunk header — `chunk-size [ chunk-ext ]`.
+
+  The chunk-size is a strict `1*HEXDIG`: no `0x`/sign prefix, no trailing junk.
+  The chunk-ext, if present, is validated against
+  `*( ";" BWS chunk-ext-name [ BWS "=" BWS chunk-ext-val ] )` with token
+  ext-names and token-or-quoted-string ext-vals — closing the chunk position
+  that was previously skipped to CRLF unvalidated. The input is a `_ScannedLine`
+  (produced by `_LineScan`), so a bad chunk line's bare CR/LF is already
+  `BareCRLF` before this runs.
+  """
+  fun parse(scanned: _ScannedLine): _ChunkHeaderResult =>
+    let line: String val = scanned.content
+    let semi = try line.find(";")?.usize() else line.size() end
+    let size_str = line.trim(0, semi)
+    if size_str.size() == 0 then return InvalidChunk end
+    // chunk-size is strictly `1*HEXDIG`. `read_int` alone is not enough: it
+    // accepts `_` as a digit-group separator, so `5_0` would parse as 0x50 —
+    // a smuggling vector (a strict intermediary chokes on `_` where Stallion
+    // reads a length). Reject any non-HEXDIG byte first.
+    for b in size_str.values() do
+      if not _is_hexdig(b) then return InvalidChunk end
+    end
+    let chunk_size =
+      try
+        (let cs, let consumed) = size_str.read_int[USize](0, 16)?
+        if consumed.usize() != size_str.size() then return InvalidChunk end
+        cs
+      else
+        return InvalidChunk
+      end
+    if semi < line.size() then
+      match _validate_ext(line.trim(semi))
+      | let e: InvalidChunkExtension => return e
+      end
+    end
+    chunk_size
+
+  fun _validate_ext(ext: String val): (None | InvalidChunkExtension) =>
+    """
+    `ext` begins with the first `;`. Split on `;` (quoted-string aware, so a
+    `;` inside an ext-val quoted-string does not split an extension), then
+    validate each `BWS ext-name [ BWS "=" BWS ext-val ]` element.
+    """
+    (let segs, let unterminated) = _QuotedSplit(ext, ';')
+    if unterminated then return InvalidChunkExtension end
+    var first = true
+    for seg in segs.values() do
+      if first then
+        // Text before the first `;` (there is none — `ext` starts with `;`).
+        first = false
+        if seg.size() != 0 then return InvalidChunkExtension end
+      else
+        if not _valid_ext_elem(seg) then return InvalidChunkExtension end
+      end
+    end
+    None
+
+  fun _valid_ext_elem(seg: String val): Bool =>
+    let s = _OWS.trim(seg)
+    if s.size() == 0 then return false end
+    match try s.find("=")?.usize() else None end
+    | let eq: USize =>
+      _Token.valid(_OWS.trim(s.trim(0, eq)))
+        and _valid_ext_val(_OWS.trim(s.trim(eq + 1)))
+    | None =>
+      _Token.valid(s)
+    end
+
+  fun _valid_ext_val(v: String val): Bool =>
+    if (v.size() >= 2) and (try v(0)? == '"' else false end) then
+      _valid_quoted_string(v)
+    else
+      _Token.valid(v)
+    end
+
+  fun _valid_quoted_string(v: String val): Bool =>
+    """RFC 9110 §5.6.4 quoted-string: `DQUOTE *( qdtext / quoted-pair ) DQUOTE`."""
+    let n = v.size()
+    var i: USize = 1
+    try
+      while i < n do
+        let c = v(i)?
+        if c == '\\' then
+          if (i + 1) >= n then return false end
+          if not _quoted_pair_octet(v(i + 1)?) then return false end
+          i = i + 2
+        elseif c == '"' then
+          return i == (n - 1)
+        elseif not _qdtext(c) then
+          return false
+        else
+          i = i + 1
+        end
+      end
+    else
+      return false
+    end
+    false
+
+  fun _is_hexdig(b: U8): Bool =>
+    ((b >= '0') and (b <= '9'))
+      or ((b >= 'a') and (b <= 'f'))
+      or ((b >= 'A') and (b <= 'F'))
+
+  fun _qdtext(c: U8): Bool =>
+    """HTAB / SP / %x21 / %x23-5B / %x5D-7E / obs-text."""
+    (c == 0x09) or (c == 0x20) or (c == 0x21)
+      or ((c >= 0x23) and (c <= 0x5B))
+      or ((c >= 0x5D) and (c <= 0x7E))
+      or (c >= 0x80)
+
+  fun _quoted_pair_octet(c: U8): Bool =>
+    """HTAB / SP / VCHAR / obs-text."""
+    (c == 0x09) or (c == 0x20) or ((c >= 0x21) and (c <= 0x7E)) or (c >= 0x80)

--- a/stallion/_cookie_validator.pony
+++ b/stallion/_cookie_validator.pony
@@ -11,11 +11,7 @@ primitive _CookieValidator
 
   fun valid_name(name: String box): Bool =>
     """Return true if `name` is a valid cookie name (RFC 2616 token)."""
-    if name.size() == 0 then return false end
-    for byte in name.values() do
-      if not _is_token_char(byte) then return false end
-    end
-    true
+    _Token.valid(name)
 
   fun valid_value(value: String box): Bool =>
     """Return true if `value` contains only valid cookie-octets."""
@@ -23,23 +19,6 @@ primitive _CookieValidator
       if not _is_cookie_octet(byte) then return false end
     end
     true
-
-  fun _is_token_char(b: U8): Bool =>
-    """
-    RFC 2616 token character: ASCII 33–126 minus separators.
-
-    Separators: ( ) < > @ , ; : \\ " / [ ] ? = { }
-    """
-    if (b < 33) or (b > 126) then return false end
-    // Check separators
-    match b
-    | '(' | ')' | '<' | '>' | '@'
-    | ',' | ';' | ':' | '\\' | '"'
-    | '/' | '[' | ']' | '?' | '='
-    | '{' | '}' => false
-    else
-      true
-    end
 
   fun _is_cookie_octet(b: U8): Bool =>
     """

--- a/stallion/_error_response.pony
+++ b/stallion/_error_response.pony
@@ -16,7 +16,7 @@ primitive _ErrorResponse
       "HTTP/1.1 413 Payload Too Large\r\nConnection: close\r\nContent-Length: 0\r\n\r\n"
     | InvalidVersion =>
       "HTTP/1.1 505 HTTP Version Not Supported\r\nConnection: close\r\nContent-Length: 0\r\n\r\n"
-    | UnsupportedTransferEncoding =>
+    | UnsupportedTransferEncoding | UnknownMethod =>
       "HTTP/1.1 501 Not Implemented\r\nConnection: close\r\nContent-Length: 0\r\n\r\n"
     else
       "HTTP/1.1 400 Bad Request\r\nConnection: close\r\nContent-Length: 0\r\n\r\n"

--- a/stallion/_field_line.pony
+++ b/stallion/_field_line.pony
@@ -1,0 +1,40 @@
+class val _Field
+  """
+  A validated header or trailer field: a `1*tchar` name (lowercased) and a
+  value free of CR, LF, and NUL.
+  """
+  let name: String val
+  let value: String val
+
+  new val create(name': String val, value': String val) =>
+    name = name'
+    value = value'
+
+type _FieldResult is (_Field | InvalidFieldName | InvalidFieldValue | ObsFold)
+
+primitive _FieldLine
+  """
+  RFC 9112 §5 field-line gate — the single place the field-line grammar is
+  enforced, shared verbatim by header parsing and trailer parsing.
+
+  The input is a `_ScannedLine` — a line already proven free of bare CR and LF
+  by `_LineScan` (the type makes that a precondition the caller cannot skip), so
+  this gate adds only the remaining rules: no obs-fold (a field-line beginning
+  with SP/HTAB), a `1*tchar` name with no whitespace before the colon, and a
+  value free of NUL. It does not re-scan for CR/LF — that rule lives in
+  `_LineScan` alone. Because both the header state and the trailer state route
+  through this one function, a tightening of the field-line grammar reaches both
+  by construction; this is the structural fix for "the field-value fix never
+  reached trailers".
+  """
+  fun parse(scanned: _ScannedLine): _FieldResult =>
+    let line: String val = scanned.content
+    if (line.size() > 0) and _OWS(try line(0)? else _Unreachable(); ' ' end) then
+      return ObsFold
+    end
+    let colon = try line.find(":")?.usize() else return InvalidFieldName end
+    let name = line.trim(0, colon)
+    if not _Token.valid(name) then return InvalidFieldName end
+    let value = _OWS.trim(line.trim(colon + 1))
+    if not _FieldValue.valid(value) then return InvalidFieldValue end
+    _Field(name.lower(), value)

--- a/stallion/_field_value.pony
+++ b/stallion/_field_value.pony
@@ -1,0 +1,26 @@
+primitive _FieldValue
+  """
+  RFC 9110 §5.5 field-value validity.
+
+  A field value containing CR, LF, or NUL is invalid: §5.5 requires a
+  recipient to reject (or rewrite) such a message, "due to the varying ways
+  that implementations might parse and interpret those characters." That
+  variance is a request-smuggling vector — an intermediary that treats a bare
+  CR or LF as a line terminator would see a header or message boundary where
+  Stallion sees ordinary field-value bytes, desynchronizing the two.
+
+  This checks exactly the §5.5 MUST-reject set (CR, LF, NUL). Other bytes —
+  including SP, HTAB, and obs-text (0x80–0xFF) — are left to the value as-is;
+  we reject what the RFC says to reject and no more.
+  """
+
+  fun forbidden(b: U8): Bool =>
+    """Whether `b` is forbidden in a field value (CR, LF, or NUL)."""
+    (b == '\r') or (b == '\n') or (b == 0)
+
+  fun valid(s: String box): Bool =>
+    """Whether `s` is free of the forbidden field-value bytes (CR, LF, NUL)."""
+    for b in s.values() do
+      if forbidden(b) then return false end
+    end
+    true

--- a/stallion/_forbidden_trailers.pony
+++ b/stallion/_forbidden_trailers.pony
@@ -1,0 +1,25 @@
+primitive _ForbiddenTrailers
+  """
+  RFC 9110 §6.5.1 — field names that must not appear in a trailer section.
+
+  A trailer arrives after the body, so honoring a framing, routing, request-
+  modifier, authentication, or payload-processing field there is a request-
+  smuggling vector. This is the trailer analogue of `_ListValuedHeaders`: a
+  curated denylist matched against the gate-normalized (lowercased) field name.
+  Names not on the list are permitted as trailers — Stallion validates them but
+  does not deliver them (the callback contract has no trailer event).
+  """
+  fun apply(name: String box): Bool =>
+    """Whether `name` (lowercased) is forbidden in a trailer section."""
+    match name
+    // Message framing and routing.
+    | "transfer-encoding" | "content-length" | "host"
+    // Request modifiers / controls (RFC 9110 §6.5.1).
+    | "cache-control" | "expect" | "max-forwards" | "pragma" | "range" | "te"
+    // Authentication and credentials.
+    | "authorization" | "proxy-authorization" | "cookie" | "set-cookie"
+    // Payload processing.
+    | "content-encoding" | "content-type" | "content-range" | "trailer" => true
+    else
+      false
+    end

--- a/stallion/_line_scan.pony
+++ b/stallion/_line_scan.pony
@@ -1,0 +1,100 @@
+class val _Line
+  """
+  A complete CRLF-terminated protocol line, with content guaranteed free of
+  any bare CR or bare LF.
+
+  Content is `buf[content_start, content_end)`; the terminating CR sits at
+  `content_end` and the LF at `content_end + 1`, so the next line begins at
+  `next_pos()`.
+  """
+  let content_start: USize
+  let content_end: USize
+
+  new val create(content_start': USize, content_end': USize) =>
+    content_start = content_start'
+    content_end = content_end'
+
+  fun is_blank(): Bool =>
+    """Whether this is the empty line (a bare CRLF with no content)."""
+    content_start == content_end
+
+  fun next_pos(): USize =>
+    """Buffer position immediately after this line's CRLF terminator."""
+    content_end + 2
+
+class val _ScannedLine
+  """
+  The content of one protocol line, already proven free of bare CR and LF by
+  `_LineScan`.
+
+  The parser gates (`_FieldLine`, `_RequestLine`, `_ChunkHeader`) take this
+  rather than a raw `String` so a caller cannot hand them bytes that skipped the
+  line policy — the line invariant the rewrite rests on. The only intended
+  construction is `_RequestParser.scanned_line` from a `_LineScan` `_Line`;
+  wrapping an arbitrary string here is a deliberate, greppable assertion that the
+  bytes are CR/LF-clean.
+  """
+  let content: String val
+
+  new val create(content': String val) =>
+    content = content'
+
+primitive _LineTooLong
+  """A line's content reached the size limit before any CRLF terminator."""
+
+primitive _LineNeedMore
+  """
+  No complete CRLF-terminated line is available yet.
+
+  A CR at the very end of the buffer is reported as need-more (not a bare CR):
+  the next read may supply the LF that completes the CRLF. This is what keeps
+  line parsing resumable at every byte boundary.
+  """
+
+type _LineResult is (_Line | BareCRLF | _LineTooLong | _LineNeedMore)
+
+primitive _LineScan
+  """
+  RFC 9112 §2.2 line policy — the single place CR/LF is interpreted, for every
+  line type (request line, header/trailer field-line, chunk-size line).
+
+  Only CRLF terminates a line. A bare LF, or a bare CR not immediately followed
+  by LF, is rejected (`BareCRLF`): folding either into a line boundary is the
+  request-smuggling vector this parser exists to close — an intermediary that
+  splits on a bare CR/LF would see a message boundary where Stallion does not.
+  A CR at the end of the buffer is need-more (it may become CRLF next read).
+
+  This is the only producer of a `_Line`, so no other code can obtain a line
+  that skipped the CR/LF check. It replaces the old `find_crlf`, which returned
+  the first CRLF and was blind to any interior bare CR/LF before it — the root
+  cause of the recurring smuggling bugs.
+  """
+  fun next(buf: Array[U8] box, from: USize, max: USize): _LineResult =>
+    """
+    Scan `buf[from..]` for one complete line. `max` bounds the content length
+    (excluding the CRLF); content reaching `max` bytes without a terminator is
+    `_LineTooLong`. A returned `_Line`'s content is free of bare CR and LF.
+    """
+    var i = from
+    let size = buf.size()
+    try
+      while i < size do
+        let b = buf(i)?
+        if b == '\n' then
+          return BareCRLF
+        elseif b == '\r' then
+          if (i + 1) == size then
+            return _LineNeedMore
+          elseif buf(i + 1)? != '\n' then
+            return BareCRLF
+          else
+            return _Line(from, i)
+          end
+        end
+        if (i - from) >= max then return _LineTooLong end
+        i = i + 1
+      end
+    else
+      _Unreachable()
+    end
+    _LineNeedMore

--- a/stallion/_parser_state.pony
+++ b/stallion/_parser_state.pony
@@ -11,385 +11,182 @@ interface ref _ParserState
   """
   A state in the HTTP request parser state machine.
 
-  Each state is a class that owns its per-state data (buffers,
-  accumulators). State transitions are explicit assignments to
-  `p.state`. Per-state data is automatically cleaned up when
-  the state transitions out.
+  Each state is a thin driver: it obtains protocol lines from `_LineScan` (the
+  single CR/LF policy) and field-lines from `_FieldLine` (the single field-line
+  gate), then transitions. No state interprets CR/LF or re-implements field-line
+  grammar itself — that is what makes every grammar rule enforced in exactly one
+  place. Per-state data (accumulators, counters) is owned by the state object and
+  released automatically on transition.
   """
   fun ref parse(p: _RequestParser ref): _ParseResult
 
 // ---------------------------------------------------------------------------
-// Buffer scanning utilities
-// ---------------------------------------------------------------------------
-
-primitive _BufferScan
-  """Byte-level scanning utilities for the parser buffer."""
-
-  fun find_crlf(buf: Array[U8] box, from: USize = 0): (USize | None) =>
-    """
-    Find the position of \\r\\n in buf starting from `from`.
-    Returns the index of \\r, or None if not found.
-    """
-    if buf.size() < (from + 2) then return None end
-    var i = from
-    let limit = buf.size() - 1
-    try
-      while i < limit do
-        if (buf(i)? == '\r') and (buf(i + 1)? == '\n') then
-          return i
-        end
-        i = i + 1
-      end
-    else
-      _Unreachable()
-    end
-    None
-
-  fun find_byte(
-    buf: Array[U8] box,
-    byte: U8,
-    from: USize,
-    to: USize = USize.max_value())
-    : (USize | None)
-  =>
-    """Find the first occurrence of `byte` in buf[from, to)."""
-    var i = from
-    let limit = to.min(buf.size())
-    try
-      while i < limit do
-        if buf(i)? == byte then return i end
-        i = i + 1
-      end
-    else
-      _Unreachable()
-    end
-    None
-
-// ---------------------------------------------------------------------------
-// Parser states
+// Request line
 // ---------------------------------------------------------------------------
 
 class _ExpectRequestLine is _ParserState
-  """
-  Initial state: waiting for a complete HTTP request line.
-
-  Format: METHOD SP request-target SP HTTP-version CRLF
-  """
+  """Initial state: waiting for a complete request line."""
   fun ref parse(p: _RequestParser ref): _ParseResult =>
-    let available = p.buf.size() - p.pos
-
-    // Check for CRLF marking end of request line
-    match \exhaustive\ _BufferScan.find_crlf(p.buf, p.pos)
-    | let crlf: USize =>
-      let line_len = crlf - p.pos
-      if line_len > p.config.max_request_line_size then
-        return TooLarge
+    match _LineScan.next(p.buf, p.pos, p.config.max_request_line_size)
+    | let line: _Line =>
+      match _RequestLine.parse(
+        p.scanned_line(line))
+      | (let m: Method, let target: String val, let v: Version) =>
+        p.pos = line.next_pos()
+        p.state = _ExpectHeaders(m, target, v, p.config)
+        _ParseContinue
+      | let e: ParseError => e
       end
-
-      // Find first space: separates method from URI
-      let method_end = match \exhaustive\ _BufferScan.find_byte(p.buf, ' ', p.pos, crlf)
-        | let i: USize => i
-        | None => return UnknownMethod
-        end
-
-      // Parse method
-      let method_str: String val = p.extract_string(p.pos, method_end)
-      let method = match \exhaustive\ Methods.parse(method_str)
-        | let m: Method => m
-        | None => return UnknownMethod
-        end
-
-      // Skip space(s) after method
-      var uri_start = method_end + 1
-      try
-        while (uri_start < crlf) and (p.buf(uri_start)? == ' ') do
-          uri_start = uri_start + 1
-        end
-      else
-        _Unreachable()
-      end
-
-      // Find second space: separates URI from version
-      let uri_end = match \exhaustive\ _BufferScan.find_byte(p.buf, ' ', uri_start, crlf)
-        | let i: USize => i
-        | None => return InvalidVersion
-        end
-
-      // Extract and validate URI
-      if uri_end == uri_start then
-        return InvalidURI
-      end
-
-      let uri: String val = p.extract_string(uri_start, uri_end)
-
-      // Validate URI: no control characters (< 0x21 or > 0x7E)
-      try
-        var i: USize = 0
-        while i < uri.size() do
-          let ch = uri(i)?
-          if (ch < 0x21) or (ch > 0x7E) then
-            return InvalidURI
-          end
-          i = i + 1
-        end
-      else
-        _Unreachable()
-      end
-
-      // Skip space(s) before version
-      var ver_start = uri_end + 1
-      try
-        while (ver_start < crlf) and (p.buf(ver_start)? == ' ') do
-          ver_start = ver_start + 1
-        end
-      else
-        _Unreachable()
-      end
-
-      // Parse version: must be exactly "HTTP/1.0" or "HTTP/1.1"
-      let ver_len = crlf - ver_start
-      if ver_len != 8 then
-        return InvalidVersion
-      end
-
-      let version = try
-        if (p.buf(ver_start)? == 'H')
-          and (p.buf(ver_start + 1)? == 'T')
-          and (p.buf(ver_start + 2)? == 'T')
-          and (p.buf(ver_start + 3)? == 'P')
-          and (p.buf(ver_start + 4)? == '/')
-          and (p.buf(ver_start + 5)? == '1')
-          and (p.buf(ver_start + 6)? == '.')
-        then
-          let minor = p.buf(ver_start + 7)?
-          if minor == '1' then
-            HTTP11
-          elseif minor == '0' then
-            HTTP10
-          else
-            return InvalidVersion
-          end
-        else
-          return InvalidVersion
-        end
-      else
-        _Unreachable()
-        return InvalidVersion
-      end
-
-      // Advance past the request line (including CRLF)
-      p.pos = crlf + 2
-
-      // Transition to header parsing
-      p.state = _ExpectHeaders(method, uri, version, p.config)
-      _ParseContinue
-
-    | None =>
-      // No complete line yet — check size limit
-      if available > p.config.max_request_line_size then
-        TooLarge
-      else
-        _ParseNeedMore
-      end
+    | BareCRLF => BareCRLF
+    | _LineTooLong => TooLarge
+    | _LineNeedMore => _ParseNeedMore
     end
+
+// ---------------------------------------------------------------------------
+// Headers
+// ---------------------------------------------------------------------------
 
 class _ExpectHeaders is _ParserState
   """
-  Parsing HTTP headers after the request line.
+  Parsing header field-lines until the empty line ends the header section.
 
-  Loops through header lines until an empty line (CRLF) marks the end
-  of headers. Tracks Content-Length and Transfer-Encoding for body handling.
+  Tracks Content-Length and Transfer-Encoding so the body framing can be
+  resolved once, at the blank line, before the request is delivered.
   """
   let _method: Method
-  let _uri: String val
+  let _target: String val
   let _version: Version
   let _config: _ParserConfig
   var _headers: Headers iso = recover iso Headers end
   var _content_length: (USize | None) = None
   var _has_transfer_encoding: Bool = false
   embed _te_codings: Array[String] = Array[String]
-  // Conjunction of every `append_codings` result; false once any
-  // Transfer-Encoding line is malformed (an unterminated quoted-string).
   var _te_well_formed: Bool = true
-  var _total_header_bytes: USize = 0
+  var _header_bytes_used: USize = 0
 
   new create(
-    method: Method,
-    uri: String val,
-    version: Version,
+    method': Method,
+    target': String val,
+    version': Version,
     config: _ParserConfig)
   =>
-    _method = method
-    _uri = uri
-    _version = version
+    _method = method'
+    _target = target'
+    _version = version'
     _config = config
 
   fun ref parse(p: _RequestParser ref): _ParseResult =>
-    // Loop through header lines
     while true do
-      match \exhaustive\ _BufferScan.find_crlf(p.buf, p.pos)
-      | let crlf: USize =>
-        if crlf == p.pos then
-          // Empty line: end of headers
-          p.pos = crlf + 2
-
-          // Check body size limit before delivering the request. The actor
-          // can now respond in on_request(), so rejections must precede delivery.
-          match _content_length
-          | let cl: USize if cl > _config.max_body_size =>
-            return BodyTooLarge
-          end
-
-          // Evaluate Transfer-Encoding before delivering the request, so
-          // unsupported (501) or invalid (400) codings are rejected without
-          // firing on_request. Only `chunked`, as the final coding, frames a
-          // body (RFC 9112 §6.1/§6.3).
-          let use_chunked: Bool =
-            if _has_transfer_encoding then
-              match \exhaustive\
-                _TransferEncoding.evaluate(_te_codings, _te_well_formed)
-              | _ChunkedFraming => true
-              | let e: ParseError => return e
-              end
-            else
-              false
-            end
-
-          // Destructive read: swap out headers as val, replace with empty
-          let headers: Headers val =
-            (_headers = recover iso Headers end)
-
-          // Deliver the request metadata
-          p.handler.request_received(_method, _uri, _version, headers)
-
-          // Determine body handling: Transfer-Encoding takes precedence
-          // over Content-Length per RFC 9112 §6.3
-          if use_chunked then
-            p.state = _ExpectChunkHeader(0, _config)
-            return _ParseContinue
-          end
-
-          match \exhaustive\ _content_length
-          | let cl: USize if cl > 0 =>
-            p.state = _ExpectFixedBody(cl)
-            return _ParseContinue
-          else
-            // No body (no Content-Length, Content-Length: 0, or None)
-            p.handler.request_complete()
-            p.state = _ExpectRequestLine
-            return _ParseContinue
-          end
+      match _LineScan.next(p.buf, p.pos, _config.max_header_size)
+      | let line: _Line =>
+        if line.is_blank() then
+          p.pos = line.next_pos()
+          return _finish(p)
         end
 
-        // Track header size
-        let line_len = (crlf - p.pos) + 2
-        _total_header_bytes = _total_header_bytes + line_len
-        if _total_header_bytes > _config.max_header_size then
+        let line_len = (line.content_end - line.content_start) + 2
+        _header_bytes_used = _header_bytes_used + line_len
+        if _header_bytes_used > _config.max_header_size then
           return TooLarge
         end
 
-        // Check for obs-fold (continuation line): reject per RFC 7230
-        try
-          let first_byte = p.buf(p.pos)?
-          if _OWS(first_byte) then
-            return MalformedHeaders
+        match _FieldLine.parse(
+          p.scanned_line(line))
+        | let f: _Field =>
+          match _track(f)
+          | let e: ParseError => return e
           end
-        else
-          _Unreachable()
+          // `_FieldLine` already lowercased the name; skip Headers' re-lower.
+          _headers._add_lowered(f.name, f.value)
+        | let e: ParseError => return e
         end
 
-        // Find colon separator
-        let colon_pos = match \exhaustive\ _BufferScan.find_byte(p.buf, ':', p.pos, crlf)
-          | let i: USize => i
-          | None => return MalformedHeaders
-          end
-
-        // Header name must not be empty
-        if colon_pos == p.pos then
-          return MalformedHeaders
-        end
-
-        // Extract header name (lowercasing happens in Headers.add)
-        let name: String val = p.extract_string(p.pos, colon_pos)
-
-        // Extract header value, skipping optional whitespace (OWS)
-        var val_start = colon_pos + 1
-        try
-          while val_start < crlf do
-            let ch = p.buf(val_start)?
-            if not _OWS(ch) then break end
-            val_start = val_start + 1
-          end
-        else
-          _Unreachable()
-        end
-
-        // Trim trailing OWS from value
-        var val_end = crlf
-        try
-          while val_end > val_start do
-            let ch = p.buf(val_end - 1)?
-            if not _OWS(ch) then break end
-            val_end = val_end - 1
-          end
-        else
-          _Unreachable()
-        end
-
-        let value: String val = p.extract_string(val_start, val_end)
-
-        // Detect special headers
-        let lower_name: String val = name.lower()
-        if lower_name == "content-length" then
-          match \exhaustive\ _parse_content_length(value)
-          | let cl: USize =>
-            match \exhaustive\ _content_length
-            | let existing: USize =>
-              if existing != cl then
-                return InvalidContentLength
-              end
-            | None =>
-              _content_length = cl
-            end
-          | InvalidContentLength => return InvalidContentLength
-          end
-        elseif lower_name == "transfer-encoding" then
-          _has_transfer_encoding = true
-          _te_well_formed =
-            _TransferEncoding.append_codings(value, _te_codings)
-              and _te_well_formed
-        end
-
-        _headers.add(name, value)
-
-        // Advance past this header line
-        p.pos = crlf + 2
-      | None =>
-        // No complete line yet — check size limit
-        let pending = p.buf.size() - p.pos
-        if (pending + _total_header_bytes) > _config.max_header_size then
-          return TooLarge
-        end
-        return _ParseNeedMore
+        p.pos = line.next_pos()
+      | BareCRLF => return BareCRLF
+      | _LineTooLong => return TooLarge
+      | _LineNeedMore => return _ParseNeedMore
       end
     end
     _Unreachable()
     _ParseNeedMore
 
+  fun ref _track(f: _Field): (None | ParseError) =>
+    """Record Content-Length / Transfer-Encoding from a recognized field."""
+    if f.name == "content-length" then
+      match _parse_content_length(f.value)
+      | let cl: USize =>
+        match _content_length
+        | let existing: USize =>
+          if existing != cl then return InvalidContentLength end
+        | None =>
+          _content_length = cl
+        end
+      | InvalidContentLength => return InvalidContentLength
+      end
+    elseif f.name == "transfer-encoding" then
+      _has_transfer_encoding = true
+      _te_well_formed =
+        _TransferEncoding.append_codings(f.value, _te_codings) and _te_well_formed
+    end
+    None
+
+  fun ref _finish(p: _RequestParser ref): _ParseResult =>
+    // RFC 9112 §6.3: Content-Length together with Transfer-Encoding is a
+    // request-smuggling vector — reject rather than pick a framing (#114).
+    if _has_transfer_encoding and (_content_length isnt None) then
+      return ContentLengthWithTransferEncoding
+    end
+
+    // Body size limit (Content-Length) before delivery — the actor may respond
+    // in on_request(), so a rejection must precede delivery.
+    match _content_length
+    | let cl: USize if cl > _config.max_body_size => return BodyTooLarge
+    end
+
+    // Resolve Transfer-Encoding framing (501/400 rejected before delivery).
+    let use_chunked: Bool =
+      if _has_transfer_encoding then
+        match _TransferEncoding.evaluate(_te_codings, _te_well_formed)
+        | _ChunkedFraming => true
+        | let e: ParseError => return e
+        end
+      else
+        false
+      end
+
+    let headers: Headers val = (_headers = recover iso Headers end)
+    p.handler.request_received(_method, _target, _version, headers)
+
+    // The protocol layer may reject the request inside request_received (a Host
+    // or URI failure calls parse_error → stop()). If so, do not transition to a
+    // body state or fire request_complete — the request was never delivered.
+    if p.failed() then return _ParseContinue end
+
+    if use_chunked then
+      p.state = _ExpectChunkHeader(0, _config)
+      return _ParseContinue
+    end
+
+    match _content_length
+    | let cl: USize if cl > 0 =>
+      p.state = _ExpectFixedBody(cl)
+      _ParseContinue
+    else
+      p.handler.request_complete()
+      p.state = _ExpectRequestLine
+      _ParseContinue
+    end
+
   fun _parse_content_length(value: String val)
     : (USize | InvalidContentLength)
   =>
-    """Parse a Content-Length value as a non-negative integer."""
-    if value.size() == 0 then
-      return InvalidContentLength
-    end
+    """Parse a Content-Length value as a non-negative `1*DIGIT` integer."""
+    if value.size() == 0 then return InvalidContentLength end
     try
       var i: USize = 0
       while i < value.size() do
         let ch = value(i)?
-        if (ch < '0') or (ch > '9') then
-          return InvalidContentLength
-        end
+        if (ch < '0') or (ch > '9') then return InvalidContentLength end
         i = i + 1
       end
       value.read_int[USize]()?._1
@@ -397,12 +194,12 @@ class _ExpectHeaders is _ParserState
       InvalidContentLength
     end
 
-class _ExpectFixedBody is _ParserState
-  """
-  Reading a fixed-length request body (Content-Length).
+// ---------------------------------------------------------------------------
+// Fixed-length body
+// ---------------------------------------------------------------------------
 
-  Delivers body data incrementally as it becomes available in the buffer.
-  """
+class _ExpectFixedBody is _ParserState
+  """Reading a fixed-length body (Content-Length), delivered incrementally."""
   var _remaining: USize
 
   new create(remaining: USize) =>
@@ -411,9 +208,7 @@ class _ExpectFixedBody is _ParserState
   fun ref parse(p: _RequestParser ref): _ParseResult =>
     let available = (p.buf.size() - p.pos).min(_remaining)
     if available > 0 then
-      let chunk: Array[U8] val =
-        p.extract_bytes(p.pos, p.pos + available)
-      p.handler.body_chunk(chunk)
+      p.handler.body_chunk(p.extract_bytes(p.pos, p.pos + available))
       p.pos = p.pos + available
       _remaining = _remaining - available
     end
@@ -426,12 +221,12 @@ class _ExpectFixedBody is _ParserState
       _ParseNeedMore
     end
 
-class _ExpectChunkHeader is _ParserState
-  """
-  Expecting a chunk size line in chunked transfer encoding.
+// ---------------------------------------------------------------------------
+// Chunked transfer encoding
+// ---------------------------------------------------------------------------
 
-  Format: chunk-size [ chunk-ext ] CRLF
-  """
+class _ExpectChunkHeader is _ParserState
+  """Expecting a chunk-size line: `chunk-size [ chunk-ext ] CRLF`."""
   var _total_body_received: USize
   let _config: _ParserConfig
 
@@ -440,64 +235,43 @@ class _ExpectChunkHeader is _ParserState
     _config = config
 
   fun ref parse(p: _RequestParser ref): _ParseResult =>
-    match \exhaustive\ _BufferScan.find_crlf(p.buf, p.pos)
-    | let crlf: USize =>
-      let line_len = crlf - p.pos
-      if line_len > _config.max_chunk_header_size then
-        return InvalidChunk
-      end
-      if line_len == 0 then
-        return InvalidChunk
-      end
-
-      // Find optional chunk extension (semicolon)
-      let size_end = match \exhaustive\ _BufferScan.find_byte(p.buf, ';', p.pos, crlf)
-        | let i: USize => i
-        | None => crlf
+    match _LineScan.next(p.buf, p.pos, _config.max_chunk_header_size)
+    | let line: _Line =>
+      if line.is_blank() then return InvalidChunk end
+      match _ChunkHeader.parse(
+        p.scanned_line(line))
+      | let chunk_size: USize =>
+        p.pos = line.next_pos()
+        if chunk_size == 0 then
+          p.state = _ExpectChunkTrailer(0, _config)
+          _ParseContinue
+        else
+          // Checked addition: a chunk-size near USize.max (a 16-HEXDIG line,
+          // which fits within max_chunk_header_size) would wrap the body-size
+          // limit with plain `+`, silently defeating max_body_size. Fail closed
+          // on overflow.
+          (let total, let overflow) = _total_body_received.addc(chunk_size)
+          if overflow or (total > _config.max_body_size) then
+            return BodyTooLarge
+          end
+          p.state =
+            _ExpectChunkData(chunk_size, _total_body_received, _config)
+          _ParseContinue
         end
-
-      // Parse hex chunk size — must consume entire string
-      let size_str: String val = p.extract_string(p.pos, size_end)
-      let chunk_size = try
-        (let cs, let consumed) = size_str.read_int[USize](0, 16)?
-        if consumed.usize() != size_str.size() then
-          return InvalidChunk
-        end
-        cs
-      else
-        return InvalidChunk
+      | let e: ParseError => e
       end
-
-      p.pos = crlf + 2
-
-      if chunk_size == 0 then
-        // Last chunk — expect trailers or final CRLF
-        p.state = _ExpectChunkTrailer(0, _config)
-        _ParseContinue
-      else
-        // Check body size limit
-        if (_total_body_received + chunk_size) > _config.max_body_size then
-          return BodyTooLarge
-        end
-        p.state = _ExpectChunkData(
-          chunk_size, _total_body_received, _config)
-        _ParseContinue
-      end
-    | None =>
-      // No complete line — check size limit
-      let pending = p.buf.size() - p.pos
-      if pending > _config.max_chunk_header_size then
-        InvalidChunk
-      else
-        _ParseNeedMore
-      end
+    | BareCRLF => BareCRLF
+    | _LineTooLong => InvalidChunk
+    | _LineNeedMore => _ParseNeedMore
     end
 
 class _ExpectChunkData is _ParserState
   """
-  Reading chunk data in chunked transfer encoding.
+  Reading chunk data, delivered incrementally, then the mandatory CRLF.
 
-  Delivers data incrementally, then expects CRLF after the chunk data.
+  The post-data terminator must be exactly CRLF (RFC 9112 §7.1) — it is not a
+  general line, so it is checked directly rather than via `_LineScan`; any other
+  bytes are `InvalidChunk`.
   """
   var _remaining: USize
   var _total_body_received: USize
@@ -516,9 +290,7 @@ class _ExpectChunkData is _ParserState
     if _remaining > 0 then
       let available = (p.buf.size() - p.pos).min(_remaining)
       if available > 0 then
-        let chunk: Array[U8] val =
-          p.extract_bytes(p.pos, p.pos + available)
-        p.handler.body_chunk(chunk)
+        p.handler.body_chunk(p.extract_bytes(p.pos, p.pos + available))
         p.pos = p.pos + available
         _remaining = _remaining - available
         _total_body_received = _total_body_received + available
@@ -528,9 +300,7 @@ class _ExpectChunkData is _ParserState
       end
     end
 
-    // Chunk data consumed — expect CRLF
-    let bytes_available = p.buf.size() - p.pos
-    if bytes_available < 2 then
+    if (p.buf.size() - p.pos) < 2 then
       return _ParseNeedMore
     end
 
@@ -549,46 +319,49 @@ class _ExpectChunkData is _ParserState
 
 class _ExpectChunkTrailer is _ParserState
   """
-  Reading optional trailer headers after the last (zero-size) chunk.
+  Reading the optional trailer section after the last chunk.
 
-  Trailers are skipped (not delivered to the receiver). The request is
-  complete when an empty line is found.
+  Trailer field-lines pass through the SAME `_FieldLine` gate as headers, plus
+  the forbidden-trailer rule (RFC 9110 §6.5.1). Trailers are validated but not
+  delivered (the callback contract has no trailer event). The request completes
+  at the empty line.
   """
-  var _total_trailer_bytes: USize
+  var _trailer_bytes_used: USize
   let _config: _ParserConfig
 
-  new create(total_trailer_bytes: USize, config: _ParserConfig) =>
-    _total_trailer_bytes = total_trailer_bytes
+  new create(trailer_bytes_used: USize, config: _ParserConfig) =>
+    _trailer_bytes_used = trailer_bytes_used
     _config = config
 
   fun ref parse(p: _RequestParser ref): _ParseResult =>
     while true do
-      match \exhaustive\ _BufferScan.find_crlf(p.buf, p.pos)
-      | let crlf: USize =>
-        if crlf == p.pos then
-          // Empty line: end of chunked message
-          p.pos = crlf + 2
+      match _LineScan.next(p.buf, p.pos, _config.max_header_size)
+      | let line: _Line =>
+        if line.is_blank() then
+          p.pos = line.next_pos()
           p.handler.request_complete()
           p.state = _ExpectRequestLine
           return _ParseContinue
         end
 
-        // Skip this trailer header line
-        let line_len = (crlf - p.pos) + 2
-        _total_trailer_bytes = _total_trailer_bytes + line_len
-        if _total_trailer_bytes > _config.max_header_size then
+        let line_len = (line.content_end - line.content_start) + 2
+        _trailer_bytes_used = _trailer_bytes_used + line_len
+        if _trailer_bytes_used > _config.max_header_size then
           return TooLarge
         end
 
-        p.pos = crlf + 2
-      | None =>
-        let pending = p.buf.size() - p.pos
-        if (pending + _total_trailer_bytes) > _config.max_header_size then
-          return TooLarge
+        match _FieldLine.parse(
+          p.scanned_line(line))
+        | let f: _Field =>
+          if _ForbiddenTrailers(f.name) then return ForbiddenTrailer end
+        | let e: ParseError => return e
         end
-        return _ParseNeedMore
+
+        p.pos = line.next_pos()
+      | BareCRLF => return BareCRLF
+      | _LineTooLong => return TooLarge
+      | _LineNeedMore => return _ParseNeedMore
       end
     end
     _Unreachable()
     _ParseNeedMore
-

--- a/stallion/_request_line.pony
+++ b/stallion/_request_line.pony
@@ -1,0 +1,92 @@
+type _RequestLineResult is
+  ( (Method, String val, Version)
+  | UnknownMethod | InvalidRequestLine | InvalidURI | InvalidVersion )
+
+primitive _RequestLine
+  """
+  RFC 9112 §3 request line — `method SP request-target SP HTTP-version`, with
+  EXACTLY one SP between the three components. Any other SP count (a missing
+  delimiter, an extra delimiter, or a space inside the request-target) is a
+  framing violation (`InvalidRequestLine`).
+
+  The request-target is validated only at the byte/framing level here: it must
+  be a non-empty run of VCHARs (no controls, NUL, or non-ASCII; SP is already
+  excluded by the split). That is the smuggling-relevant check, enforced where
+  the bytes are. The target is delivered RAW; parsing it into a URI structure
+  (origin/absolute/authority form) is the protocol layer's job.
+
+  The input is a `_ScannedLine` (produced by `_LineScan`), so the request line
+  is already free of bare CR/LF before this runs.
+  """
+  fun parse(scanned: _ScannedLine): _RequestLineResult =>
+    let line: String val = scanned.content
+    let sp1 = try line.find(" ")?.usize() else return InvalidRequestLine end
+    let sp2 =
+      try line.find(" ", (sp1 + 1).isize())?.usize()
+      else return InvalidRequestLine
+      end
+    // A third SP means more than two delimiters — malformed framing.
+    if (try line.find(" ", (sp2 + 1).isize())?; true else false end) then
+      return InvalidRequestLine
+    end
+
+    let method_str = line.trim(0, sp1)
+    let method' =
+      match Methods.parse(method_str)
+      | let m: Method => m
+      | None =>
+        // Not a method we implement. A valid token is an unimplemented method
+        // (`UnknownMethod` → 501); a non-token is a malformed request line
+        // (`InvalidRequestLine` → 400).
+        if _Token.valid(method_str) then
+          return UnknownMethod
+        else
+          return InvalidRequestLine
+        end
+      end
+
+    let target = line.trim(sp1 + 1, sp2)
+    match _valid_target(target)
+    | let e: InvalidURI => return e
+    end
+
+    let version' =
+      match _parse_version(line.trim(sp2 + 1))
+      | let v: Version => v
+      | None => return InvalidVersion
+      end
+
+    (method', target, version')
+
+  fun _valid_target(target: String val): (None | InvalidURI) =>
+    """
+    Framing-level byte check: the request-target must be a non-empty run of
+    VCHARs (0x21–0x7E). Controls (incl. NUL), DEL, and raw non-ASCII are
+    rejected; conformant targets percent-encode them. Structural URI validity
+    is left to the protocol layer.
+    """
+    if target.size() == 0 then return InvalidURI end
+    for b in target.values() do
+      if (b < 0x21) or (b > 0x7E) then return InvalidURI end
+    end
+    None
+
+  fun _parse_version(s: String val): (Version | None) =>
+    """Exactly `HTTP/1.0` or `HTTP/1.1`."""
+    if s.size() != 8 then return None end
+    try
+      if (s(0)? == 'H') and (s(1)? == 'T') and (s(2)? == 'T')
+        and (s(3)? == 'P') and (s(4)? == '/') and (s(5)? == '1')
+        and (s(6)? == '.')
+      then
+        match s(7)?
+        | '1' => HTTP11
+        | '0' => HTTP10
+        else None
+        end
+      else
+        None
+      end
+    else
+      None
+    end

--- a/stallion/_request_parser.pony
+++ b/stallion/_request_parser.pony
@@ -70,8 +70,31 @@ class _RequestParser
     """
     _failed = true
 
+  fun box failed(): Bool =>
+    """
+    Whether the parser has stopped (a parse error fired, or a handler called
+    `stop()` during a callback). A state that invokes a handler callback which
+    may reject the request (e.g. delivering a request whose Host the protocol
+    layer rejects) must check this before firing further callbacks.
+    """
+    _failed
+
+  fun ref scanned_line(line: _Line): _ScannedLine =>
+    """
+    Extract a `_LineScan` line's content as a `_ScannedLine` token — the only
+    intended way to produce one. Requiring a `_Line` ties the token to the line
+    policy, so the gates that consume it cannot be fed un-scanned bytes.
+    """
+    _ScannedLine(extract_string(line.content_start, line.content_end))
+
   fun ref extract_bytes(from: USize, to: USize): Array[U8] iso^ =>
-    """Copy bytes from buf[from..to) into a new iso array."""
+    """
+    Copy bytes from buf[from..to) into a new iso array.
+
+    Must COPY, not view: callers (the parser states) may hold the result across
+    `parse()` calls, and `parse()` compacts `buf` via `trim_in_place(pos)`. A
+    zero-copy view into `buf` would dangle after compaction.
+    """
     let len = to - from
     let out = recover Array[U8].create(len) end
     var i = from

--- a/stallion/_test.pony
+++ b/stallion/_test.pony
@@ -15,6 +15,21 @@ actor \nodoc\ Main is TestList
     // OWS tests
     test(_TestOWS)
 
+    // Token tests
+    test(_TestToken)
+
+    // Field value tests
+    test(_TestFieldValue)
+
+    // Request conformance corpus (table-driven)
+    test(_TestRequestConformance)
+    test(_TestRequestParity)
+    test(_TestBareCRLFInjection)
+    test(_TestParseSplitInvariance)
+    test(_TestCompletionPoints)
+    test(_TestSizeLimitChunkHeader)
+    test(_TestSizeLimitHeadersCumulative)
+
     // Quoted-split tokenizer tests
     test(_TestQuotedSplit)
 
@@ -104,6 +119,12 @@ actor \nodoc\ Main is TestList
     // Server integration tests
     test(_TestServerHelloWorld)
     test(_TestServerParseError)
+    test(_TestServerMissingHost)
+    test(_TestServerDuplicateHost)
+    test(_TestServerConnectOk)
+    test(_TestServerUnknownMethod)
+    test(_TestServerDuplicateHostHTTP10)
+    test(_TestServerDuplicateHostWithBody)
     test(_TestKeepAlive)
     test(_TestConnectionClose)
     test(_TestHTTP10Close)

--- a/stallion/_test_cookie_validator.pony
+++ b/stallion/_test_cookie_validator.pony
@@ -150,7 +150,7 @@ primitive \nodoc\ _CookieTestGenerators
       let s = String
       var b: U8 = 33
       while b <= 126 do
-        if _CookieValidator._is_token_char(b) then s.push(b) end
+        if _Token(b) then s.push(b) end
         b = b + 1
       end
       s

--- a/stallion/_test_field_value.pony
+++ b/stallion/_test_field_value.pony
@@ -1,0 +1,34 @@
+use "pony_test"
+
+class \nodoc\ iso _TestFieldValue is UnitTest
+  """
+  Verify the `_FieldValue` forbidden-byte predicate and whole-string check
+  against the RFC 9110 §5.5 MUST-reject set (CR, LF, NUL).
+  """
+  fun name(): String => "field_value/forbidden_and_valid"
+
+  fun apply(h: TestHelper) =>
+    // The three forbidden bytes.
+    h.assert_true(_FieldValue.forbidden('\r'), "CR is forbidden")
+    h.assert_true(_FieldValue.forbidden('\n'), "LF is forbidden")
+    h.assert_true(_FieldValue.forbidden(0), "NUL is forbidden")
+
+    // Bytes that are allowed in a field value: SP, HTAB, visible ASCII,
+    // and obs-text (0x80–0xFF) are not forbidden.
+    h.assert_false(_FieldValue.forbidden(' '), "SP is allowed")
+    h.assert_false(_FieldValue.forbidden('\t'), "HTAB is allowed")
+    h.assert_false(_FieldValue.forbidden('a'), "letter is allowed")
+    h.assert_false(_FieldValue.forbidden('0'), "digit is allowed")
+    h.assert_false(_FieldValue.forbidden(0x7F), "DEL is not in the set")
+    h.assert_false(_FieldValue.forbidden(0x80), "obs-text is allowed")
+    h.assert_false(_FieldValue.forbidden(0xFF), "obs-text is allowed")
+
+    // valid: rejects any string containing a forbidden byte, accepts the
+    // rest. Empty is valid (a field value may be empty).
+    h.assert_true(_FieldValue.valid(""), "empty value is valid")
+    h.assert_true(_FieldValue.valid("application/json"), "plain value")
+    h.assert_true(_FieldValue.valid("a b\tc"), "interior SP and HTAB")
+    h.assert_false(_FieldValue.valid("a\rb"), "interior CR")
+    h.assert_false(_FieldValue.valid("a\nb"), "interior LF")
+    h.assert_false(_FieldValue.valid(recover val String.>push(0) end),
+      "interior NUL")

--- a/stallion/_test_request_conformance.pony
+++ b/stallion/_test_request_conformance.pony
@@ -1,0 +1,413 @@
+use "pony_test"
+
+// ---------------------------------------------------------------------------
+// Table-driven HTTP/1.1 request conformance corpus (parser level).
+//
+// Each case is (name, raw-bytes, expected-outcome). Outcomes are:
+//   _Accept     — request_received with the given method/target/version, the
+//                 exact body bytes, and exactly one request_complete.
+//   _Incomplete — the parser consumed the bytes without completing or erroring
+//                 (it needs more data); no request_complete, no parse_error.
+//   ParseError  — exactly one parse_error with that specific error value.
+//
+// Assertions target the specific dimension so flipping any case's expectation
+// makes it fail (counterfactual-friendly). The harness runs every case and
+// reports each failure by name, so running the corpus against a parser yields a
+// failure catalogue rather than a single opaque failure.
+//
+// Raw bytes are authored as String literals with explicit \r\n; control bytes
+// (NUL, VT) use \xNN escapes. Pony strings are length-counted, not
+// NUL-terminated, so an embedded \x00 is a real byte in the request.
+// ---------------------------------------------------------------------------
+
+primitive \nodoc\ _Incomplete
+  """Expected outcome: parser needs more data (no completion, no error)."""
+
+class \nodoc\ val _Accept
+  """Expected outcome: a fully parsed request with these fields."""
+  let method: String
+  let target: String
+  let version: Version
+  let body: String
+
+  new val create(
+    method': String,
+    target': String,
+    version': Version,
+    body': String = "")
+  =>
+    method = method'
+    target = target'
+    version = version'
+    body = body'
+
+type _Expected is (_Accept | _Incomplete | ParseError)
+
+class \nodoc\ val _Case
+  let name: String
+  let raw: String
+  let expected: _Expected
+
+  new val create(name': String, raw': String, expected': _Expected) =>
+    name = name'
+    raw = raw'
+    expected = expected'
+
+class \nodoc\ iso _TestRequestConformance is UnitTest
+  """
+  Runs the parser-level conformance corpus single-shot through `_RequestParser`
+  and asserts each case's expected outcome. A failure names the offending case.
+  """
+  fun name(): String => "parser/conformance"
+
+  fun apply(h: TestHelper) =>
+    for c in _ConformanceCases.all().values() do
+      _CaseRunner.run(h, c)
+    end
+
+primitive \nodoc\ _CaseRunner
+  """
+  Runs one conformance `_Case` single-shot through `_RequestParser` and asserts
+  its expected outcome, naming the case on failure. Shared by the table corpus
+  and the parity matrix.
+  """
+  fun run(h: TestHelper, c: _Case) =>
+    let notify: _TestParserNotify ref = _TestParserNotify
+    let parser = _RequestParser(notify)
+    parser.parse(recover c.raw.array().clone() end)
+
+    match c.expected
+    | let a: _Accept => _assert_accept(h, c, notify, a)
+    | _Incomplete => _assert_incomplete(h, c, notify)
+    | let e: ParseError => _assert_reject(h, c, notify, e)
+    end
+
+  fun _assert_accept(
+    h: TestHelper,
+    c: _Case,
+    notify: _TestParserNotify,
+    a: _Accept)
+  =>
+    if notify.errors.size() != 0 then
+      h.fail(_fail(c, "accept", _first_error(notify)))
+      return
+    end
+    if notify.requests.size() != 1 then
+      h.fail(_fail(c, "1 request",
+        notify.requests.size().string() + " requests"))
+      return
+    end
+    if notify.completed != 1 then
+      h.fail(_fail(c, "1 completion",
+        notify.completed.string() + " completions"))
+      return
+    end
+    try
+      (let m, let u, let v, _) = notify.requests(0)?
+      if m.string() != a.method then
+        h.fail(_fail(c, "method " + a.method, "method " + m.string()))
+      end
+      if u != a.target then
+        h.fail(_fail(c, "target " + a.target, "target " + u))
+      end
+      if not (v is a.version) then
+        h.fail(_fail(c, "version mismatch", "version mismatch"))
+      end
+      let got_body = notify.collected_body_string()
+      if got_body != a.body then
+        h.fail(_fail(c, "body '" + a.body + "'", "body '" + got_body + "'"))
+      end
+    else
+      h.fail(_fail(c, "readable request", "unreadable request"))
+    end
+
+  fun _assert_incomplete(h: TestHelper, c: _Case, notify: _TestParserNotify) =>
+    if notify.errors.size() != 0 then
+      h.fail(_fail(c, "incomplete", _first_error(notify)))
+    elseif notify.completed != 0 then
+      h.fail(_fail(c, "incomplete", "completed"))
+    end
+
+  fun _assert_reject(
+    h: TestHelper,
+    c: _Case,
+    notify: _TestParserNotify,
+    e: ParseError)
+  =>
+    if notify.errors.size() != 1 then
+      let got =
+        if notify.errors.size() == 0 then
+          if notify.completed > 0 then "accept" else "incomplete" end
+        else
+          notify.errors.size().string() + " errors"
+        end
+      h.fail(_fail(c, e.string(), got))
+      return
+    end
+    try
+      let actual = notify.errors(0)?
+      if not (actual is e) then
+        h.fail(_fail(c, e.string(), actual.string()))
+      end
+    else
+      h.fail(_fail(c, e.string(), "unreadable error"))
+    end
+
+  fun _first_error(notify: _TestParserNotify): String =>
+    try notify.errors(0)?.string() else "accept" end
+
+  fun _fail(c: _Case, want: String, got: String): String =>
+    "[" + c.name + "] expected " + want + ", got " + got
+
+primitive \nodoc\ _ConformanceCases
+  """
+  The parser-level conformance corpus. Grouped by concern; `all()` concatenates
+  every group. Protocol-layer cases (request-target structure, Host, CONNECT)
+  live in the HTTPServer-level suite, not here.
+  """
+  fun all(): Array[_Case] val =>
+    let out = recover iso Array[_Case] end
+    for c in request_line().values() do out.push(c) end
+    for c in header_validation().values() do out.push(c) end
+    for c in content_length().values() do out.push(c) end
+    for c in transfer_encoding().values() do out.push(c) end
+    for c in chunked_body().values() do out.push(c) end
+    for c in trailers().values() do out.push(c) end
+    consume out
+
+  fun request_line(): Array[_Case] val =>
+    """
+    Request line: `method SP request-target SP HTTP-version CRLF`, exactly one
+    SP between components (RFC 9112 §3). `space_in_request_target` is handled
+    HERE (parser level) as a framing violation, not at the protocol layer.
+    """
+    [ _Case("rl_simple_ok",
+        "GET / HTTP/1.1\r\nHost: a\r\n\r\n",
+        _Accept("GET", "/", HTTP11))
+      _Case("rl_http10_ok",
+        "GET / HTTP/1.0\r\nHost: a\r\n\r\n",
+        _Accept("GET", "/", HTTP10))
+      _Case("bare_lf_request_line",
+        "GET / HTTP/1.1\nHost: a\r\n\r\n",
+        BareCRLF)
+      _Case("bad_version",
+        "GET / HTTP/5.6\r\nHost: a\r\n\r\n",
+        InvalidVersion)
+      _Case("non_token_method",
+        "GE(T / HTTP/1.1\r\nHost: a\r\n\r\n",
+        InvalidRequestLine)
+      _Case("unknown_method",
+        "FOOBAR / HTTP/1.1\r\nHost: a\r\n\r\n",
+        UnknownMethod)
+      _Case("multi_sp_request_line",
+        "GET  / HTTP/1.1\r\nHost: a\r\n\r\n",
+        InvalidRequestLine)
+      _Case("space_in_request_target",
+        "GET /a b HTTP/1.1\r\nHost: a\r\n\r\n",
+        InvalidRequestLine)
+      _Case("empty_request_target",
+        "GET  HTTP/1.1\r\nHost: a\r\n\r\n",
+        InvalidURI)
+    ]
+
+  fun header_validation(): Array[_Case] val =>
+    """
+    Header field-lines: name is `1*tchar` (`_Token`); value is free of CR/LF/NUL
+    (CR/LF as `BareCRLF` via the line policy, NUL as `InvalidFieldValue`); no
+    obs-fold; no whitespace before the colon.
+    """
+    [ _Case("ws_before_colon",
+        "GET / HTTP/1.1\r\nHost: a\r\nFoo : bar\r\n\r\n",
+        InvalidFieldName)
+      _Case("non_token_field_name",
+        "GET / HTTP/1.1\r\nHost: a\r\nFo@o: bar\r\n\r\n",
+        InvalidFieldName)
+      _Case("interior_ws_in_name",
+        "POST / HTTP/1.1\r\nHost: a\r\nContent -Length: 5\r\n" +
+        "Transfer-Encoding: chunked\r\n\r\n5\r\n01234\r\n0\r\n\r\n",
+        InvalidFieldName)
+      _Case("bare_cr_in_value",
+        "GET / HTTP/1.1\r\nHost: a\r\nX: b\rc\r\n\r\n",
+        BareCRLF)
+      _Case("nul_in_value",
+        "GET / HTTP/1.1\r\nHost: a\r\nX: b\x00c\r\n\r\n",
+        InvalidFieldValue)
+      _Case("obs_fold",
+        "GET / HTTP/1.1\r\nHost: a\r\nX: b\r\n cont\r\n\r\n",
+        ObsFold)
+      _Case("leading_space_in_header_line",
+        "GET / HTTP/1.1\r\n Host: a\r\n\r\n",
+        ObsFold)
+    ]
+
+  fun content_length(): Array[_Case] val =>
+    [ _Case("cl_simple_ok",
+        "POST / HTTP/1.1\r\nHost: a\r\nContent-Length: 3\r\n\r\nabc",
+        _Accept("POST", "/", HTTP11, "abc"))
+      _Case("cl_duplicate_disagree",
+        "POST / HTTP/1.1\r\nHost: a\r\nContent-Length: 3\r\n" +
+        "Content-Length: 4\r\n\r\nabc",
+        InvalidContentLength)
+      _Case("cl_duplicate_same",
+        "POST / HTTP/1.1\r\nHost: a\r\nContent-Length: 3\r\n" +
+        "Content-Length: 3\r\n\r\nabc",
+        _Accept("POST", "/", HTTP11, "abc"))
+      _Case("cl_comma_list_diff",
+        "POST / HTTP/1.1\r\nHost: a\r\nContent-Length: 3, 4\r\n\r\nabc",
+        InvalidContentLength)
+      _Case("cl_comma_list_same",
+        "POST / HTTP/1.1\r\nHost: a\r\nContent-Length: 3, 3\r\n\r\nabc",
+        InvalidContentLength)
+      _Case("cl_non_digit",
+        "POST / HTTP/1.1\r\nHost: a\r\nContent-Length: 3abc\r\n\r\nabc",
+        InvalidContentLength)
+      _Case("cl_plus_prefix",
+        "POST / HTTP/1.1\r\nHost: a\r\nContent-Length: +3\r\n\r\nabc",
+        InvalidContentLength)
+      _Case("cl_leading_zero",
+        "POST / HTTP/1.1\r\nHost: a\r\nContent-Length: 003\r\n\r\nabc",
+        _Accept("POST", "/", HTTP11, "abc"))
+      _Case("cl_empty",
+        "POST / HTTP/1.1\r\nHost: a\r\nContent-Length: \r\n\r\nabc",
+        InvalidContentLength)
+    ]
+
+  fun transfer_encoding(): Array[_Case] val =>
+    [ _Case("chunked_ok",
+        "POST / HTTP/1.1\r\nHost: a\r\nTransfer-Encoding: chunked\r\n\r\n" +
+        "5\r\n01234\r\n0\r\n\r\n",
+        _Accept("POST", "/", HTTP11, "01234"))
+      _Case("te_and_cl",
+        "POST / HTTP/1.1\r\nHost: a\r\nContent-Length: 5\r\n" +
+        "Transfer-Encoding: chunked\r\n\r\n5\r\n01234\r\n0\r\n\r\n",
+        ContentLengthWithTransferEncoding)
+      _Case("te_cl_reordered",
+        "POST / HTTP/1.1\r\nHost: a\r\nTransfer-Encoding: chunked\r\n" +
+        "Content-Length: 5\r\n\r\n5\r\n01234\r\n0\r\n\r\n",
+        ContentLengthWithTransferEncoding)
+      _Case("te_chunked_not_final",
+        "POST / HTTP/1.1\r\nHost: a\r\n" +
+        "Transfer-Encoding: chunked, gzip\r\n\r\n5\r\n01234\r\n0\r\n\r\n",
+        InvalidTransferEncoding)
+      _Case("te_double_chunked",
+        "POST / HTTP/1.1\r\nHost: a\r\n" +
+        "Transfer-Encoding: chunked, chunked\r\n\r\n5\r\n01234\r\n0\r\n\r\n",
+        InvalidTransferEncoding)
+      _Case("te_multi_header_chunked",
+        "POST / HTTP/1.1\r\nHost: a\r\nTransfer-Encoding: chunked\r\n" +
+        "Transfer-Encoding: chunked\r\n\r\n5\r\n01234\r\n0\r\n\r\n",
+        InvalidTransferEncoding)
+      _Case("te_unknown_only",
+        "POST / HTTP/1.1\r\nHost: a\r\nTransfer-Encoding: fugazi\r\n\r\n",
+        UnsupportedTransferEncoding)
+      _Case("te_obfuscated_control",
+        "POST / HTTP/1.1\r\nHost: a\r\nTransfer-Encoding: \x0bchunked\r\n\r\n" +
+        "5\r\n01234\r\n0\r\n\r\n",
+        InvalidTransferEncoding)
+    ]
+
+  fun chunked_body(): Array[_Case] val =>
+    [ _Case("chunk_bare_lf_terminator",
+        "POST / HTTP/1.1\r\nHost: a\r\nTransfer-Encoding: chunked\r\n\r\n" +
+        "5\n01234\r\n0\r\n\r\n",
+        BareCRLF)
+      _Case("chunk_size_garbage_after",
+        "POST / HTTP/1.1\r\nHost: a\r\nTransfer-Encoding: chunked\r\n\r\n" +
+        "5XX\r\n01234\r\n0\r\n\r\n",
+        InvalidChunk)
+      _Case("chunk_size_hex_prefix",
+        "POST / HTTP/1.1\r\nHost: a\r\nTransfer-Encoding: chunked\r\n\r\n" +
+        "0x5\r\n01234\r\n0\r\n\r\n",
+        InvalidChunk)
+      _Case("chunk_size_underscore",
+        "POST / HTTP/1.1\r\nHost: a\r\nTransfer-Encoding: chunked\r\n\r\n" +
+        "5_0\r\n01234\r\n0\r\n\r\n",
+        InvalidChunk)
+      _Case("chunk_size_overflow_wraps_limit",
+        // A first chunk advances total to 1, then a USize.max chunk-size would
+        // wrap the body-size check below the limit with plain `+`. Must reject.
+        "POST / HTTP/1.1\r\nHost: a\r\nTransfer-Encoding: chunked\r\n\r\n" +
+        "1\r\nX\r\nffffffffffffffff\r\n",
+        BodyTooLarge)
+      _Case("chunk_ext_nul",
+        "POST / HTTP/1.1\r\nHost: a\r\nTransfer-Encoding: chunked\r\n\r\n" +
+        "5;\x00\r\n01234\r\n0\r\n\r\n",
+        InvalidChunkExtension)
+      _Case("chunk_ext_bare_cr",
+        "POST / HTTP/1.1\r\nHost: a\r\nTransfer-Encoding: chunked\r\n\r\n" +
+        "5;a\rb\r\n01234\r\n0\r\n\r\n",
+        BareCRLF)
+      _Case("chunk_ext_ok",
+        "POST / HTTP/1.1\r\nHost: a\r\nTransfer-Encoding: chunked\r\n\r\n" +
+        "5;ext\r\n01234\r\n0\r\n\r\n",
+        _Accept("POST", "/", HTTP11, "01234"))
+      _Case("chunk_ext_token_value",
+        "POST / HTTP/1.1\r\nHost: a\r\nTransfer-Encoding: chunked\r\n\r\n" +
+        "5;a=b\r\n01234\r\n0\r\n\r\n",
+        _Accept("POST", "/", HTTP11, "01234"))
+      _Case("chunk_ext_quoted_value",
+        "POST / HTTP/1.1\r\nHost: a\r\nTransfer-Encoding: chunked\r\n\r\n" +
+        "5;a=\"b\"\r\n01234\r\n0\r\n\r\n",
+        _Accept("POST", "/", HTTP11, "01234"))
+      _Case("chunk_ext_bad_name",
+        "POST / HTTP/1.1\r\nHost: a\r\nTransfer-Encoding: chunked\r\n\r\n" +
+        "5;a@b\r\n01234\r\n0\r\n\r\n",
+        InvalidChunkExtension)
+      _Case("chunk_ext_empty_quoted_value",
+        "POST / HTTP/1.1\r\nHost: a\r\nTransfer-Encoding: chunked\r\n\r\n" +
+        "5;a=\"\"\r\n01234\r\n0\r\n\r\n",
+        _Accept("POST", "/", HTTP11, "01234"))
+      _Case("chunk_ext_unterminated_quote",
+        "POST / HTTP/1.1\r\nHost: a\r\nTransfer-Encoding: chunked\r\n\r\n" +
+        "5;a=\"b\r\n01234\r\n0\r\n\r\n",
+        InvalidChunkExtension)
+      _Case("chunk_ext_ctl_in_quoted",
+        "POST / HTTP/1.1\r\nHost: a\r\nTransfer-Encoding: chunked\r\n\r\n" +
+        "5;a=\"\x01\"\r\n01234\r\n0\r\n\r\n",
+        InvalidChunkExtension)
+      _Case("chunk_data_bad_terminator",
+        "POST / HTTP/1.1\r\nHost: a\r\nTransfer-Encoding: chunked\r\n\r\n" +
+        "5\r\n01234XY\r\n0\r\n\r\n",
+        InvalidChunk)
+      _Case("chunk_data_bare_lf_terminator",
+        "POST / HTTP/1.1\r\nHost: a\r\nTransfer-Encoding: chunked\r\n\r\n" +
+        "5\r\n01234\n0\r\n\r\n",
+        InvalidChunk)
+      _Case("chunk_missing_final_crlf",
+        "POST / HTTP/1.1\r\nHost: a\r\nTransfer-Encoding: chunked\r\n\r\n" +
+        "5\r\n01234\r\n0\r\n",
+        _Incomplete)
+    ]
+
+  fun trailers(): Array[_Case] val =>
+    """
+    Trailer field-lines pass through the SAME field-line gate as headers
+    (`BareCRLF`, `InvalidFieldName`, `InvalidFieldValue`), plus the forbidden-
+    trailer rule (RFC 9110 §6.5.1): framing/routing/control fields are rejected
+    even when syntactically valid.
+    """
+    [ _Case("trailer_allowed_ok",
+        "POST / HTTP/1.1\r\nHost: a\r\nTransfer-Encoding: chunked\r\n\r\n" +
+        "5\r\n01234\r\n0\r\nX-Checksum: abc\r\n\r\n",
+        _Accept("POST", "/", HTTP11, "01234"))
+      _Case("trailer_injection_te",
+        "POST / HTTP/1.1\r\nHost: a\r\nTransfer-Encoding: chunked\r\n\r\n" +
+        "5\r\n01234\r\n0\r\nTransfer-Encoding: chunked\r\n\r\n",
+        ForbiddenTrailer)
+      _Case("trailer_injection_cl",
+        "POST / HTTP/1.1\r\nHost: a\r\nTransfer-Encoding: chunked\r\n\r\n" +
+        "5\r\n01234\r\n0\r\nContent-Length: 5\r\n\r\n",
+        ForbiddenTrailer)
+      _Case("trailer_injection_host",
+        "POST / HTTP/1.1\r\nHost: a\r\nTransfer-Encoding: chunked\r\n\r\n" +
+        "5\r\n01234\r\n0\r\nHost: evil\r\n\r\n",
+        ForbiddenTrailer)
+      _Case("trailer_non_token_name",
+        "POST / HTTP/1.1\r\nHost: a\r\nTransfer-Encoding: chunked\r\n\r\n" +
+        "5\r\n01234\r\n0\r\nFo@o: bar\r\n\r\n",
+        InvalidFieldName)
+      _Case("trailer_bare_lf",
+        "POST / HTTP/1.1\r\nHost: a\r\nTransfer-Encoding: chunked\r\n\r\n" +
+        "5\r\n01234\r\n0\r\nX-Foo: a\nb\r\n\r\n",
+        BareCRLF)
+    ]

--- a/stallion/_test_request_framing.pony
+++ b/stallion/_test_request_framing.pony
@@ -1,0 +1,175 @@
+use "pony_test"
+
+// ---------------------------------------------------------------------------
+// Framing & incremental coverage (Discussion #123 §1d).
+//
+// A conformance corpus has no MUST-vector for keep-alive / pipelining / partial
+// input, so a rewrite could regress resumability or shift a completion point
+// and nothing would fail. These tests close that gap:
+//   - parse-split invariance: a request fed in any chunking parses identically
+//     to the single-shot result (locks resumability at every byte boundary).
+//   - completion-point pins: request_complete fires at exactly one place per
+//     framing, and not before.
+//   - max_chunk_header_size: the one _ParserConfig limit with no prior test.
+// ---------------------------------------------------------------------------
+
+class \nodoc\ iso _TestParseSplitInvariance is UnitTest
+  """
+  Feeding a well-formed request in fixed-size chunks (down to byte-by-byte)
+  yields the same observable result as a single-shot parse.
+  """
+  fun name(): String => "parser/parse_split_invariance"
+
+  fun apply(h: TestHelper) =>
+    let requests =
+      [ "GET / HTTP/1.1\r\nHost: a\r\n\r\n"
+        "POST / HTTP/1.1\r\nHost: a\r\nContent-Length: 5\r\n\r\nhello"
+        "POST / HTTP/1.1\r\nHost: a\r\nTransfer-Encoding: chunked\r\n\r\n" +
+          "5\r\n01234\r\n0\r\n\r\n"
+        "GET /1 HTTP/1.1\r\nHost: a\r\n\r\nGET /2 HTTP/1.1\r\nHost: a\r\n\r\n"
+      ]
+    for raw in requests.values() do
+      let single = _Signature.of(raw, raw.size())
+      for chunk_size in [as USize: 1; 2; 3; 5; 8; 13].values() do
+        let split = _Signature.of(raw, chunk_size)
+        if not single.eq(split) then
+          h.fail("split invariance broken at chunk_size=" +
+            chunk_size.string() + " for request: " + raw +
+            "\n  single-shot: " + single.show() +
+            "\n  chunked:     " + split.show())
+        end
+      end
+    end
+
+class \nodoc\ val _Signature
+  """The observable result of a parse, for equality comparison across splits."""
+  let requests: USize
+  let completed: USize
+  let errors: USize
+  let body: String
+
+  new val create(
+    requests': USize,
+    completed': USize,
+    errors': USize,
+    body': String)
+  =>
+    requests = requests'
+    completed = completed'
+    errors = errors'
+    body = body'
+
+  new val of(raw: String, chunk_size: USize) =>
+    let notify: _TestParserNotify ref = _TestParserNotify
+    let parser = _RequestParser(notify)
+    let bytes: Array[U8] val = raw.array()
+    let step = chunk_size.max(1)
+    var i: USize = 0
+    while i < bytes.size() do
+      let stop = (i + step).min(bytes.size())
+      let seg = recover iso Array[U8](stop - i) end
+      var j = i
+      while j < stop do
+        try seg.push(bytes(j)?) end
+        j = j + 1
+      end
+      parser.parse(consume seg)
+      i = stop
+    end
+    requests = notify.requests.size()
+    completed = notify.completed
+    errors = notify.errors.size()
+    body = notify.collected_body_string()
+
+  fun eq(other: _Signature): Bool =>
+    (requests == other.requests) and (completed == other.completed)
+      and (errors == other.errors) and (body == other.body)
+
+  fun show(): String =>
+    "requests=" + requests.string() + " completed=" + completed.string() +
+    " errors=" + errors.string() + " body='" + body + "'"
+
+class \nodoc\ iso _TestCompletionPoints is UnitTest
+  """
+  request_complete fires at exactly one place per framing, and not before:
+  no-body right after the blank line; fixed body when the last byte arrives;
+  chunked at the empty trailer line.
+  """
+  fun name(): String => "parser/completion_points"
+
+  fun apply(h: TestHelper) =>
+    // No body: completes only once the blank line's final LF arrives.
+    _step(h, "no-body",
+      "GET / HTTP/1.1\r\nHost: a\r\n\r", 0,
+      "\n", 1)
+
+    // Fixed body: completes only when the final body byte arrives.
+    _step(h, "fixed-body",
+      "POST / HTTP/1.1\r\nHost: a\r\nContent-Length: 3\r\n\r\nab", 0,
+      "c", 1)
+
+    // Chunked: completes only at the empty trailer line.
+    _step(h, "chunked",
+      "POST / HTTP/1.1\r\nHost: a\r\nTransfer-Encoding: chunked\r\n\r\n" +
+      "5\r\n01234\r\n0\r\n", 0,
+      "\r\n", 1)
+
+  fun _step(
+    h: TestHelper,
+    label: String,
+    before: String,
+    expected_before: USize,
+    rest: String,
+    expected_after: USize)
+  =>
+    let notify: _TestParserNotify ref = _TestParserNotify
+    let parser = _RequestParser(notify)
+    parser.parse(recover before.array().clone() end)
+    h.assert_eq[USize](expected_before, notify.completed,
+      label + ": completions before final bytes")
+    parser.parse(recover rest.array().clone() end)
+    h.assert_eq[USize](expected_after, notify.completed,
+      label + ": completions after final bytes")
+
+class \nodoc\ iso _TestSizeLimitChunkHeader is UnitTest
+  """Chunk-size line (with extension) exceeding max_chunk_header_size → reject."""
+  fun name(): String => "parser/size_limit_chunk_header"
+
+  fun apply(h: TestHelper) =>
+    let config = _ParserConfig(where max_chunk_header_size' = 8)
+    let notify: _TestParserNotify ref = _TestParserNotify
+    let parser = _RequestParser(notify, config)
+    // Chunk header "5;aaaaaaaaaaaa" is 14 bytes > 8.
+    let raw: String val =
+      "POST / HTTP/1.1\r\nHost: a\r\nTransfer-Encoding: chunked\r\n\r\n" +
+      "5;aaaaaaaaaaaa\r\n01234\r\n0\r\n\r\n"
+    parser.parse(recover raw.array().clone() end)
+
+    h.assert_eq[USize](1, notify.errors.size(), "should have 1 error")
+    try
+      h.assert_true(notify.errors(0)? is InvalidChunk, "should be InvalidChunk")
+    end
+
+class \nodoc\ iso _TestSizeLimitHeadersCumulative is UnitTest
+  """
+  Many individually-small, individually-valid header lines that together exceed
+  max_header_size → TooLarge. The per-line _LineScan cap can't catch this; the
+  cumulative budget must (a DoS bound, not exercised by the single-oversized-line
+  size test).
+  """
+  fun name(): String => "parser/size_limit_headers_cumulative"
+
+  fun apply(h: TestHelper) =>
+    let config = _ParserConfig(where max_header_size' = 20)
+    let notify: _TestParserNotify ref = _TestParserNotify
+    let parser = _RequestParser(notify, config)
+    // Each "A: b\r\n" is 6 bytes; five of them is 30 > 20, but no single line
+    // exceeds the limit.
+    let raw: String val =
+      "GET / HTTP/1.1\r\nA: b\r\nA: b\r\nA: b\r\nA: b\r\nA: b\r\n\r\n"
+    parser.parse(recover raw.array().clone() end)
+
+    h.assert_eq[USize](1, notify.errors.size(), "should have 1 error")
+    try
+      h.assert_true(notify.errors(0)? is TooLarge, "should be TooLarge")
+    end

--- a/stallion/_test_request_parity.pony
+++ b/stallion/_test_request_parity.pony
@@ -1,0 +1,164 @@
+use "pony_test"
+
+// ---------------------------------------------------------------------------
+// Cross-position parity matrix (Discussion #123 §1e).
+//
+// For each malformed-byte class, assert rejection at EVERY position it can
+// appear: request line, header name, header value, chunk-size line, chunk
+// extension, trailer name, trailer value. This is the direct antidote to "the
+// field-value fix never reached trailers" — a class fixed at one position but
+// not another shows up here as a single failing cell.
+//
+// Reuses the `_Case` / `_CaseRunner` machinery from the conformance corpus.
+// ---------------------------------------------------------------------------
+
+class \nodoc\ iso _TestRequestParity is UnitTest
+  fun name(): String => "parser/parity_matrix"
+
+  fun apply(h: TestHelper) =>
+    for c in _ParityCases.all().values() do
+      _CaseRunner.run(h, c)
+    end
+
+primitive \nodoc\ _ParityCases
+  fun all(): Array[_Case] val =>
+    let out = recover iso Array[_Case] end
+    for c in bare_cr().values() do out.push(c) end
+    for c in bare_lf().values() do out.push(c) end
+    for c in non_token_name().values() do out.push(c) end
+    for c in nul_in_value().values() do out.push(c) end
+    consume out
+
+  fun bare_cr(): Array[_Case] val =>
+    """A lone CR (not followed by LF) at each position → BareCRLF."""
+    [ _Case("parity_cr_request_line",
+        "GET /a\rb HTTP/1.1\r\nHost: a\r\n\r\n", BareCRLF)
+      _Case("parity_cr_header_name",
+        "GET / HTTP/1.1\r\nHost: a\r\nX\rY: v\r\n\r\n", BareCRLF)
+      _Case("parity_cr_header_value",
+        "GET / HTTP/1.1\r\nHost: a\r\nX: a\rb\r\n\r\n", BareCRLF)
+      _Case("parity_cr_chunk_size",
+        "POST / HTTP/1.1\r\nHost: a\r\nTransfer-Encoding: chunked\r\n\r\n" +
+        "5\rx\r\n01234\r\n0\r\n\r\n", BareCRLF)
+      _Case("parity_cr_chunk_ext",
+        "POST / HTTP/1.1\r\nHost: a\r\nTransfer-Encoding: chunked\r\n\r\n" +
+        "5;a\rb\r\n01234\r\n0\r\n\r\n", BareCRLF)
+      _Case("parity_cr_trailer_name",
+        "POST / HTTP/1.1\r\nHost: a\r\nTransfer-Encoding: chunked\r\n\r\n" +
+        "5\r\n01234\r\n0\r\nX\rY: v\r\n\r\n", BareCRLF)
+      _Case("parity_cr_trailer_value",
+        "POST / HTTP/1.1\r\nHost: a\r\nTransfer-Encoding: chunked\r\n\r\n" +
+        "5\r\n01234\r\n0\r\nX: a\rb\r\n\r\n", BareCRLF)
+    ]
+
+  fun bare_lf(): Array[_Case] val =>
+    """A lone LF (not preceded by CR) at each position → BareCRLF."""
+    [ _Case("parity_lf_request_line",
+        "GET /a\nb HTTP/1.1\r\nHost: a\r\n\r\n", BareCRLF)
+      _Case("parity_lf_header_name",
+        "GET / HTTP/1.1\r\nHost: a\r\nX\nY: v\r\n\r\n", BareCRLF)
+      _Case("parity_lf_header_value",
+        "GET / HTTP/1.1\r\nHost: a\r\nX: a\nb\r\n\r\n", BareCRLF)
+      _Case("parity_lf_chunk_size",
+        "POST / HTTP/1.1\r\nHost: a\r\nTransfer-Encoding: chunked\r\n\r\n" +
+        "5\nx\r\n01234\r\n0\r\n\r\n", BareCRLF)
+      _Case("parity_lf_chunk_ext",
+        "POST / HTTP/1.1\r\nHost: a\r\nTransfer-Encoding: chunked\r\n\r\n" +
+        "5;a\nb\r\n01234\r\n0\r\n\r\n", BareCRLF)
+      _Case("parity_lf_trailer_name",
+        "POST / HTTP/1.1\r\nHost: a\r\nTransfer-Encoding: chunked\r\n\r\n" +
+        "5\r\n01234\r\n0\r\nX\nY: v\r\n\r\n", BareCRLF)
+      _Case("parity_lf_trailer_value",
+        "POST / HTTP/1.1\r\nHost: a\r\nTransfer-Encoding: chunked\r\n\r\n" +
+        "5\r\n01234\r\n0\r\nX: a\nb\r\n\r\n", BareCRLF)
+    ]
+
+  fun non_token_name(): Array[_Case] val =>
+    """
+    A non-token character in a name position. A non-token method is a malformed
+    request line (InvalidRequestLine); header and trailer names → InvalidFieldName.
+    """
+    [ _Case("parity_nontoken_method",
+        "GE@T / HTTP/1.1\r\nHost: a\r\n\r\n", InvalidRequestLine)
+      _Case("parity_nontoken_header_name",
+        "GET / HTTP/1.1\r\nHost: a\r\nX@Y: v\r\n\r\n", InvalidFieldName)
+      _Case("parity_nontoken_trailer_name",
+        "POST / HTTP/1.1\r\nHost: a\r\nTransfer-Encoding: chunked\r\n\r\n" +
+        "5\r\n01234\r\n0\r\nX@Y: v\r\n\r\n", InvalidFieldName)
+    ]
+
+  fun nul_in_value(): Array[_Case] val =>
+    """A NUL byte in a value position → InvalidFieldValue (header and trailer)."""
+    [ _Case("parity_nul_header_value",
+        "GET / HTTP/1.1\r\nHost: a\r\nX: a\x00b\r\n\r\n", InvalidFieldValue)
+      _Case("parity_nul_trailer_value",
+        "POST / HTTP/1.1\r\nHost: a\r\nTransfer-Encoding: chunked\r\n\r\n" +
+        "5\r\n01234\r\n0\r\nX: a\x00b\r\n\r\n", InvalidFieldValue)
+    ]
+
+// ---------------------------------------------------------------------------
+// Bare-CR/LF injection sweep (Discussion #123 §1e).
+//
+// Insert a single bare CR or bare LF at every offset within the framing region
+// of a well-formed, body-less request. The parser must NEVER deliver a
+// completed request with the byte silently folded in — it must reject or stay
+// incomplete. A folded-and-completed request is a smuggling desync, recorded
+// here as a violation.
+//
+// Exhaustive over offsets (stronger than random sampling). The template has no
+// body, so completion is all-or-nothing; the trailing CRLF terminator is left
+// out of the injection range (a byte after it is a legitimate next-request
+// prefix, not a fold).
+// ---------------------------------------------------------------------------
+
+class \nodoc\ iso _TestBareCRLFInjection is UnitTest
+  fun name(): String => "parser/bare_crlf_injection"
+
+  fun apply(h: TestHelper) =>
+    let template = "GET / HTTP/1.1\r\nHost: a\r\nX: y\r\n\r\n"
+    let base: Array[U8] val = template.array()
+    // Leave the final CRLF (the empty-line terminator) out of the range.
+    let limit = base.size() - 2
+    var violations: USize = 0
+    var first_offset: USize = 0
+    var first_byte: U8 = 0
+
+    for b in [as U8: '\r'; '\n'].values() do
+      var at: USize = 0
+      while at < limit do
+        let notify: _TestParserNotify ref = _TestParserNotify
+        let parser = _RequestParser(notify)
+        parser.parse(_inject(base, at, b))
+        if notify.completed != 0 then
+          if violations == 0 then
+            first_offset = at
+            first_byte = b
+          end
+          violations = violations + 1
+        end
+        at = at + 1
+      end
+    end
+
+    h.assert_eq[USize](0, violations,
+      "bare CR/LF folded into a completed request in " + violations.string() +
+      " of " + (limit * 2).string() + " injections; first at offset " +
+      first_offset.string() + " byte 0x" + _hex(first_byte))
+
+  fun _inject(base: Array[U8] val, at: USize, b: U8): Array[U8] iso^ =>
+    """Return a copy of `base` with byte `b` inserted before index `at`."""
+    let out = recover Array[U8](base.size() + 1) end
+    var i: USize = 0
+    while i < base.size() do
+      if i == at then out.push(b) end
+      try out.push(base(i)?) end
+      i = i + 1
+    end
+    out
+
+  fun _hex(b: U8): String =>
+    let digits = "0123456789abcdef"
+    let s = recover String(2) end
+    try s.push(digits(((b and 0xF0) >> 4).usize())?) end
+    try s.push(digits((b and 0x0F).usize())?) end
+    consume s

--- a/stallion/_test_request_parser.pony
+++ b/stallion/_test_request_parser.pony
@@ -763,8 +763,9 @@ class \nodoc\ iso _TestContentLengthZero is UnitTest
 
 class \nodoc\ iso _TestContentLengthAndChunked is UnitTest
   """
-  Both Content-Length and Transfer-Encoding: chunked → chunked takes
-  precedence per RFC 7230 §3.3.3.
+  Both Content-Length and Transfer-Encoding present → reject with
+  ContentLengthWithTransferEncoding (RFC 9112 §6.3, request-smuggling vector).
+  A recipient must not silently pick a framing. Closes #114.
   """
   fun name(): String => "parser/content_length_and_chunked"
 
@@ -779,12 +780,11 @@ class \nodoc\ iso _TestContentLengthAndChunked is UnitTest
     let parser = _RequestParser(notify)
     parser.parse(recover raw.array().clone() end)
 
-    h.assert_eq[USize](1, notify.requests.size(), "1 request")
-    h.assert_eq[USize](1, notify.completed, "1 completion")
-    h.assert_eq[USize](0, notify.errors.size(), "0 errors")
-    // Body is 5 bytes (chunked), not 100 (Content-Length)
-    h.assert_eq[String val](
-      "Hello", notify.collected_body_string())
+    h.assert_eq[USize](1, notify.errors.size(), "should have 1 error")
+    try
+      h.assert_true(notify.errors(0)? is ContentLengthWithTransferEncoding,
+        "should be ContentLengthWithTransferEncoding")
+    end
 
 class \nodoc\ iso _TestDuplicateContentLength is UnitTest
   """Two Content-Length headers with differing values → InvalidContentLength."""
@@ -1105,12 +1105,13 @@ class \nodoc\ iso _TestTransferEncodingEvaluate is UnitTest
     _check(h, "chunked, chunked", "invalid")
     _check(h, "", "invalid")
     _check(h, " , ", "invalid")
-    // Only SP and HTAB are OWS; a coding wrapped in other control bytes
-    // (here a vertical tab) must not normalize to the `chunked` token.
+    // Only SP and HTAB are OWS; a coding name wrapped in other control bytes
+    // (here vertical tabs) is not a valid `token`, so the Transfer-Encoding is
+    // malformed (400) rather than an unimplemented coding (501).
     let vtab: String val = recover val
       String.>push(0x0b).>append("chunked").>push(0x0b)
     end
-    _check(h, vtab, "unsupported")
+    _check(h, vtab, "invalid")
     // A comma inside a quoted transfer-parameter value (RFC 9112 §7) must
     // not split the coding. Before the quoted-string-aware tokenizer these
     // were torn in half and rejected as invalid/unsupported.

--- a/stallion/_test_server_conformance.pony
+++ b/stallion/_test_server_conformance.pony
@@ -1,0 +1,138 @@
+use "pony_test"
+use lori = "lori"
+
+// ---------------------------------------------------------------------------
+// HTTPServer-level (protocol-layer) conformance (Discussion #123 boundary).
+//
+// Request-target structure and Host presence/uniqueness live at the protocol
+// layer, where URI and CONNECT handling already are — not in the parser. These
+// drive a real connection through HTTPServer and assert on the status line,
+// reusing the harness actors (_TestServerListener, _TestHelloServerFactory,
+// _TestHTTPClient) defined in _test_server.pony.
+//
+// missing_host / duplicate_host encode NEW behavior (RFC 9110 §7.2 /
+// 9112 §3.2): a server MUST answer 400 to an HTTP/1.1 request that lacks Host
+// or carries more than one. Not enforced today — these are catalogue entries
+// until the rewrite adds the check. connect_ok is a guard: a valid CONNECT
+// (authority-form target + Host) is accepted.
+// ---------------------------------------------------------------------------
+
+class \nodoc\ iso _TestServerMissingHost is UnitTest
+  """HTTP/1.1 request with no Host header → 400 Bad Request (RFC 9110 §7.2)."""
+  fun name(): String => "server/missing host"
+
+  fun apply(h: TestHelper) =>
+    h.long_test(5_000_000_000)
+    let port = "45920"
+    let host = ifdef linux then "127.0.0.2" else "localhost" end
+    let config = ServerConfig(host, port)
+    let listener = _TestServerListener(h, port, _TestHelloServerFactory,
+      config,
+      {(h': TestHelper, port': String) =>
+        let client = _TestHTTPClient(h', port',
+          "GET / HTTP/1.1\r\n\r\n", "400 Bad Request", None)
+        h'.dispose_when_done(client)
+      })
+    h.dispose_when_done(listener)
+
+class \nodoc\ iso _TestServerDuplicateHost is UnitTest
+  """HTTP/1.1 request with two Host headers → 400 Bad Request (RFC 9110 §7.2)."""
+  fun name(): String => "server/duplicate host"
+
+  fun apply(h: TestHelper) =>
+    h.long_test(5_000_000_000)
+    let port = "45921"
+    let host = ifdef linux then "127.0.0.2" else "localhost" end
+    let config = ServerConfig(host, port)
+    let listener = _TestServerListener(h, port, _TestHelloServerFactory,
+      config,
+      {(h': TestHelper, port': String) =>
+        let client = _TestHTTPClient(h', port',
+          "GET / HTTP/1.1\r\nHost: a\r\nHost: b\r\n\r\n",
+          "400 Bad Request", None)
+        h'.dispose_when_done(client)
+      })
+    h.dispose_when_done(listener)
+
+class \nodoc\ iso _TestServerConnectOk is UnitTest
+  """A valid CONNECT (authority-form target + Host) is accepted."""
+  fun name(): String => "server/connect ok"
+
+  fun apply(h: TestHelper) =>
+    h.long_test(5_000_000_000)
+    let port = "45922"
+    let host = ifdef linux then "127.0.0.2" else "localhost" end
+    let config = ServerConfig(host, port)
+    let listener = _TestServerListener(h, port, _TestHelloServerFactory,
+      config,
+      {(h': TestHelper, port': String) =>
+        let client = _TestHTTPClient(h', port',
+          "CONNECT example.com:443 HTTP/1.1\r\nHost: example.com:443\r\n\r\n",
+          "200 OK", None)
+        h'.dispose_when_done(client)
+      })
+    h.dispose_when_done(listener)
+
+class \nodoc\ iso _TestServerDuplicateHostWithBody is UnitTest
+  """
+  A duplicate-Host request that also carries a body → 400, and the body must not
+  be processed: request_received rejects, stopping the parser before any body
+  state. Exercises the `failed()` guard in the parser's _finish.
+  """
+  fun name(): String => "server/duplicate host with body"
+
+  fun apply(h: TestHelper) =>
+    h.long_test(5_000_000_000)
+    let port = "45925"
+    let host = ifdef linux then "127.0.0.2" else "localhost" end
+    let config = ServerConfig(host, port)
+    let listener = _TestServerListener(h, port, _TestHelloServerFactory,
+      config,
+      {(h': TestHelper, port': String) =>
+        let client = _TestHTTPClient(h', port',
+          "POST / HTTP/1.1\r\nHost: a\r\nHost: b\r\nContent-Length: 3\r\n\r\nabc",
+          "400 Bad Request", None)
+        h'.dispose_when_done(client)
+      })
+    h.dispose_when_done(listener)
+
+class \nodoc\ iso _TestServerDuplicateHostHTTP10 is UnitTest
+  """
+  An HTTP/1.0 request with two Host headers → 400 (duplicate Host is rejected on
+  any version, not just HTTP/1.1).
+  """
+  fun name(): String => "server/duplicate host http10"
+
+  fun apply(h: TestHelper) =>
+    h.long_test(5_000_000_000)
+    let port = "45924"
+    let host = ifdef linux then "127.0.0.2" else "localhost" end
+    let config = ServerConfig(host, port)
+    let listener = _TestServerListener(h, port, _TestHelloServerFactory,
+      config,
+      {(h': TestHelper, port': String) =>
+        let client = _TestHTTPClient(h', port',
+          "GET / HTTP/1.0\r\nHost: a\r\nHost: b\r\n\r\n",
+          "400 Bad Request", None)
+        h'.dispose_when_done(client)
+      })
+    h.dispose_when_done(listener)
+
+class \nodoc\ iso _TestServerUnknownMethod is UnitTest
+  """A valid-token but unimplemented method → 501 Not Implemented."""
+  fun name(): String => "server/unknown method"
+
+  fun apply(h: TestHelper) =>
+    h.long_test(5_000_000_000)
+    let port = "45923"
+    let host = ifdef linux then "127.0.0.2" else "localhost" end
+    let config = ServerConfig(host, port)
+    let listener = _TestServerListener(h, port, _TestHelloServerFactory,
+      config,
+      {(h': TestHelper, port': String) =>
+        let client = _TestHTTPClient(h', port',
+          "FOOBAR / HTTP/1.1\r\nHost: localhost\r\n\r\n",
+          "501 Not Implemented", None)
+        h'.dispose_when_done(client)
+      })
+    h.dispose_when_done(listener)

--- a/stallion/_test_token.pony
+++ b/stallion/_test_token.pony
@@ -1,0 +1,71 @@
+use "pony_test"
+
+class \nodoc\ iso _TestToken is UnitTest
+  """
+  Verify the `_Token` predicate and whole-string validity check against the
+  RFC 9110 §5.6.2 `tchar` set and its boundaries.
+  """
+  fun name(): String => "token/predicate_and_valid"
+
+  fun apply(h: TestHelper) =>
+    // Representative tchar from the punctuation list, plus DIGIT and ALPHA.
+    h.assert_true(_Token('!'), "! is tchar")
+    h.assert_true(_Token('#'), "# is tchar")
+    h.assert_true(_Token('$'), "$ is tchar")
+    h.assert_true(_Token('%'), "% is tchar")
+    h.assert_true(_Token('&'), "& is tchar")
+    h.assert_true(_Token('\''), "apostrophe is tchar")
+    h.assert_true(_Token('*'), "* is tchar")
+    h.assert_true(_Token('+'), "+ is tchar")
+    h.assert_true(_Token('-'), "- is tchar")
+    h.assert_true(_Token('.'), ". is tchar")
+    h.assert_true(_Token('^'), "^ is tchar")
+    h.assert_true(_Token('_'), "_ is tchar")
+    h.assert_true(_Token('`'), "backtick is tchar")
+    h.assert_true(_Token('|'), "| is tchar")
+    h.assert_true(_Token('~'), "~ is tchar")
+    h.assert_true(_Token('0'), "digit is tchar")
+    h.assert_true(_Token('9'), "digit is tchar")
+    h.assert_true(_Token('A'), "uppercase letter is tchar")
+    h.assert_true(_Token('z'), "lowercase letter is tchar")
+
+    // Every RFC 9110 §5.6.2 delimiter is rejected.
+    h.assert_false(_Token('('), "( is a delimiter")
+    h.assert_false(_Token(')'), ") is a delimiter")
+    h.assert_false(_Token('<'), "< is a delimiter")
+    h.assert_false(_Token('>'), "> is a delimiter")
+    h.assert_false(_Token('@'), "@ is a delimiter")
+    h.assert_false(_Token(','), ", is a delimiter")
+    h.assert_false(_Token(';'), "; is a delimiter")
+    h.assert_false(_Token(':'), ": is a delimiter")
+    h.assert_false(_Token('\\'), "backslash is a delimiter")
+    h.assert_false(_Token('"'), "double quote is a delimiter")
+    h.assert_false(_Token('/'), "/ is a delimiter")
+    h.assert_false(_Token('['), "[ is a delimiter")
+    h.assert_false(_Token(']'), "] is a delimiter")
+    h.assert_false(_Token('?'), "? is a delimiter")
+    h.assert_false(_Token('='), "= is a delimiter")
+    h.assert_false(_Token('{'), "{ is a delimiter")
+    h.assert_false(_Token('}'), "} is a delimiter")
+
+    // Whitespace and control bytes are not tchar.
+    h.assert_false(_Token(' '), "SP is not tchar")
+    h.assert_false(_Token('\t'), "HTAB is not tchar")
+    h.assert_false(_Token('\r'), "CR is not tchar")
+    h.assert_false(_Token('\n'), "LF is not tchar")
+
+    // Range boundaries: 0x20 (SP) just below, 0x21 (!) first, 0x7E (~)
+    // last, 0x7F (DEL) just above, and 0xFF.
+    h.assert_false(_Token(0x20), "0x20 is below the visible range")
+    h.assert_true(_Token(0x21), "0x21 is the first visible char")
+    h.assert_true(_Token(0x7E), "0x7E is the last visible char")
+    h.assert_false(_Token(0x7F), "DEL is above the visible range")
+    h.assert_false(_Token(0xFF), "0xFF is not tchar")
+
+    // valid: non-empty 1*tchar, rejecting empty and any non-tchar byte.
+    h.assert_true(_Token.valid("Content-Length"), "valid token name")
+    h.assert_true(_Token.valid("X-Custom_Header"), "valid token name")
+    h.assert_false(_Token.valid(""), "empty is not a token")
+    h.assert_false(_Token.valid("Content-Length "), "trailing space")
+    h.assert_false(_Token.valid("Content -Length"), "interior space")
+    h.assert_false(_Token.valid("Foo@Bar"), "interior delimiter")

--- a/stallion/_token.pony
+++ b/stallion/_token.pony
@@ -1,0 +1,39 @@
+primitive _Token
+  """
+  RFC 9110 §5.6.2 token: a non-empty sequence of `tchar`.
+
+  ```
+  tchar = "!" / "#" / "$" / "%" / "&" / "'" / "*" / "+" / "-" / "." /
+          "^" / "_" / "`" / "|" / "~" / DIGIT / ALPHA
+  ```
+
+  Equivalently: visible ASCII (0x21–0x7E) excluding the delimiters
+  `( ) < > @ , ; : \ " / [ ] ? = { }` (and, implicitly, SP/HTAB and control
+  bytes, which fall outside 0x21–0x7E). This is the same set RFC 2616 calls a
+  token, so cookie names (RFC 6265 §4.1.1, which defers to the RFC 2616 token)
+  use it too.
+
+  Single source for "what counts as a token character" across the parser
+  (HTTP field names, RFC 9112 §5.1) and the cookie validator, mirroring how
+  `_OWS` is the single source for optional whitespace.
+  """
+
+  fun apply(b: U8): Bool =>
+    """Whether `b` is a `tchar` (a valid token character)."""
+    if (b < 0x21) or (b > 0x7E) then return false end
+    match b
+    | '(' | ')' | '<' | '>' | '@'
+    | ',' | ';' | ':' | '\\' | '"'
+    | '/' | '[' | ']' | '?' | '='
+    | '{' | '}' => false
+    else
+      true
+    end
+
+  fun valid(s: String box): Bool =>
+    """Whether `s` is a non-empty token (`1*tchar`)."""
+    if s.size() == 0 then return false end
+    for b in s.values() do
+      if not apply(b) then return false end
+    end
+    true

--- a/stallion/_transfer_encoding.pony
+++ b/stallion/_transfer_encoding.pony
@@ -19,9 +19,10 @@ primitive _TransferEncoding
   fun append_codings(value: String val, tokens: Array[String] ref): Bool =>
     """
     Tokenize one Transfer-Encoding field value and append each normalized
-    coding name to `tokens`. Returns `false` if the value was malformed
-    (an unterminated quoted-string), in which case the caller must treat the
-    whole Transfer-Encoding as invalid rather than trust the tokens.
+    coding name to `tokens`. Returns `false` if the value was malformed — an
+    unterminated quoted-string, or a coding name that is not a valid token — in
+    which case the caller must treat the whole Transfer-Encoding as invalid
+    rather than trust the tokens.
 
     The value is split on `,` with `_QuotedSplit`, which respects quoted
     strings so a comma inside a `quoted-string` transfer-parameter value
@@ -33,13 +34,21 @@ primitive _TransferEncoding
     Transfer-Encoding header lines.
     """
     (let parts, let unterminated) = _QuotedSplit(value, ',')
+    var well_formed = not unterminated
     for raw in parts.values() do
       let coding: String = _normalize(raw)
       if coding.size() > 0 then
-        tokens.push(coding)
+        // A transfer-coding name is a token (RFC 9112 §6.1). A non-token
+        // coding (e.g. an obfuscated `\x0bchunked`) is a syntax error, not an
+        // unimplemented coding, so the value is malformed rather than 501.
+        if _Token.valid(coding) then
+          tokens.push(coding)
+        else
+          well_formed = false
+        end
       end
     end
-    not unterminated
+    well_formed
 
   fun _normalize(raw: String box): String iso^ =>
     """

--- a/stallion/headers.pony
+++ b/stallion/headers.pony
@@ -43,6 +43,17 @@ class Headers
     """
     _headers.push(Header(name.lower(), value))
 
+  fun ref _add_lowered(name: String val, value: String val) =>
+    """
+    Add a header entry whose name is ALREADY lowercased, skipping the redundant
+    `lower()` that `add` performs.
+
+    Precondition: `name` must already be lowercase — the parser's field-line
+    gate normalizes it. Passing a mixed-case name here breaks case-insensitive
+    `get()`/`set()` lookup, so external callers should use `add` instead.
+    """
+    _headers.push(Header(name, value))
+
   fun get(name: String): (String | None) =>
     """
     Get the value for the given header name (case-insensitive).

--- a/stallion/http_server.pony
+++ b/stallion/http_server.pony
@@ -159,6 +159,23 @@ class HTTPServer is
     version: Version,
     headers: Headers val)
   =>
+    // RFC 9110 §7.2 / RFC 9112 §3.2: an HTTP/1.1 request must carry exactly one
+    // Host field — reject (400) a missing Host on HTTP/1.1. We additionally
+    // reject a DUPLICATE Host on ANY version: a second Host line is request-
+    // smuggling surface regardless of protocol version (security over strict
+    // conformance). This needs the assembled headers, so it lives here, not in
+    // the parser. Count Host field-LINES via values(), not get(): get() combines
+    // repeated list-valued fields into one value, which would hide a duplicate
+    // Host behind a single combined result.
+    var host_count: USize = 0
+    for hdr in headers.values() do
+      if hdr.name == "host" then host_count = host_count + 1 end
+    end
+    if (host_count > 1) or ((host_count == 0) and (version is HTTP11)) then
+      parse_error(BadHostHeader)
+      return
+    end
+
     // Parse raw URI string into structured form. The parser already validated
     // basic syntax (no control characters); this catches structural failures
     // from the RFC 3986 parser (e.g., invalid authority in CONNECT targets).
@@ -230,14 +247,24 @@ class HTTPServer is
       _current_responder = None
       recv.on_request_complete(req, resp)
     else
+      // request_complete only fires for a delivered request: the parser's
+      // `_finish` returns early (checking `failed()`) when request_received
+      // rejected, so this branch is unreachable.
       _Unreachable()
     end
 
   fun ref parse_error(err: ParseError) =>
     // Send error directly to TCP (bypassing queue) then close.
     // Discarding pending pipelined responses is acceptable per HTTP spec
-    // since parse errors indicate a corrupt data stream.
+    // since parse errors indicate a corrupt data stream. Stop the parser so it
+    // delivers no further callbacks — parse_error may be called by the parser
+    // itself or internally here (Host/URI rejection in request_received), and
+    // in the latter case the parser is otherwise unaware the request was
+    // rejected and would keep parsing.
     _tcp_connection.send(_ErrorResponse.for_error(err))
+    match _parser
+    | let p: _RequestParser => p.stop()
+    end
     _close_connection()
 
   //

--- a/stallion/parse_error.pony
+++ b/stallion/parse_error.pony
@@ -20,17 +20,85 @@ primitive InvalidVersion
   """HTTP version is not HTTP/1.0 or HTTP/1.1."""
   fun string(): String iso^ => "InvalidVersion".clone()
 
-primitive MalformedHeaders
-  """Header syntax is invalid (missing colon, obs-fold continuation line)."""
-  fun string(): String iso^ => "MalformedHeaders".clone()
+primitive BareCRLF
+  """
+  A bare CR or bare LF appears inside a protocol line.
+
+  Only CRLF terminates a line. A lone CR (not immediately followed by LF) or a
+  lone LF anywhere in the request line, a header or trailer field-line, or a
+  chunk-size/extension line is rejected (RFC 9110 §5.5, RFC 9112 §2.2/§5).
+  Treating a bare CR or LF as a line boundary is a request-smuggling vector: an
+  intermediary that splits on it sees a message boundary where Stallion would
+  not, desynchronizing the two.
+  """
+  fun string(): String iso^ => "BareCRLF".clone()
+
+primitive InvalidFieldName
+  """
+  A header or trailer field name is not a valid token.
+
+  The name must be `1*tchar` (RFC 9110 §5.6.2, RFC 9112 §5.1). Rejected: a
+  non-token character, interior whitespace, whitespace between the name and the
+  colon, an empty name, or a missing colon.
+  """
+  fun string(): String iso^ => "InvalidFieldName".clone()
+
+primitive InvalidFieldValue
+  """
+  A header or trailer field value contains a forbidden byte.
+
+  RFC 9110 §5.5 requires rejecting a field value containing NUL. (Bare CR and
+  LF in a value are caught earlier by the line policy as `BareCRLF`; this error
+  covers the remaining forbidden byte, NUL.)
+  """
+  fun string(): String iso^ => "InvalidFieldValue".clone()
+
+primitive ObsFold
+  """
+  A header or trailer field uses obsolete line folding.
+
+  An obs-fold continuation line (a field-line beginning with SP or HTAB) is
+  rejected per RFC 9112 §5.2.
+  """
+  fun string(): String iso^ => "ObsFold".clone()
+
+primitive InvalidRequestLine
+  """
+  The request line is not `method SP request-target SP HTTP-version CRLF`.
+
+  Exactly one space separates each component (RFC 9112 §3). A different number
+  of spaces — extra delimiters, or a space inside the request-target — is a
+  framing violation and is rejected here.
+  """
+  fun string(): String iso^ => "InvalidRequestLine".clone()
 
 primitive InvalidContentLength
   """Content-Length is non-numeric, negative, or has conflicting values."""
   fun string(): String iso^ => "InvalidContentLength".clone()
 
 primitive InvalidChunk
-  """Chunked transfer encoding error: bad chunk size or missing CRLF."""
+  """
+  A chunk-size line is malformed.
+
+  The chunk-size must be `1*HEXDIG` (RFC 9112 §7.1). Rejected: a non-hex chunk
+  size, garbage after the size, an empty size line, or a missing CRLF after the
+  chunk data. (Forbidden bytes in a chunk extension are `InvalidChunkExtension`;
+  a bare CR or LF in a chunk line is `BareCRLF`.)
+  """
   fun string(): String iso^ => "InvalidChunk".clone()
+
+primitive InvalidChunkExtension
+  """
+  A chunk extension contains forbidden or malformed bytes.
+
+  A chunk-ext is `*( BWS ";" BWS chunk-ext-name [ BWS "=" BWS chunk-ext-val ] )`
+  where names are tokens and values are token or quoted-string (RFC 9112 §7.1.1).
+  Optional whitespace within the extension list is tolerated; whitespace between
+  the chunk-size and the first `;` is rejected as `InvalidChunk` (RFC 9110 §5.6.3
+  permits rejecting BWS). Unvalidated chunk-extension bytes are a smuggling
+  surface, so they are parsed rather than skipped to CRLF.
+  """
+  fun string(): String iso^ => "InvalidChunkExtension".clone()
 
 primitive BodyTooLarge
   """Request body exceeds the configured maximum body size."""
@@ -55,8 +123,51 @@ primitive UnsupportedTransferEncoding
   """
   fun string(): String iso^ => "UnsupportedTransferEncoding".clone()
 
+primitive ForbiddenTrailer
+  """
+  A trailer field carries a name that is not allowed in a trailer section.
+
+  RFC 9110 §6.5.1 forbids trailer fields that affect message framing, routing,
+  request modifiers, authentication, or payload processing — for example
+  `Transfer-Encoding`, `Content-Length`, and `Host`. A recipient must reject or
+  ignore such a trailer; Stallion rejects, because honoring a framing field that
+  arrives *after* the body is a request-smuggling vector. The trailer field's
+  syntax may be perfectly valid — the fault is the field's presence in a
+  trailer.
+  """
+  fun string(): String iso^ => "ForbiddenTrailer".clone()
+
+primitive BadHostHeader
+  """
+  A request's Host header field is missing (HTTP/1.1) or duplicated (any version).
+
+  RFC 9110 §7.2 / RFC 9112 §3.2 require every HTTP/1.1 request to carry exactly
+  one Host field; a server must answer 400 to one that lacks Host or has more
+  than one. Stallion also rejects a duplicate Host on HTTP/1.0 — a second Host
+  line is request-smuggling surface regardless of version. Enforced at the
+  protocol layer (where the assembled headers are known), not the parser.
+  """
+  fun string(): String iso^ => "BadHostHeader".clone()
+
+primitive ContentLengthWithTransferEncoding
+  """
+  A request carries both Content-Length and Transfer-Encoding header fields.
+
+  RFC 9112 §6.3 forbids this combination ("A sender MUST NOT send a
+  Content-Length header field in any message that contains a
+  Transfer-Encoding header field") because it is a request-smuggling vector:
+  an intermediary that honors one header while Stallion honors the other can
+  be desynchronized, letting a smuggled request slip past. Rather than pick a
+  framing, Stallion rejects the message — the presence of both headers is
+  itself the fault, regardless of what either header's value resolves to.
+  """
+  fun string(): String iso^ => "ContentLengthWithTransferEncoding".clone()
+
 type ParseError is
-  (TooLarge | UnknownMethod | InvalidURI | InvalidVersion | MalformedHeaders
-  | InvalidContentLength | InvalidChunk | BodyTooLarge
-  | InvalidTransferEncoding | UnsupportedTransferEncoding)
+  (TooLarge | UnknownMethod | InvalidURI | InvalidVersion
+  | BareCRLF | InvalidFieldName | InvalidFieldValue | ObsFold
+  | InvalidRequestLine | InvalidContentLength | InvalidChunk
+  | InvalidChunkExtension | BodyTooLarge | InvalidTransferEncoding
+  | UnsupportedTransferEncoding | ContentLengthWithTransferEncoding
+  | ForbiddenTrailer | BadHostHeader)
   """Parse error encountered during HTTP request parsing."""


### PR DESCRIPTION
Stallion's HTTP/1.1 request parser had a class of request-smuggling bugs, each found at a different parse position (Content-Length + Transfer-Encoding both present; non-token field names; bare CR/LF/NUL in values; unvalidated chunk extensions and trailers). They share one root cause: the parser found the first CRLF and validated only the positions that happened to re-scan the bytes, so every other position was a silent hole.

This rewrites the parser to be conformant-by-construction: no byte reaches a consumer unless it has passed the validation gate for its grammar position, and each grammar rule is enforced in exactly one place. A single line policy (`_LineScan`, replacing the permissive `find_crlf`) interprets CR/LF for every line type; a single field-line gate is shared verbatim by the header and trailer states (so a fix can no longer miss trailers); chunk size and chunk extension, the request line, methods, and request-target bytes are all validated. The gates take a typed token built only from the line scanner, so a caller cannot feed them bytes that skipped the line policy. Body and chunk-data delivery are unchanged.

The work is driven by a committed conformance test suite — a table-driven corpus, a cross-position parity matrix, an exhaustive bare-CR/LF injection sweep, and framing/resumability tests — which defines the correct behavior and is the arbiter of the rewrite.

User-visible behavior is in the release notes: the parser now rejects the smuggling vectors it previously accepted, enforces a single Host header field (and rejects a duplicate Host on any version), and returns 501 for a well-formed but unimplemented method.

Designed and reviewed via Discussion #123. Validating the Host field *value* is intentionally out of scope and tracked in #124.

Closes #114