### PR TITLE
Update lori to 0.17.0

### DIFF
--- a/.release-notes/next-release.md
+++ b/.release-notes/next-release.md
@@ -1,0 +1,89 @@
+## Fix a hang when closing a connection from a request callback
+
+Calling `HTTPServer.close()` from inside `on_request()`, `on_body_chunk()`, or `on_request_complete()` — rejecting an oversized request with a 413 as soon as the headers arrive, for example — could leave the connection attempting one more read on the socket it had just closed. Under connection churn, with many connections opening and closing, that stray read could block one of the runtime's scheduler threads and keep the program from exiting.
+
+Closing a connection from a request callback no longer leaves that read outstanding.
+
+## Fix a connection wedging under sustained write backpressure
+
+A connection could permanently stop making progress under sustained write backpressure while the client was still sending. Stallion stops reading from a connection while backpressure is applied to it, and under sustained backpressure that pause could become permanent: data stopped moving in both directions and the connection did not recover on its own, staying wedged until something closed it. It was most likely to appear on a multi-threaded runtime.
+
+Such a connection now recovers and continues once the backpressure clears.
+
+## Fix backpressure not stopping incoming requests on an HTTPS connection
+
+When the send buffer fills, stallion stops reading from the connection and `on_throttled()` fires. On an HTTPS connection reading continued anyway: everything already decrypted from the same read was parsed, so an actor that had just received `on_throttled()` was handed more requests through `on_request()`, `on_body_chunk()`, and `on_request_complete()`. Stallion supports HTTP pipelining, so one read can carry several requests.
+
+Reading now stops on an HTTPS connection as soon as backpressure is applied, the same as on a plaintext one. Data already decrypted is held rather than dropped. It is parsed once backpressure clears and `on_unthrottled()` fires, ahead of anything read off the socket afterward.
+
+## Fix on_chunk_sent firing once per write-queue drain instead of once per chunk
+
+`Responder.send_chunk()` returns a `ChunkSendToken`, and `on_chunk_sent()` fires with that token once the chunk has been handed to the operating system. That pairing is what flow-controlled streaming is built on: send a chunk, wait for its callback, send the next. It did not hold. One callback was delivered each time the write queue drained completely rather than one per chunk, so an actor that sent several chunks while the socket was backed up got fewer callbacks than it had chunks outstanding.
+
+An actor that drives the next chunk from `on_chunk_sent()`, which is what `examples/streaming` does, stops sending when a callback it is waiting on never arrives, and the response is never finished. Keeping more than one chunk in flight made this more likely, because that is exactly when several chunks drain together.
+
+Every chunk that `send_chunk()` accepts now produces exactly one `on_chunk_sent()` callback, carrying that chunk's own token, in the order the chunks were sent.
+
+## Fix a possible write hang under load
+
+Under write load, sending response data could hang the whole program. When the send buffer filled on a blocking file descriptor, the write stalled and never returned. Connections use non-blocking descriptors, so this was only reachable once the operating system had reused a closed connection's descriptor number for a blocking socket elsewhere in the process. Rare, but possible.
+
+Sends now use a socket call, new in ponyc 0.67.0, that returns when the send buffer is full instead of stalling. The hang is closed on Linux, FreeBSD, OpenBSD, and DragonFly. macOS and Windows are unchanged.
+
+## Remove HTTPServer.yield_read()
+
+`yield_read()` is gone. It could not do what its name said. A yield only ever took effect at the end of a delivery, so every request carried by the read it was called from was parsed and answered anyway — and a single read carries as many pipelined requests as fit in the buffer. What it actually did was skip the tail of a read the connection was about to stop reading regardless.
+
+It was also callable anywhere on the server object. Only a call from inside a request callback had a defined meaning; a call from a behavior, from `on_closed()`, or after close either yielded a later read you did not mean or did nothing at all.
+
+Use `read_buffer_size` on `ServerConfig` instead. That is the value which actually bounds how much a connection does per scheduler turn.
+
+```pony
+// Before
+fun ref on_request_complete(request': Request val, responder: Responder) =>
+  responder.respond(response)
+  if (_count % 5) == 0 then
+    _http.yield_read()
+  end
+
+// After — set it once, when you build the config
+match lori.MakeReadBufferSize(4096)
+| let b: lori.ReadBufferSize =>
+  ServerConfig(host, port where read_buffer_size' = b)
+end
+```
+
+## Add read_buffer_size to ServerConfig
+
+How many bytes a connection reads before it hands the scheduler back and resumes on a later turn. It defaults to 16KB, which is what connections used before and what they still use if you set nothing.
+
+Lowering it bounds how much one connection does per turn, at the cost of more turns to get through the same data. Under sustained pipelined traffic that bound is what keeps one busy connection from monopolising a scheduler thread, because every request carried by a single read is parsed and answered before the connection gives the turn back.
+
+```pony
+match lori.MakeReadBufferSize(4096)
+| let b: lori.ReadBufferSize =>
+  ServerConfig("0.0.0.0", "80" where read_buffer_size' = b)
+end
+```
+
+## Require ponyc 0.67.0 or later
+
+Stallion now requires ponyc 0.67.0 or later on every platform. The previous minimum was 0.64.0, and 0.66.0 on Windows; 0.64.0 through 0.66.x are no longer supported. The write hang under load is closed by a socket call that ponyc added in 0.67.0.
+
+## Move to ponylang/ssl 3.0.0
+
+Stallion now requires ponylang/ssl 3.0.0, where it required 2.0.1. Stallion's own API is unchanged by the move: you build an `SSLContext val` and hand it to `HTTPServer.ssl` exactly as before.
+
+Your own code can break if it picks up the new version. If your application does not declare ssl itself, it gets 3.0.0 through stallion, and your own `use "ssl/net"` or `use "ssl/crypto"` code is built against it. If your application does declare ssl, your declaration is the one that applies.
+
+The twelve protocol-version primitives now spell their acronyms in full. They are the values passed to `SSLContext.set_min_proto_version` and `set_max_proto_version`, so if you pin a TLS version on the context you hand to `HTTPServer.ssl`, that call no longer compiles until you rename it:
+
+```pony
+// Before
+ctx.set_min_proto_version(Tls1u2Version())?
+
+// After
+ctx.set_min_proto_version(TLS1u2Version())?
+```
+
+`SSLContext.alpn_set_resolver` also changed: it takes an `ALPNProtocolResolver val` where it took a `box`. Constructing a `Digest`, `Digest.final`, and `HmacSha256` are all partial and need a `?`. `SSLState` gained an `SSLDisposed` member, which breaks an exhaustive match on `SSL.state()`. And a reference typed `HashFn tag` no longer compiles, so type it `val` or `box`. See the ponylang/ssl 3.0.0 release notes for more on each.

