### PR TITLE
Fix idle timeout connection handling and double on_closed

### DIFF
--- a/.release-notes/next-release.md
+++ b/.release-notes/next-release.md
@@ -4,3 +4,15 @@ Building stallion for Windows now requires ponyc 0.66.0 or later and Windows 11 
 
 On Windows, backpressure notifications (`on_throttled`/`on_unthrottled`) now fire based on whether the operating system can actually accept more data, matching the behavior on other platforms. Previously they could fire based on an internal heuristic that did not reflect the real state of the socket.
 
+## Fix idle timeout never closing stalled connections
+
+A connection that stalled in the middle of a request or response — a client that stopped reading or sending — was never closed by the idle timeout and held the connection open indefinitely, letting a slow or stuck client exhaust the server. The idle timeout now closes any connection with no activity for the configured time, wherever it is in the request/response cycle. Connections still actively transferring data are not affected — they keep the connection alive.
+
+## Fix connections closed mid-transfer by the idle timeout
+
+A connection could be closed by its idle timeout while it was still actively transferring data to a slow peer. A large transfer draining slowly to a slow reader looked idle even though data was still moving, so it was closed mid-transfer. A connection is now closed by the idle timeout only when no data has moved in either direction for the timeout.
+
+## Fix on_closed firing twice when a backpressured connection closes
+
+When a connection was closed while under write backpressure, the `on_closed` callback fired twice. It now fires exactly once.
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,7 +46,7 @@ Concretely: a field name containing `_` is a valid RFC 9110 §5.6.2 token, so we
 
 Package: `stallion` (repo name is `stallion`, Pony package name is `stallion`)
 
-Built on lori (v0.16.0). Lori provides raw TCP I/O with a connection-actor model: `_on_received(data: Array[U8] iso)` for incoming data, `TCPConnection.send(data): (SendToken | SendError)` for outgoing, plus backpressure notifications, SSL support, per-connection ASIO-level idle timers, and general-purpose one-shot timers.
+Built on lori (v0.16.1). Lori provides raw TCP I/O with a connection-actor model: `_on_received(data: Array[U8] iso)` for incoming data, `TCPConnection.send(data): (SendToken | SendError)` for outgoing, plus backpressure notifications, SSL support, per-connection ASIO-level idle timers, and general-purpose one-shot timers.
 
 ### Key design decisions
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this project will be documented in this file. This projec
 
 ### Fixed
 
