### PR TITLE
Fix server going silent after sending a large response

### DIFF
--- a/.release-notes/fix-silent-connection-after-large-response.md
+++ b/.release-notes/fix-silent-connection-after-large-response.md
@@ -1,0 +1,3 @@
+## Fix server going silent after sending a large response
+
+After sending a large response, a server could stop reading anything further from that connection — additional requests on a keep-alive connection would never reach your handlers. No error was raised and the connection was not closed; it simply went quiet, even though the client was still sending. This most often showed up when sending or streaming large responses. Incoming requests are now delivered as expected.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,7 +46,7 @@ Concretely: a field name containing `_` is a valid RFC 9110 §5.6.2 token, so we
 
 Package: `stallion` (repo name is `stallion`, Pony package name is `stallion`)
 
-Built on lori (v0.15.0). Lori provides raw TCP I/O with a connection-actor model: `_on_received(data: Array[U8] iso)` for incoming data, `TCPConnection.send(data): (SendToken | SendError)` for outgoing, plus backpressure notifications, SSL support, per-connection ASIO-level idle timers, and general-purpose one-shot timers.
+Built on lori (v0.15.1). Lori provides raw TCP I/O with a connection-actor model: `_on_received(data: Array[U8] iso)` for incoming data, `TCPConnection.send(data): (SendToken | SendError)` for outgoing, plus backpressure notifications, SSL support, per-connection ASIO-level idle timers, and general-purpose one-shot timers.
 
 ### Key design decisions
 

--- a/corral.json
+++ b/corral.json
@@ -13,7 +13,7 @@
   "deps": [
     {
       "locator": "github.com/ponylang/lori.git",
-      "version": "0.15.0"
+      "version": "0.15.1"
     },
     {
       "locator": "github.com/ponylang/ssl.git",


### PR DESCRIPTION
Updates lori to 0.15.1, which fixes a server that could stop reading after a large response drained under backpressure, leaving further requests on the connection undelivered.