--- a/.release-notes/update-ssl-to-2.0.1.md
+++ b/.release-notes/update-ssl-to-2.0.1.md
@@ -1,3 +1,0 @@
-## Update ponylang/ssl to 2.0.1
-
-Updates the ponylang/ssl dependency to 2.0.1 to pick up a bug fix.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,7 @@ Read [CONTRIBUTING.md](CONTRIBUTING.md).
 ## Building and testing
 
 ```
+make ssl=4.0.x                       # build + run tests (OpenSSL 4.x)
 make ssl=3.0.x                       # build + run tests (OpenSSL 3.x)
 make ssl=1.1.x                       # OpenSSL 1.1.x
 make ssl=libressl                    # LibreSSL

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,24 @@ All notable changes to this project will be documented in this file. This projec
 
 ### Fixed
 
+- Fix a hang when closing a connection from a request callback ([PR #140](https://github.com/ponylang/stallion/pull/140))
+- Fix a connection wedging under sustained write backpressure ([PR #140](https://github.com/ponylang/stallion/pull/140))
+- Fix backpressure not stopping incoming requests on an HTTPS connection ([PR #140](https://github.com/ponylang/stallion/pull/140))
+- Fix on_chunk_sent firing once per write-queue drain instead of once per chunk ([PR #140](https://github.com/ponylang/stallion/pull/140))
+- Fix a possible write hang under load ([PR #140](https://github.com/ponylang/stallion/pull/140))
+
 
 ### Added
 
+- Add read_buffer_size to ServerConfig ([PR #140](https://github.com/ponylang/stallion/pull/140))
+
+
 
 ### Changed
+
+- Remove HTTPServer.yield_read() ([PR #140](https://github.com/ponylang/stallion/pull/140))
+- Require ponyc 0.67.0 or later ([PR #140](https://github.com/ponylang/stallion/pull/140))
+- Move to ponylang/ssl 3.0.0 ([PR #140](https://github.com/ponylang/stallion/pull/140))
 
 
 ## [0.8.0] - 2026-06-30

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,9 @@ else
 endif
 
 ifeq (,$(filter $(MAKECMDGOALS),clean docs TAGS))
-  ifeq ($(ssl), 3.0.x)
+  ifeq ($(ssl), 4.0.x)
+          SSL = -Dopenssl_4.0.x
+  else ifeq ($(ssl), 3.0.x)
           SSL = -Dopenssl_3.0.x
   else ifeq ($(ssl), 1.1.x)
           SSL = -Dopenssl_1.1.x

--- a/README.md
+++ b/README.md
@@ -8,14 +8,14 @@ stallion is beta quality software that will change frequently. Expect breaking c
 
 ## Installation
 
-* Requires ponyc 0.64.0 or later. On Windows, requires ponyc 0.66.0 or later.
+* Requires ponyc 0.67.0 or later.
 * Install [corral](https://github.com/ponylang/corral)
 * `corral add github.com/ponylang/stallion.git --version 0.8.0`
 * `corral fetch` to fetch your dependencies
 * `use "stallion"` to include this package
 * `corral run -- ponyc` to compile your application
 
-You'll also need a SSL library installed on your platform. See the [net-ssl](https://github.com/ponylang/net-ssl) installation instructions for details.
+This library depends on [ponylang/ssl](https://github.com/ponylang/ssl). It requires a C SSL library to be installed. Please see the [ssl installation instructions](https://github.com/ponylang/ssl?tab=readme-ov-file#installation) for more information.
 
 ## Usage
 

--- a/corral.json
+++ b/corral.json
@@ -13,11 +13,11 @@
   "deps": [
     {
       "locator": "github.com/ponylang/lori.git",
-      "version": "0.16.1"
+      "version": "0.17.0"
     },
     {
       "locator": "github.com/ponylang/ssl.git",
-      "version": "2.0.1"
+      "version": "3.0.0"
     },
     {
       "locator": "github.com/ponylang/uri.git",

--- a/examples/README.md
+++ b/examples/README.md
@@ -30,6 +30,6 @@ Request processing deadline that sets a 5-second timer then delegates to a worke
 
 Streams responses using chunked transfer encoding with flow-controlled delivery driven by `on_chunk_sent()` callbacks. Demonstrates matching on `StartChunkedResponseResult` from `start_chunked_response()`, then using `send_chunk()`, `finish_response()`, and `on_chunk_sent()` on `Responder` and `HTTPServerLifecycleEventReceiver`. The actor sends the first chunk in `on_request()`, then each `on_chunk_sent()` callback triggers the next chunk — natural backpressure without timers or manual windowing.
 
-## [yield](yield/)
+## [read-buffer-size](read-buffer-size/)
 
-Yields the read loop every N requests for scheduler fairness. Demonstrates calling `HTTPServer.yield_read()` from `on_request_complete` to implement a request-count-based yield policy. Under sustained pipelined traffic, periodic yields give other actors a chance to run. The yield is a one-shot pause — reading resumes automatically in the next scheduler turn.
+Reads a small amount from each connection before handing the scheduler back. Demonstrates setting `read_buffer_size` on `ServerConfig`. A connection reads up to that many bytes in one scheduler turn and then queues itself to continue later, which is what bounds how much work one busy connection does per turn.

--- a/examples/read-buffer-size/main.pony
+++ b/examples/read-buffer-size/main.pony
@@ -1,14 +1,16 @@
 """
-HTTP server that yields the read loop every N requests for scheduler
-fairness. Under sustained pipelined traffic a single connection's read
-loop can monopolize the Pony scheduler; periodic `yield_read()` calls
-give other actors a chance to run.
+HTTP server that reads a small amount from each connection before handing
+the scheduler back.
 
-Demonstrates calling `HTTPServer.yield_read()` from `on_request_complete`
-to implement a request-count-based yield policy. The yield is a one-shot
-pause — the read loop resumes automatically in the next scheduler turn.
+A connection reads up to its read buffer size in one scheduler turn, then
+queues itself to continue on a later turn. Under sustained pipelined
+traffic that bound is what keeps one busy connection from monopolizing a
+scheduler thread, because every request carried by a single read is parsed
+and answered before the connection gives the turn back.
 
-Try it with pipelined requests to see the yield in action:
+Demonstrates setting `read_buffer_size` on `ServerConfig`. The default is
+16KB; this server uses 1KB, so it does roughly a sixteenth as much work per
+turn and takes more turns to do it.
 
 ```
 printf 'GET / HTTP/1.1\r\nHost: localhost\r\n\r\n%.0s' {1..20} | nc localhost 8080