+- Fix idle timeout never closing stalled connections ([PR #137](https://github.com/ponylang/stallion/pull/137))
+- Fix connections closed mid-transfer by the idle timeout ([PR #137](https://github.com/ponylang/stallion/pull/137))
+- Fix on_closed firing twice when a backpressured connection closes ([PR #137](https://github.com/ponylang/stallion/pull/137))
+
 
 ### Added
 

--- a/corral.json
+++ b/corral.json
@@ -13,7 +13,7 @@
   "deps": [
     {
       "locator": "github.com/ponylang/lori.git",
-      "version": "0.16.0"
+      "version": "0.16.1"
     },
     {
       "locator": "github.com/ponylang/ssl.git",

--- a/stallion/_test.pony
+++ b/stallion/_test.pony
@@ -155,6 +155,7 @@ actor \nodoc\ Main is TestList
     test(_TestErrorResponse431)
     test(_TestErrorResponse505)
     test(_TestIdleTimeout)
+    test(_TestIdleTimeoutClosesStalledConnection)
     test(_TestMaxRequestsPerConnection)
     test(_TestServerTimerFires)
     test(_TestServerTimerCancelled)

--- a/stallion/_test_server.pony
+++ b/stallion/_test_server.pony
@@ -207,6 +207,100 @@ class \nodoc\ iso _TestIdleTimeout is UnitTest
       })
     h.dispose_when_done(listener)
 
+class \nodoc\ iso _TestIdleTimeoutClosesStalledConnection is UnitTest
+  """
+  A connection that stalls mid-request must be closed by the idle timeout.
+
+  Configure a 1-second idle timeout and a server whose handler never
+  responds. The client sends a complete request and then does nothing, so
+  the request is in flight with no socket activity. The idle timeout must
+  still close the connection — completion is gated on the client seeing the
+  close. Before the fix the idle timeout only fired between requests, so a
+  connection stalled mid-request like this leaked.
+  """
+  fun name(): String => "server/idle timeout closes stalled connection"
+
+  fun apply(h: TestHelper) =>
+    h.long_test(5_000_000_000)
+    let port = "45896"
+    let host = ifdef linux then "127.0.0.2" else "localhost" end
+    let idle_timeout = match lori.MakeIdleTimeout(1_000)
+    | let t: lori.IdleTimeout => t
+    end
+    let config = ServerConfig(host, port where idle_timeout' = idle_timeout)
+    let listener = _TestServerListener(h, port,
+      _TestNeverRespondsServerFactory, config,
+      {(h': TestHelper, port': String) =>
+        let request = "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n"
+        let client = _TestExpectIdleClose(h', port', request)
+        h'.dispose_when_done(client)
+      })
+    h.dispose_when_done(listener)
+
+class \nodoc\ val _TestNeverRespondsServerFactory is _TestConnectionFactory
+  fun apply(
+    auth: lori.TCPServerAuth,
+    fd: U32,
+    config: ServerConfig,
+    ssl_ctx: (ssl_net.SSLContext val | None)
+  ): lori.TCPConnectionActor =>
+    _TestNeverRespondsServer(auth, fd, config, ssl_ctx)
+
+actor \nodoc\ _TestNeverRespondsServer is HTTPServerActor
+  var _http: HTTPServer = HTTPServer.none()
+
+  new create(
+    auth: lori.TCPServerAuth,
+    fd: U32,
+    config: ServerConfig,
+    ssl_ctx: (ssl_net.SSLContext val | None))
+  =>
+    _http = match ssl_ctx
+    | let ctx: ssl_net.SSLContext val =>
+      HTTPServer.ssl(auth, ctx, fd, this, config)
+    else
+      HTTPServer(auth, fd, this, config)
+    end
+
+  fun ref _http_connection(): HTTPServer => _http
+
+  fun ref on_request_complete(request': Request val, responder: Responder) =>
+    // Never respond — the connection stalls mid-request. The idle timeout
+    // must close it.
+    None
+
+actor \nodoc\ _TestExpectIdleClose is
+  (lori.TCPConnectionActor & lori.ClientLifecycleEventReceiver)
+
+  var _tcp_connection: lori.TCPConnection = lori.TCPConnection.none()
+  let _h: TestHelper
+  let _request: String val
+
+  new create(h: TestHelper, port: String, request: String val) =>
+    _h = h
+    _request = request
+    let host = ifdef linux then "127.0.0.2" else "localhost" end
+    _tcp_connection = lori.TCPConnection.client(
+      lori.TCPConnectAuth(_h.env.root), host, port, "", this, this)
+
+  fun ref _connection(): lori.TCPConnection =>
+    _tcp_connection
+
+  fun ref _on_connected() =>
+    _tcp_connection.send(_request)
+
+  fun ref _on_received(data: Array[U8] iso) =>
+    // The server never produces a response; ignore anything that arrives.
+    None
+
+  fun ref _on_closed() =>
+    // The idle timeout closed the stalled connection — the fix works.
+    _h.complete(true)
+
+  fun ref _on_connection_failure(reason: lori.ConnectionFailureReason) =>
+    _h.fail("client connection failed")
+    _h.complete(false)
+
 class \nodoc\ iso _TestMaxRequestsPerConnection is UnitTest
   """
   Configure `max_requests_per_connection' = 2`. Send 3 pipelined HTTP/1.1

--- a/stallion/http_server.pony
+++ b/stallion/http_server.pony
@@ -42,7 +42,6 @@ class HTTPServer is
   var _requests_pending: USize = 0
   var _requests_completed: USize = 0
   var _parser: (_RequestParser | None) = None
-  var _idle: Bool = true
   embed _pending_sent_tokens: Array[(ChunkSendToken | None)]
 
   new none() =>
@@ -268,7 +267,6 @@ class HTTPServer is
       _Unreachable(); return
     end
     _requests_pending = _requests_pending + 1
-    _idle = false
 
     // Safety net: close if too many pipelined requests are pending
     match \exhaustive\ _config
@@ -360,9 +358,9 @@ class HTTPServer is
     Decrements the pending request count, increments the completed count,
     and decides whether to close the connection. The check order is:
     keep-alive=false closes first (existing HTTP semantics), then
-    max-requests check (connection resource limit), then idle if no more
-    requests are pending. Pipelined requests already in flight still get
-    served — the connection closes after the Nth response flushes.
+    max-requests check (connection resource limit). Pipelined requests
+    already in flight still get served — the connection closes after the
+    Nth response flushes.
     """
     _requests_pending = _requests_pending - 1
     _requests_completed = _requests_completed + 1
@@ -370,8 +368,6 @@ class HTTPServer is
       _close_connection()
     elseif _max_requests_reached() then
       _close_connection()
-    elseif _requests_pending == 0 then
-      _idle = true
     end
 
   fun _max_requests_reached(): Bool =>
@@ -445,10 +441,16 @@ class HTTPServer is
     end
 
   fun ref _handle_idle_timeout() =>
-    """Close the connection if it is idle (between requests)."""
-    if _idle then
-      _close_connection()
-    end
+    """
+    Close the connection on idle timeout.
+
+    "Idle" means no socket activity for the configured timeout, matching
+    lori's idle timer — not "between requests". A connection that stalls
+    mid-request or mid-response with no activity is closed like any other
+    idle connection. A client that keeps trickling data resets the timer
+    and is not closed; only fully-stalled connections are.
+    """
+    _close_connection()
 
   fun ref _handle_timer(token: lori.TimerToken) =>
     """Forward one-shot timer firing to the receiver."""
@@ -558,6 +560,9 @@ class HTTPServer is
       | let r: HTTPServerLifecycleEventReceiver ref => r.on_closed()
       | None => _Unreachable()
       end
-      _tcp_connection.close()
+      // Set _Closed before close(): on a muted connection close() hard-closes
+      // synchronously and re-enters _on_closed; the _Closed state makes that
+      // re-entry a no-op, so on_closed fires exactly once.
       _state = _Closed
+      _tcp_connection.close()
     end


### PR DESCRIPTION
Updates lori to 0.16.1 and fixes stallion's idle timeout handling, plus a double `on_closed`. Three user-facing fixes (three CHANGELOG entries, added manually):

- **Idle timeout now closes stalled connections.** A connection stalled mid-request/response (client stopped reading or sending) was never closed and leaked. The idle timeout now closes any connection with no activity for the configured time.
- **Active transfers are no longer closed mid-transfer** by the idle timeout (from the lori 0.16.1 bump).
- **`on_closed` fires once, not twice**, when a backpressured connection closes (it hard-closed synchronously and re-entered `_on_closed` while still `_Active`).