### PR TITLE
Run breakage test against ponyc main

### DIFF
--- a/.github/workflows/breakage-against-ponyc-latest.yml
+++ b/.github/workflows/breakage-against-ponyc-latest.yml
@@ -13,7 +13,7 @@ jobs:
     name: Test against ponyc main
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/ponylang/shared-docker-ci-standard-builder-with-libressl-4.2.1:release
+      image: ghcr.io/ponylang/shared-docker-ci-standard-builder-with-libressl-4.2.1:nightly
     steps:
       - uses: actions/checkout@v6.0.2
       - name: Test


### PR DESCRIPTION
The breakage test ran in the builder image's `release` tag, which is built from
the most recent ponyc release. That gave the job the same coverage pr.yml's
vs-ponyc-release job already has, so we wouldn't find out about a breaking ponyc
change until it shipped. The same image publishes a `nightly` tag built from
ponyc main; this switches to it.

Closes #141