@@ -36,13 +38,20 @@ actor Listener is lori.TCPListenerActor
   =>
     _out = out
     _server_auth = lori.TCPServerAuth(auth)
-    _config = stallion.ServerConfig(host, port)
+    _config =
+      match lori.MakeReadBufferSize(1024)
+      | let b: lori.ReadBufferSize =>
+        stallion.ServerConfig(host, port where read_buffer_size' = b)
+      else
+        // 1024 is greater than zero, so this cannot happen.
+        stallion.ServerConfig(host, port)
+      end
     _tcp_listener = lori.TCPListener(auth, host, port, this)
 
   fun ref _listener(): lori.TCPListener => _tcp_listener
 
   fun ref _on_accept(fd: U32): lori.TCPConnectionActor =>
-    YieldServer(_server_auth, fd, _config, _out)
+    ReadBufferServer(_server_auth, fd, _config, _out)
 
   fun ref _on_listening() =>
     try
@@ -58,7 +67,7 @@ actor Listener is lori.TCPListenerActor
   fun ref _on_closed() =>
     _out.print("Server closed")
 
-actor YieldServer is stallion.HTTPServerActor
+actor ReadBufferServer is stallion.HTTPServerActor
   var _http: stallion.HTTPServer = stallion.HTTPServer.none()
   let _out: OutStream
   var _request_count: USize = 0
@@ -86,9 +95,3 @@ actor YieldServer is stallion.HTTPServerActor
       .add_chunk(body)
       .build()
     responder.respond(response)
-
-    // Yield every 5 requests to let other actors run
-    if (_request_count % 5) == 0 then
-      _out.print("Yielding after request " + _request_count.string())
-      _http.yield_read()
-    end

--- a/stallion/_test.pony
+++ b/stallion/_test.pony
@@ -210,6 +210,7 @@ actor \nodoc\ Main is TestList
     test(_TestHTTP10ChunkedRejection)
     test(_TestChunkSentCallback)
 
+
     // URI parsing integration tests
     test(_TestURIParsing)
     test(_TestConnectURIParsing)

--- a/stallion/_test_server.pony
+++ b/stallion/_test_server.pony
@@ -289,9 +289,9 @@ actor \nodoc\ _TestExpectIdleClose is
   fun ref _on_connected() =>
     _tcp_connection.send(_request)
 
-  fun ref _on_received(data: Array[U8] iso) =>
+  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     // The server never produces a response; ignore anything that arrives.
-    None
+    lori.KeepReading
 
   fun ref _on_closed() =>
     // The idle timeout closed the stalled connection — the fix works.
@@ -352,8 +352,9 @@ actor \nodoc\ _TestMaxRequestsClient is
       "GET /2 HTTP/1.1\r\nHost: localhost\r\n\r\n" +
       "GET /3 HTTP/1.1\r\nHost: localhost\r\n\r\n")
 
