### PR TITLE
Document Windows ponyc 0.66.0 requirement in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ stallion is beta quality software that will change frequently. Expect breaking c
 
 ## Installation
 
-* Requires ponyc 0.64.0 or later
+* Requires ponyc 0.64.0 or later. On Windows, requires ponyc 0.66.0 or later.
 * Install [corral](https://github.com/ponylang/corral)
 * `corral add github.com/ponylang/stallion.git --version 0.7.3`
 * `corral fetch` to fetch your dependencies


### PR DESCRIPTION
The lori 0.16.0 update raised the ponyc requirement to 0.66.0 on Windows. The README listed only 0.64.0; this adds the Windows floor.