-  fun ref _on_received(data: Array[U8] iso) =>
+  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _response.append(consume data)
+    lori.KeepReading
 
   fun ref _on_closed() =>
     let r: String val = _response.clone()
@@ -852,12 +853,13 @@ actor \nodoc\ _TestHTTPClient is
   fun ref _on_connected() =>
     _tcp_connection.send(_request)
 
-  fun ref _on_received(data: Array[U8] iso) =>
+  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _response.append(consume data)
     // Check if we have a complete response (headers end with \r\n\r\n)
     if _response.contains("\r\n\r\n") then
       _verify_response()
     end
+    lori.KeepReading
 
   fun ref _on_connection_failure(reason: lori.ConnectionFailureReason) =>
     _h.fail("Client connection failed")
@@ -920,7 +922,7 @@ actor \nodoc\ _TestHTTPClientExpectClose is
   fun ref _on_connected() =>
     _tcp_connection.send(_request)
 
-  fun ref _on_received(data: Array[U8] iso) =>
+  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _response.append(consume data)
     if _response.contains("\r\n\r\n") then
       let response: String val = _response.clone()
@@ -932,6 +934,7 @@ actor \nodoc\ _TestHTTPClientExpectClose is
         _h.complete(false)
       end
     end
+    lori.KeepReading
 
   fun ref _on_closed() =>
     if _response_ok then
@@ -977,7 +980,7 @@ actor \nodoc\ _TestKeepAliveClient is
     _tcp_connection.send(
       "GET /1 HTTP/1.1\r\nHost: localhost\r\n\r\n")
 
-  fun ref _on_received(data: Array[U8] iso) =>
+  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _response.append(consume data)
     let r: String val = _response.clone()
 
@@ -997,6 +1000,7 @@ actor \nodoc\ _TestKeepAliveClient is
         _h.complete(true)
       end
     end
+    lori.KeepReading
 
   fun ref _on_closed() =>
     if _requests_sent < 2 then
@@ -1253,7 +1257,7 @@ actor \nodoc\ _TestPipelineClient is
       "GET /1 HTTP/1.1\r\nHost: localhost\r\n\r\n" +
       "GET /2 HTTP/1.1\r\nHost: localhost\r\n\r\n")
 
-  fun ref _on_received(data: Array[U8] iso) =>
+  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _response.append(consume data)
     let r: String val = _response.clone()
     // Check if we have all 3 responses
@@ -1275,6 +1279,7 @@ actor \nodoc\ _TestPipelineClient is
         _h.complete(false)
       end
     end
+    lori.KeepReading
 
   fun ref _on_connection_failure(reason: lori.ConnectionFailureReason) =>
     _h.fail("Client connection failed")
@@ -1306,7 +1311,7 @@ actor \nodoc\ _TestPipelineCloseClient is
   fun ref _on_connected() =>
     _tcp_connection.send(_request)
 
-  fun ref _on_received(data: Array[U8] iso) =>
+  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _response.append(consume data)
     let r: String val = _response.clone()
     // Look for 2 occurrences of "Hello, World!"
@@ -1314,6 +1319,7 @@ actor \nodoc\ _TestPipelineCloseClient is
       r.find("Hello, World!", 0, 1)?  // Find 2nd occurrence (0-indexed nth)
       _got_responses = true
     end
+    lori.KeepReading
 
   fun ref _on_closed() =>
     if _got_responses then
@@ -1358,7 +1364,7 @@ actor \nodoc\ _TestStreamClient is
     _tcp_connection.send(
       "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n")
 
-  fun ref _on_received(data: Array[U8] iso) =>
+  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _response.append(consume data)
     let r: String val = _response.clone()
     // Check for terminal chunk
@@ -1370,7 +1376,7 @@ actor \nodoc\ _TestStreamClient is
         _h.fail(
           "Missing Transfer-Encoding: chunked header in:\n" + r)
         _h.complete(false)
-        return
+        return lori.KeepReading
       end
       // Verify chunk data is present
       if not (r.contains("chunk1") and r.contains("chunk2")
@@ -1378,10 +1384,11 @@ actor \nodoc\ _TestStreamClient is
       then
         _h.fail("Missing chunk data in:\n" + r)
         _h.complete(false)
-        return
+        return lori.KeepReading
       end
       _h.complete(true)
     end
+    lori.KeepReading
 
   fun ref _on_connection_failure(reason: lori.ConnectionFailureReason) =>
     _h.fail("Client connection failed")
@@ -1460,7 +1467,7 @@ actor \nodoc\ _TestMaxPendingClient is
   fun ref _on_connected() =>
     _tcp_connection.send(_request)
 
-  fun ref _on_received(data: Array[U8] iso) =>
+  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _response.append(consume data)
     let r: String val = _response.clone()
     if (not _got_ok) and r.contains("first-ok") then
@@ -1469,6 +1476,7 @@ actor \nodoc\ _TestMaxPendingClient is
     if (not _got_500) and r.contains("500 Internal Server Error") then
       _got_500 = true
     end
+    lori.KeepReading
 
   fun ref _on_closed() =>
     if _got_ok and _got_500 then
@@ -1639,7 +1647,7 @@ actor \nodoc\ _TestChunkSentClient is
     _tcp_connection.send(
       "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n")
 
-  fun ref _on_received(data: Array[U8] iso) =>
+  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _response.append(consume data)
     let r: String val = _response.clone()
     // Check for terminal chunk
@@ -1650,7 +1658,7 @@ actor \nodoc\ _TestChunkSentClient is
         _h.fail(
           "Missing Transfer-Encoding: chunked header in:\n" + r)
         _h.complete(false)
-        return
+        return lori.KeepReading
       end
       // Verify all 3 chunks arrived
       if not (r.contains("cs-chunk-1") and r.contains("cs-chunk-2")
@@ -1658,10 +1666,11 @@ actor \nodoc\ _TestChunkSentClient is
       then
         _h.fail("Missing chunk data in:\n" + r)
         _h.complete(false)
-        return
+        return lori.KeepReading
       end
       _h.complete(true)
     end
+    lori.KeepReading
 
   fun ref _on_connection_failure(reason: lori.ConnectionFailureReason) =>
     _h.fail("Client connection failed")
@@ -2056,7 +2065,7 @@ actor \nodoc\ _TestPipelinedBodiesClient is
   fun ref _on_connected() =>
     _tcp_connection.send(_request)
 
-  fun ref _on_received(data: Array[U8] iso) =>
+  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _response.append(consume data)
     let r: String val = _response.clone()
     if (not _got_first) and r.contains("first") then
@@ -2065,6 +2074,7 @@ actor \nodoc\ _TestPipelinedBodiesClient is
     if (not _got_second) and r.contains("second") then
       _got_second = true
     end
+    lori.KeepReading
 
   fun ref _on_closed() =>
     if _got_first and _got_second then
@@ -2323,11 +2333,12 @@ actor \nodoc\ _TestSSLHTTPClient is
   fun ref _on_connected() =>
     _tcp_connection.send(_request)
 
-  fun ref _on_received(data: Array[U8] iso) =>
+  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _response.append(consume data)
     if _response.contains("\r\n\r\n") then
       _verify_response()
     end
+    lori.KeepReading
 
   fun ref _on_connection_failure(reason: lori.ConnectionFailureReason) =>
     _h.fail("SSL client connection failed")
@@ -2389,7 +2400,7 @@ actor \nodoc\ _TestSSLHTTPClientExpectClose is
   fun ref _on_connected() =>
     _tcp_connection.send(_request)
 
-  fun ref _on_received(data: Array[U8] iso) =>
+  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _response.append(consume data)
     if _response.contains("\r\n\r\n") then
       let response: String val = _response.clone()
@@ -2401,6 +2412,7 @@ actor \nodoc\ _TestSSLHTTPClientExpectClose is
         _h.complete(false)
       end
     end
+    lori.KeepReading
 
   fun ref _on_closed() =>
     if _response_ok then
@@ -2449,7 +2461,7 @@ actor \nodoc\ _TestSSLKeepAliveClient is
     _tcp_connection.send(
       "GET /1 HTTP/1.1\r\nHost: localhost\r\n\r\n")
 
-  fun ref _on_received(data: Array[U8] iso) =>
+  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _response.append(consume data)
     let r: String val = _response.clone()
 
@@ -2466,6 +2478,7 @@ actor \nodoc\ _TestSSLKeepAliveClient is
         _h.complete(true)
       end
     end
+    lori.KeepReading
 
   fun ref _on_closed() =>
     if _requests_sent < 2 then
@@ -2505,7 +2518,7 @@ actor \nodoc\ _TestSSLStreamClient is
     _tcp_connection.send(
       "GET / HTTP/1.1\r\nHost: localhost\r\n\r\n")
 
-  fun ref _on_received(data: Array[U8] iso) =>
+  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _response.append(consume data)
     let r: String val = _response.clone()
     if r.contains("0\r\n\r\n") then
@@ -2515,17 +2528,18 @@ actor \nodoc\ _TestSSLStreamClient is
         _h.fail(
           "Missing Transfer-Encoding: chunked header in:\n" + r)
         _h.complete(false)
-        return
+        return lori.KeepReading
       end
       if not (r.contains("chunk1") and r.contains("chunk2")
         and r.contains("chunk3"))
       then
         _h.fail("Missing chunk data in:\n" + r)
         _h.complete(false)
-        return
+        return lori.KeepReading
       end
       _h.complete(true)
     end
+    lori.KeepReading
 
   fun ref _on_connection_failure(reason: lori.ConnectionFailureReason) =>
     _h.fail("SSL stream client connection failed")

--- a/stallion/http_server.pony
+++ b/stallion/http_server.pony
@@ -76,7 +76,8 @@ class HTTPServer is
     _queue = _ResponseQueue(this)
     _parser = _RequestParser(this, config._parser_config())
     _tcp_connection =
-      lori.TCPConnection.server(auth, fd, server_actor, this)
+      lori.TCPConnection.server(auth, fd, server_actor, this
+        where read_buffer_size = config.read_buffer_size)
 
   new ssl(
     auth: lori.TCPServerAuth,
@@ -98,7 +99,8 @@ class HTTPServer is
     _queue = _ResponseQueue(this)
     _parser = _RequestParser(this, config._parser_config())
     _tcp_connection =
-      lori.TCPConnection.ssl_server(auth, ssl_ctx, fd, server_actor, this)
+      lori.TCPConnection.ssl_server(auth, ssl_ctx, fd, server_actor, this
+        where read_buffer_size = config.read_buffer_size)
 
   fun ref _connection(): lori.TCPConnection =>
     """Return the underlying TCP connection."""
@@ -114,8 +116,9 @@ class HTTPServer is
       _tcp_connection.idle_timeout(c.idle_timeout)
     end
 
-  fun ref _on_received(data: Array[U8] iso) =>
+  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
     _state.on_received(this, consume data)
+    lori.KeepReading
 
   fun ref _on_closed() =>
     _state.on_closed(this)
@@ -489,24 +492,6 @@ class HTTPServer is
     idempotent due to the `_Active` state guard.
     """
     _close_connection()
-
-  fun ref yield_read() =>
-    """
-    Request the read loop to exit after the current callback returns,
-    giving other actors a chance to run. Reading resumes automatically
-    in the next scheduler turn — no explicit action is needed.
-
-    Call this from HTTP callbacks (`on_request`, `on_body_chunk`,
-    `on_request_complete`) to implement yield policies such as yielding
-    every N requests during pipelining storms or every N bytes of body
-    data.
-
-    Operates at the TCP level: it prevents the *next* socket read, not
-    the processing of already-buffered data. If a single receive delivers
-    a buffer containing multiple pipelined requests, all are parsed and
-    all callbacks fire before the yield takes effect.
-    """
-    _tcp_connection.yield_read()
 
   fun ref set_timer(duration: lori.TimerDuration)
     : (lori.TimerToken | lori.SetTimerError)

--- a/stallion/server_config.pony
+++ b/stallion/server_config.pony
@@ -54,6 +54,7 @@ class val ServerConfig
   let max_pending_responses: USize
   let idle_timeout: (lori.IdleTimeout | None)
   let max_requests_per_connection: (MaxRequestsPerConnection | None)
+  let read_buffer_size: lori.ReadBufferSize
 
   new val create(
     host': String,
@@ -64,7 +65,8 @@ class val ServerConfig
     max_body_size': USize = 1_048_576,
     max_pending_responses': USize = 100,
     idle_timeout': (lori.IdleTimeout | None) = DefaultIdleTimeout(),
-    max_requests_per_connection': (MaxRequestsPerConnection | None) = None)
+    max_requests_per_connection': (MaxRequestsPerConnection | None) = None,
+    read_buffer_size': lori.ReadBufferSize = lori.DefaultReadBufferSize())
   =>
     """
     Create server configuration.
@@ -80,6 +82,11 @@ class val ServerConfig
     keep-alive connection can serve before the server closes it. `None`
     (the default) means unlimited. Use `MakeMaxRequestsPerConnection` to
     create validated limit values (must be at least 1).
+    `read_buffer_size'` is how many bytes a connection reads before it
+    hands the scheduler back and resumes on a later turn. Smaller values
+    bound how much one connection does per turn, at the cost of more
+    turns. Defaults to 16KB. Use `lori.MakeReadBufferSize(bytes)` to
+    create custom values.
     """
     host = host'
     port = port'
@@ -90,6 +97,7 @@ class val ServerConfig
     max_pending_responses = max_pending_responses'
     idle_timeout = idle_timeout'
     max_requests_per_connection = max_requests_per_connection'
+    read_buffer_size = read_buffer_size'
 
   fun _parser_config(): _ParserConfig val =>
     """Create a parser config from the parser limit fields."""


### PR DESCRIPTION
lori 0.17.0 has `_on_received` return a `ReadAction` saying whether the read loop should keep reading, and requires ponylang/ssl 3.0.0 and ponyc 0.67.0.

This removes `HTTPServer.yield_read()` rather than adapting it. A yield only ever took effect at a delivery boundary, so every request carried by the read it was called from was parsed and answered regardless — and one read carries as many pipelined requests as fit in the buffer. It could not bound the work it existed to bound. It was also callable anywhere on the server object, and only a call from inside a request callback had a defined meaning; from a behavior, from `on_closed()`, or after close it either yielded a later read the caller did not mean or did nothing.

What actually bounds per-turn work is how many bytes a connection reads before handing the scheduler back. lori already takes that as a constructor parameter and stallion was letting it default to 16KB with no way to change it, so `ServerConfig` gains `read_buffer_size` and forwards it.

`examples/yield/` becomes `examples/read-buffer-size/`, setting a 1KB buffer.

This also deletes `.release-notes/update-ssl-to-2.0.1.md`. Its CHANGELOG line shipped under 0.5.2 and the file was never rotated out, so it would have gone into the next release's notes saying stallion had moved to ponylang/ssl 2.0.1.

Courier still has its own `yield_read()`. The same removal argument applies to it, but the `read_buffer_size` half does not — courier does not pipeline, so one read produces one delivery and per-turn work is already bounded. That is a separate change.
