### PR TITLE
Fix on_chunk_sent not firing when the connection closes

### DIFF
--- a/.release-notes/next-release.md
+++ b/.release-notes/next-release.md
@@ -18,11 +18,21 @@ Reading now stops on an HTTPS connection as soon as backpressure is applied, the
 
 ## Fix on_chunk_sent firing once per write-queue drain instead of once per chunk
 
-`Responder.send_chunk()` returns a `ChunkSendToken`, and `on_chunk_sent()` fires with that token once the chunk has been handed to the operating system. That pairing is what flow-controlled streaming is built on: send a chunk, wait for its callback, send the next. It did not hold. One callback was delivered each time the write queue drained completely rather than one per chunk, so an actor that sent several chunks while the socket was backed up got fewer callbacks than it had chunks outstanding.
+`Responder.send_chunk()` returns a `ChunkSendToken`, and `on_chunk_sent()` fires with that token only after the chunk's bytes have reached the operating system. That pairing is what flow-controlled streaming is built on: send a chunk, wait for its callback, send the next. It did not hold. One callback was delivered each time the write queue drained completely rather than one per chunk, so an actor that sent several chunks while the socket was backed up got fewer callbacks than it had chunks outstanding.
 
 An actor that drives the next chunk from `on_chunk_sent()`, which is what `examples/streaming` does, stops sending when a callback it is waiting on never arrives, and the response is never finished. Keeping more than one chunk in flight made this more likely, because that is exactly when several chunks drain together.
 
-Every chunk that `send_chunk()` accepts now produces exactly one `on_chunk_sent()` callback, carrying that chunk's own token, in the order the chunks were sent.
+Your actor no longer gets one callback per write-queue drain. Each callback carries the token of a single chunk, and the callbacks arrive in the order the chunks were sent.
+
+## Fix on_chunk_sent not firing when the connection closes
+
+A chunk whose bytes had reached the operating system got no `on_chunk_sent()` callback at all if the connection then closed. The callback was discarded the moment the close began.
+
+A request carrying `Connection: close` was the common way to hit this: the server streamed a chunk, finished the response, and the connection closed in the same actor turn, so none of that response's callbacks arrived. An actor that waited for a callback before sending the next chunk, as `examples/streaming` does, stopped there, and the response was never finished.
+
+The callback for a chunk whose bytes have already reached the operating system is no longer discarded when a close begins. It can now arrive while the connection is closing.
+
+No callback fires until the chunk's bytes reach the operating system, and even then it can be lost: when the connection's close is reported first, any callback queued behind that report never reaches your actor. One way that happens is a callback and the close landing in the same actor turn, where the close is delivered synchronously and the callback is queued behind it (`ponylang/lori#345`). An actor that sends the next chunk only after the previous one's callback can still stall that way, leaving the response unfinished.
 
 ## Fix a possible write hang under load
 
@@ -87,3 +97,44 @@ ctx.set_min_proto_version(TLS1u2Version())?
 ```
 
 `SSLContext.alpn_set_resolver` also changed: it takes an `ALPNProtocolResolver val` where it took a `box`. Constructing a `Digest`, `Digest.final`, and `HmacSha256` are all partial and need a `?`. `SSLState` gained an `SSLDisposed` member, which breaks an exhaustive match on `SSL.state()`. And a reference typed `HashFn tag` no longer compiles, so type it `val` or `box`. See the ponylang/ssl 3.0.0 release notes for more on each.
+
+## Change when on_closed() fires
+
+`on_closed()` used to fire in the actor turn the close was started in. For a server closing on `keep_alive=false`, that was the same turn as the response. It now fires once the connection is closed. That change applies to closes the server starts; when the peer disconnects first, `on_closed()` fires when that close is reported, as it did before.
+
+A connection in the middle of a graceful close is not closed. A graceful close does not finish until everything has been sent and the peer has closed its half; a hard close closes immediately.
+
+For a close the server starts on a connection that is not under backpressure, the connection is closed once the peer closes its half. There is no timeout on that wait. For a close the server starts on a connection that is under backpressure — between `on_throttled()` and `on_unthrottled()` — the close is a hard close and `on_closed()` fires in that same turn.
+
+To close without waiting on the peer, call `dispose()` on the server actor. `HTTPServerActor` is a `lori.TCPConnectionActor`, so it has `dispose()`: the connection is hard-closed and `on_closed()` is delivered in the dispose turn.
+
+An application that releases resources in `on_closed()` now releases them when the peer closes the connection, not when the close started. A user timer that comes due after the server has started closing still fires, so an actor with a deadline still gets it and can call `dispose()` to close without waiting on the peer. An application that called `HTTPServer.close()` from inside `on_closed()` used to recurse without bound; that recursion is gone.
+
+## Report a closed connection from Responder
+
+`Responder.start_chunked_response()` and `Responder.send_chunk()` used to report success on a connection that was closed or closing, for a response or a chunk that was then dropped: `start_chunked_response()` returned `StreamingStarted`, and `send_chunk()` returned a `ChunkSendToken` for a chunk that never went out.
+
+`start_chunked_response()` now returns a new `ConnectionClosed` when the connection is closed or closing, and `send_chunk()` returns `None`, which is what it already returns when the call was a no-op.
+
+`ConnectionClosed` is a new member of the `StartChunkedResponseResult` union, alongside `StreamingStarted`, `ChunkedNotSupported` and `AlreadyResponded`. That is source-breaking: an exhaustive match on the union does not compile until you add the case. A match with an `else` is unaffected.
+
+```pony
+// Before
+match \exhaustive\ responder.start_chunked_response(stallion.StatusOK, headers)
+| stallion.StreamingStarted => responder.send_chunk("chunk 1\n")
+| stallion.ChunkedNotSupported => responder.respond(fallback)
+| stallion.AlreadyResponded => None
+end
+
+// After
+match \exhaustive\ responder.start_chunked_response(stallion.StatusOK, headers)
+| stallion.StreamingStarted => responder.send_chunk("chunk 1\n")
+| stallion.ChunkedNotSupported => responder.respond(fallback)
+| stallion.AlreadyResponded => None
+| stallion.ConnectionClosed => None
+end
+```
+
+On a connection that is closed or closing, an HTTP/1.0 request gets `ConnectionClosed` rather than `ChunkedNotSupported`, because falling back to `respond()` does not work there either. A `Responder` that has already responded still gets `AlreadyResponded`. `ConnectionClosed` starts nothing, so a second `start_chunked_response()` returns it again, and a `send_chunk()` after it returns `None`.
+
+An actor called back at `on_chunk_sent()` while the connection is closing gets `None` from `send_chunk()` before it has been told anything is closing.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file. This projec
 - Fix backpressure not stopping incoming requests on an HTTPS connection ([PR #140](https://github.com/ponylang/stallion/pull/140))
 - Fix on_chunk_sent firing once per write-queue drain instead of once per chunk ([PR #140](https://github.com/ponylang/stallion/pull/140))
 - Fix a possible write hang under load ([PR #140](https://github.com/ponylang/stallion/pull/140))
+- Fix on_chunk_sent not firing when the connection closes ([PR #146](https://github.com/ponylang/stallion/pull/146))
 
 
 ### Added
@@ -24,6 +25,8 @@ All notable changes to this project will be documented in this file. This projec
 - Remove HTTPServer.yield_read() ([PR #140](https://github.com/ponylang/stallion/pull/140))
 - Require ponyc 0.67.0 or later ([PR #140](https://github.com/ponylang/stallion/pull/140))
 - Move to ponylang/ssl 3.0.0 ([PR #140](https://github.com/ponylang/stallion/pull/140))
+- Change when on_closed() fires ([PR #146](https://github.com/ponylang/stallion/pull/146))
+- Report a closed connection from Responder ([PR #146](https://github.com/ponylang/stallion/pull/146))
 
 
 ## [0.8.0] - 2026-06-30

--- a/examples/streaming/main.pony
+++ b/examples/streaming/main.pony
@@ -5,8 +5,13 @@ flow-controlled delivery driven by `on_chunk_sent()` callbacks.
 Demonstrates the streaming response API: `start_chunked_response()`,
 `send_chunk()`, `finish_response()`, and `on_chunk_sent()`. The actor sends
 the first chunk in `on_request()`, then each `on_chunk_sent()` callback
-drives the next chunk. This ensures the OS has accepted each chunk before
-sending the next — natural backpressure without timers or manual windowing.
+drives the next chunk, so the OS has accepted each chunk before the next one
+goes out — backpressure without timers or manual windowing.
+
+A callback can go missing; see
+`stallion.HTTPServerLifecycleEventReceiver.on_chunk_sent()` for when. This
+actor stops sending when one does, and because it calls `finish_response()`
+from the fifth callback, the response body is left unterminated.
 
 Note: this demonstrates streaming *responses*, not streaming request
 bodies. Request body data arrives via `on_body_chunk()` callbacks — this
@@ -93,6 +98,7 @@ actor StreamServer is stallion.HTTPServerActor
         .build()
       responder.respond(response)
     | stallion.AlreadyResponded => None
+    | stallion.ConnectionClosed => None
     end
 
   fun ref on_chunk_sent(token: stallion.ChunkSendToken) =>

--- a/stallion/_connection_state.pony
+++ b/stallion/_connection_state.pony
@@ -4,10 +4,11 @@ trait ref _ConnectionState
   """
   Connection lifecycle state.
 
-  Dispatches lori events to the appropriate server methods based on
-  what operations are valid in each state. Two states: `_Active`
-  (processing requests, including idle keep-alive periods) and `_Closed`
-  (all operations are no-ops).
+  Routes lori's events to the server methods that are valid in the current
+  state: `_Active` (processing requests, including idle keep-alive periods),
+  `_Closing` (stallion has stopped taking new work, and lori can still report
+  send outcomes for data already handed to it), and `_Closed` (every
+  operation is a no-op).
   """
 
   fun ref on_received(server: HTTPServer ref, data: Array[U8] iso)
@@ -25,6 +26,9 @@ trait ref _ConnectionState
   fun ref on_sent(server: HTTPServer ref, token: lori.SendToken)
     """Handle send completion notification from lori."""
 
+  fun ref on_send_failed(server: HTTPServer ref, token: lori.SendToken)
+    """Handle send failure notification from lori."""
+
   fun ref on_idle_timeout(server: HTTPServer ref)
     """Handle connection going idle."""
 
@@ -36,6 +40,9 @@ trait ref _ConnectionState
 
   fun ref on_timer_failure(server: HTTPServer ref)
     """Handle user timer ASIO subscription failure."""
+
+  fun ref close(server: HTTPServer ref)
+    """Handle a request to close the connection."""
 
 class ref _Active is _ConnectionState
   """
@@ -57,6 +64,9 @@ class ref _Active is _ConnectionState
   fun ref on_sent(server: HTTPServer ref, token: lori.SendToken) =>
     server._handle_sent(token)
 
+  fun ref on_send_failed(server: HTTPServer ref, token: lori.SendToken) =>
+    server._handle_send_failed(token)
+
   fun ref on_idle_timeout(server: HTTPServer ref) =>
     server._handle_idle_timeout()
 
@@ -68,6 +78,59 @@ class ref _Active is _ConnectionState
 
   fun ref on_timer_failure(server: HTTPServer ref) =>
     server._handle_timer_failure()
+
+  fun ref close(server: HTTPServer ref) =>
+    server._start_close()
+
+class ref _Closing is _ConnectionState
+  """
+  Connection is closing — stallion has stopped taking new work, and lori can
+  still report send outcomes for data already handed to it.
+
+  Entered when stallion starts a close. Left when lori reports the connection
+  closed. Also left when lori reports a start failure:
+  `HTTPServer._on_start_failure` sets `_Closed` directly rather than routing
+  through this state machine.
+
+  Send outcomes, lori's report that the connection closed, and the actor's own
+  timer are all handled here. The timer matters: this state can last as long as
+  the peer takes to close its half, and an actor that set a deadline with
+  `HTTPServer.set_timer()` has no other way to hear from the connection until
+  `on_closed()`. Everything else is a no-op.
+  """
+
+  fun ref on_received(server: HTTPServer ref, data: Array[U8] iso) =>
+    None
+
+  fun ref on_closed(server: HTTPServer ref) =>
+    server._handle_closed()
+
+  fun ref on_throttled(server: HTTPServer ref) =>
+    None
+
+  fun ref on_unthrottled(server: HTTPServer ref) =>
+    None
+
+  fun ref on_sent(server: HTTPServer ref, token: lori.SendToken) =>
+    server._handle_sent(token)
+
+  fun ref on_send_failed(server: HTTPServer ref, token: lori.SendToken) =>
+    server._handle_send_failed(token)
+
+  fun ref on_idle_timeout(server: HTTPServer ref) =>
+    None
+
+  fun ref on_timer(server: HTTPServer ref, token: lori.TimerToken) =>
+    server._handle_timer(token)
+
+  fun ref on_idle_timer_failure(server: HTTPServer ref) =>
+    None
+
+  fun ref on_timer_failure(server: HTTPServer ref) =>
+    server._handle_timer_failure()
+
+  fun ref close(server: HTTPServer ref) =>
+    None
 
 class ref _Closed is _ConnectionState
   """
@@ -89,6 +152,9 @@ class ref _Closed is _ConnectionState
   fun ref on_sent(server: HTTPServer ref, token: lori.SendToken) =>
     None
 
+  fun ref on_send_failed(server: HTTPServer ref, token: lori.SendToken) =>
+    None
+
   fun ref on_idle_timeout(server: HTTPServer ref) =>
     None
 
@@ -99,4 +165,7 @@ class ref _Closed is _ConnectionState
     None
 
   fun ref on_timer_failure(server: HTTPServer ref) =>
+    None
+
+  fun ref close(server: HTTPServer ref) =>
     None

--- a/stallion/_response_queue.pony
+++ b/stallion/_response_queue.pony
@@ -89,8 +89,9 @@ class ref _ResponseQueue
 
     Called by `Responder.send_chunk()` to mint a token before submitting
     data to the queue. The token travels alongside the data through
-    buffering and flushing, ultimately reaching the actor via
-    `on_chunk_sent()` when the OS accepts the bytes.
+    buffering and flushing. No callback fires until the chunk's bytes reach
+    the OS, and even then it can be lost — see
+    `HTTPServerLifecycleEventReceiver.on_chunk_sent()`.
     """
     let id = _next_chunk_token_id
     _next_chunk_token_id = _next_chunk_token_id + 1
@@ -180,6 +181,10 @@ class ref _ResponseQueue
     """
     _closed = true
     _entries.clear()
+
+  fun is_closed(): Bool =>
+    """Whether the queue is closed. A closed queue discards all work."""
+    _closed
 
   fun pending(): USize =>
     """Number of requests registered but not yet finished."""

--- a/stallion/_test.pony
+++ b/stallion/_test.pony
@@ -70,6 +70,13 @@ actor \nodoc\ Main is TestList
     test(_TestStartChunkedHTTP10)
     test(_TestStartChunkedAlreadyResponded)
     test(_TestStartChunkedAlreadyStreaming)
+    test(_TestSendChunkAfterClose)
+    test(_TestStartChunkedConnectionClosed)
+    test(_TestStartChunkedClosedAfterResponded)
+    test(_TestStartChunkedClosedBeatsHTTP10)
+    test(_TestStartChunkedClosedLeavesState)
+    test(_TestStartChunkedClosedMidCall)
+    test(_TestSendChunkClosedMidCall)
 
     // Parser property-based tests
     test(Property1UnitTest[(String val, String val)](
@@ -201,6 +208,7 @@ actor \nodoc\ Main is TestList
     test(_TestQueueTokenNoneForInternalSends)
     test(_TestQueueTokenThrottle)
     test(_TestQueueTokenClose)
+    test(_TestQueueIsClosed)
 
     // Pipelining and streaming integration tests
     test(_TestPipelineCorrectness)
@@ -209,6 +217,11 @@ actor \nodoc\ Main is TestList
     test(_TestMaxPendingOverflow)
     test(_TestHTTP10ChunkedRejection)
     test(_TestChunkSentCallback)
+    test(_TestChunkSentBeforeClose)
+    test(_TestChunkSentMultipleBeforeClose)
+    test(_TestOnClosedAfterResponse)
+    test(_TestChunkSentPipelinedNonHead)
+    test(_TestTimerFiresWhileClosing)
 
 
     // URI parsing integration tests

--- a/stallion/_test_response_builder.pony
+++ b/stallion/_test_response_builder.pony
@@ -288,3 +288,155 @@ class \nodoc\ iso _TestStartChunkedAlreadyStreaming is UnitTest
     let second = responder.start_chunked_response(StatusOK)
     h.assert_is[StartChunkedResponseResult](AlreadyResponded, second,
       "second call should return AlreadyResponded")
+
+class \nodoc\ iso _TestSendChunkAfterClose is UnitTest
+  """
+  Verify that send_chunk() returns None once the queue has closed, and
+  flushes nothing beyond the headers start_chunked_response() already sent.
+  """
+  fun name(): String => "responder/send_chunk_after_close"
+
+  fun apply(h: TestHelper) =>
+    let notify = _TestQueueNotify
+    let queue = _ResponseQueue(notify)
+    let id = queue.register(true)
+
+    let responder = Responder._create(queue, id, HTTP11)
+    responder.start_chunked_response(StatusOK)
+    h.assert_eq[USize](1, notify.flushed_data.size(),
+      "start_chunked_response should have flushed the headers")
+
+    queue.close()
+
+    match responder.send_chunk("lost")
+    | let _: ChunkSendToken =>
+      h.fail("send_chunk on a closed queue should return None")
+    end
+
+    h.assert_eq[USize](1, notify.flushed_data.size(),
+      "send_chunk on a closed queue should flush nothing")
+
+class \nodoc\ iso _TestStartChunkedConnectionClosed is UnitTest
+  """
+  Verify that start_chunked_response() returns ConnectionClosed on a closed
+  queue and flushes nothing.
+  """
+  fun name(): String => "responder/start_chunked_connection_closed"
+
+  fun apply(h: TestHelper) =>
+    let notify = _TestQueueNotify
+    let queue = _ResponseQueue(notify)
+    let id = queue.register(true)
+    queue.close()
+
+    let responder = Responder._create(queue, id, HTTP11)
+    let result = responder.start_chunked_response(StatusOK)
+
+    h.assert_is[StartChunkedResponseResult](ConnectionClosed, result,
+      "a closed queue should return ConnectionClosed")
+    h.assert_eq[USize](0, notify.flushed_data.size(),
+      "no data should be flushed on a closed queue")
+
+class \nodoc\ iso _TestStartChunkedClosedAfterResponded is UnitTest
+  """
+  Verify that a Responder that already responded returns AlreadyResponded
+  even on a closed queue: Responder state is tested before the connection.
+  """
+  fun name(): String => "responder/start_chunked_closed_after_responded"
+
+  fun apply(h: TestHelper) =>
+    let queue = _ResponseQueue(_TestQueueNotify)
+    let id = queue.register(true)
+
+    let responder = Responder._create(queue, id, HTTP11)
+    responder.respond("HTTP/1.1 200 OK\r\n\r\nfirst")
+    queue.close()
+
+    h.assert_is[StartChunkedResponseResult](AlreadyResponded,
+      responder.start_chunked_response(StatusOK),
+      "a Responder that already responded should return AlreadyResponded")
+
+class \nodoc\ iso _TestStartChunkedClosedBeatsHTTP10 is UnitTest
+  """
+  Verify that an HTTP/1.0 Responder on a closed queue returns
+  ConnectionClosed, not ChunkedNotSupported: the closed check comes first,
+  because falling back to respond() does not work on a closed queue either.
+  """
+  fun name(): String => "responder/start_chunked_closed_beats_http10"
+
+  fun apply(h: TestHelper) =>
+    let queue = _ResponseQueue(_TestQueueNotify)
+    let id = queue.register(true)
+    queue.close()
+
+    let responder = Responder._create(queue, id, HTTP10)
+
+    h.assert_is[StartChunkedResponseResult](ConnectionClosed,
+      responder.start_chunked_response(StatusOK),
+      "the closed check should beat the HTTP/1.0 check")
+
+class \nodoc\ iso _TestStartChunkedClosedLeavesState is UnitTest
+  """
+  Verify that returning ConnectionClosed starts nothing: a second
+  start_chunked_response() returns ConnectionClosed again rather than
+  AlreadyResponded, which it would if the first call had moved the state.
+  """
+  fun name(): String => "responder/start_chunked_closed_leaves_state"
+
+  fun apply(h: TestHelper) =>
+    let queue = _ResponseQueue(_TestQueueNotify)
+    let id = queue.register(true)
+    queue.close()
+
+    let responder = Responder._create(queue, id, HTTP11)
+    responder.start_chunked_response(StatusOK)
+
+    h.assert_is[StartChunkedResponseResult](ConnectionClosed,
+      responder.start_chunked_response(StatusOK),
+      "ConnectionClosed should leave the Responder unstarted")
+
+class \nodoc\ iso _TestStartChunkedClosedMidCall is UnitTest
+  """
+  Verify that start_chunked_response() reports ConnectionClosed when the
+  connection closes during its own send, and leaves the Responder unstarted.
+  """
+  fun name(): String => "responder/start_chunked_closed_mid_call"
+
+  fun apply(h: TestHelper) =>
+    let notify = _TestQueueNotify
+    let queue = _ResponseQueue(notify)
+    notify.queue = queue
+    let id = queue.register(true)
+    notify.close_on_next_flush = true
+
+    let responder = Responder._create(queue, id, HTTP11)
+
+    h.assert_is[StartChunkedResponseResult](ConnectionClosed,
+      responder.start_chunked_response(StatusOK),
+      "a close during send_data should report ConnectionClosed")
+
+    h.assert_is[StartChunkedResponseResult](ConnectionClosed,
+      responder.start_chunked_response(StatusOK),
+      "nothing was started, so a second call reports ConnectionClosed again")
+
+class \nodoc\ iso _TestSendChunkClosedMidCall is UnitTest
+  """
+  Verify that send_chunk() returns None when the connection closes during
+  its own send.
+  """
+  fun name(): String => "responder/send_chunk_closed_mid_call"
+
+  fun apply(h: TestHelper) =>
+    let notify = _TestQueueNotify
+    let queue = _ResponseQueue(notify)
+    notify.queue = queue
+    let id = queue.register(true)
+
+    let responder = Responder._create(queue, id, HTTP11)
+    responder.start_chunked_response(StatusOK)
+    notify.close_on_next_flush = true
+
+    match responder.send_chunk("lost")
+    | let _: ChunkSendToken =>
+      h.fail("a close during send_data should hand back no token")
+    end

--- a/stallion/_test_response_queue.pony
+++ b/stallion/_test_response_queue.pony
@@ -13,6 +13,11 @@ class \nodoc\ ref _TestQueueNotify is _ResponseQueueNotify
   var close_on_flush_data: Bool = false
   var flush_data_close_trigger: String val = ""
 
+  // Close the queue from inside the next `_flush_data`, whatever the data is.
+  // Simulates a send error, which closes the connection before `send_data`
+  // returns to its caller. Cleared as it fires, so it closes once.
+  var close_on_next_flush: Bool = false
+
   // One-shot re-throttle hook: when the cumulative flush count reaches
   // `throttle_after`, call throttle() once and clear the hook. Simulates lori
   // re-applying backpressure synchronously inside send() (a partial write
@@ -45,6 +50,12 @@ class \nodoc\ ref _TestQueueNotify is _ResponseQueueNotify
         match queue
         | let q: _ResponseQueue => q.throttle()
         end
+      end
+    end
+    if close_on_next_flush then
+      close_on_next_flush = false
+      match queue
+      | let q: _ResponseQueue => q.close()
       end
     end
     if close_on_flush_data then
@@ -1024,3 +1035,22 @@ primitive \nodoc\ _PermutationGenerator
           end
           consume result
         })
+
+// ---------------------------------------------------------------------------
+// Closed-queue accessor
+// ---------------------------------------------------------------------------
+
+class \nodoc\ iso _TestQueueIsClosed is UnitTest
+  """
+  Verify is_closed() reports false on a fresh queue and true after close().
+  """
+  fun name(): String => "response-queue/is_closed"
+
+  fun apply(h: TestHelper) =>
+    let queue = _ResponseQueue(_TestQueueNotify)
+
+    h.assert_false(queue.is_closed(), "a fresh queue is not closed")
+
+    queue.close()
+
+    h.assert_true(queue.is_closed(), "a queue is closed after close()")

--- a/stallion/_test_server.pony
+++ b/stallion/_test_server.pony
@@ -1544,6 +1544,7 @@ actor \nodoc\ _TestChunkedFallbackServer is HTTPServerActor
         .build()
       responder.respond(response)
     | AlreadyResponded => None
+    | ConnectionClosed => None
     end
 
 class \nodoc\ iso _TestChunkSentCallback is UnitTest
@@ -2636,3 +2637,507 @@ actor \nodoc\ _TestPlainTCPClient is
 
   fun ref _on_connected() =>
     _tcp_connection.send("NOT AN SSL HANDSHAKE\r\n")
+
+// ---------------------------------------------------------------------------
+// Chunk delivery and on_closed timing across a close
+//
+// These tests assert on the server side, so they need a TestHelper inside the
+// server actor. _TestConnectionFactory.apply has no TestHelper parameter, so a
+// factory that needs one holds it in a field and hands it to the actor it
+// builds — the same shape as _TestStartFailureServerFactory.
+// ---------------------------------------------------------------------------
+
+class \nodoc\ iso _TestChunkSentBeforeClose is UnitTest
+  """
+  One chunk on a connection that closes: start_chunked_response(),
+  send_chunk(), finish_response() on a request carrying `Connection: close`.
+  The server counts the tokens send_chunk() returned against the
+  on_chunk_sent() callbacks it received and compares them from on_closed().
+  """
+  fun name(): String => "server/chunk sent before close"
+
+  fun apply(h: TestHelper) =>
+    h.long_test(5_000_000_000)
+    let port = "45880"
+    let host = ifdef linux then "127.0.0.2" else "localhost" end
+    let config = ServerConfig(host, port)
+    let listener = _TestTrackingListener(h, port,
+      _TestChunkCountServerFactory(h, 1), config,
+      {(h': TestHelper, port': String) =>
+        let client = _TestPassiveClient(h', port',
+          "GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n")
+        h'.dispose_when_done(client)
+      })
+    h.dispose_when_done(listener)
+
+class \nodoc\ iso _TestChunkSentMultipleBeforeClose is UnitTest
+  """
+  Three chunks in flight in one turn on a connection that closes. Same
+  assertion as `server/chunk sent before close`.
+  """
+  fun name(): String => "server/multiple chunks sent before close"
+
+  fun apply(h: TestHelper) =>
+    h.long_test(5_000_000_000)
+    let port = "45890"
+    let host = ifdef linux then "127.0.0.2" else "localhost" end
+    let config = ServerConfig(host, port)
+    let listener = _TestTrackingListener(h, port,
+      _TestChunkCountServerFactory(h, 3), config,
+      {(h': TestHelper, port': String) =>
+        let client = _TestPassiveClient(h', port',
+          "GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n")
+        h'.dispose_when_done(client)
+      })
+    h.dispose_when_done(listener)
+
+class \nodoc\ iso _TestOnClosedAfterResponse is UnitTest
+  """
+  A complete response on a request carrying `Connection: close`. The server
+  sets a flag on the line after respond() returns and asserts it from
+  on_closed(), so the test fails if on_closed() fires while respond() is
+  still running.
+  """
+  fun name(): String => "server/on_closed after response"
+
+  fun apply(h: TestHelper) =>
+    h.long_test(5_000_000_000)
+    let port = "45881"
+    let host = ifdef linux then "127.0.0.2" else "localhost" end
+    let config = ServerConfig(host, port)
+    let listener = _TestTrackingListener(h, port,
+      _TestOnClosedTimingServerFactory(h), config,
+      {(h': TestHelper, port': String) =>
+        let client = _TestPassiveClient(h', port',
+          "GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n")
+        h'.dispose_when_done(client)
+      })
+    h.dispose_when_done(listener)
+
+class \nodoc\ iso _TestChunkSentPipelinedNonHead is UnitTest
+  """
+  Two pipelined requests, the second carrying `Connection: close`. The server
+  streams a chunk on the second responder while it is behind the head, so the
+  chunk buffers, then answers the first and lets the queue cascade. Same
+  assertion as `server/chunk sent before close`.
+  """
+  fun name(): String => "server/chunk sent on pipelined non-head response"
+
+  fun apply(h: TestHelper) =>
+    h.long_test(5_000_000_000)
+    let port = "45897"
+    let host = ifdef linux then "127.0.0.2" else "localhost" end
+    let config = ServerConfig(host, port)
+    let listener = _TestTrackingListener(h, port,
+      _TestPipelinedChunkServerFactory(h), config,
+      {(h': TestHelper, port': String) =>
+        let client = _TestPassiveClient(h', port',
+          "GET /1 HTTP/1.1\r\nHost: localhost\r\n\r\n" +
+          "GET /2 HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n")
+        h'.dispose_when_done(client)
+      })
+    h.dispose_when_done(listener)
+
+actor \nodoc\ _TestTrackingListener is lori.TCPListenerActor
+  """
+  Test listener that keeps every server actor it accepts and disposes them
+  when it closes. `_TestServerListener` keeps none, and it is shared by every
+  other server test, so the tests that need disposal use this one.
+  """
+  var _tcp_listener: lori.TCPListener = lori.TCPListener.none()
+  let _server_auth: lori.TCPServerAuth
+  let _connection_factory: _TestConnectionFactory
+  let _config: ServerConfig
+  let _h: TestHelper
+  let _port: String
+  let _start_client: {(TestHelper, String)} val
+  embed _connections: Array[lori.TCPConnectionActor]
+
+  new create(
+    h: TestHelper,
+    port: String,
+    connection_factory: _TestConnectionFactory,
+    config: ServerConfig,
+    start_client: {(TestHelper, String)} val)
+  =>
+    _h = h
+    _port = port
+    _connection_factory = connection_factory
+    _config = config
+    _start_client = start_client
+    _connections = Array[lori.TCPConnectionActor]
+    let listen_auth = lori.TCPListenAuth(_h.env.root)
+    _server_auth = lori.TCPServerAuth(listen_auth)
+    let host = ifdef linux then "127.0.0.2" else "localhost" end
+    _tcp_listener = lori.TCPListener(listen_auth, host, port, this)
+
+  fun ref _listener(): lori.TCPListener =>
+    _tcp_listener
+
+  fun ref _on_accept(fd: U32): lori.TCPConnectionActor =>
+    let conn = _connection_factory(_server_auth, fd, _config, None)
+    _connections.push(conn)
+    conn
+
+  fun ref _on_listening() =>
+    _start_client(_h, _port)
+
+  fun ref _on_listen_failure() =>
+    _h.fail("Listener failed to start on port " + _port)
+    _h.complete(false)
+
+  fun ref _on_closed() =>
+    for conn in _connections.values() do
+      conn.dispose()
+    end
+    _connections.clear()
+
+actor \nodoc\ _TestPassiveClient is
+  (lori.TCPConnectionActor & lori.ClientLifecycleEventReceiver)
+  """
+  Test client that sends a request and then holds its socket open, discarding
+  whatever comes back. It never closes first: a client that half-closes right
+  after its request can put the response and the peer's close in one server
+  turn, where a chunk's delivery callback is legitimately lost. It closes in
+  response to the server's close, which is what lets the server's
+  `on_closed()` fire; the tests that use this client assert and complete
+  there.
+  """
+  var _tcp_connection: lori.TCPConnection = lori.TCPConnection.none()
+  let _h: TestHelper
+  let _request: String val
+  var _bytes_received: USize = 0
+
+  new create(h: TestHelper, port: String, request: String val) =>
+    _h = h
+    _request = request
+    let host = ifdef linux then "127.0.0.2" else "localhost" end
+    _tcp_connection = lori.TCPConnection.client(
+      lori.TCPConnectAuth(_h.env.root), host, port, "", this, this)
+
+  fun ref _connection(): lori.TCPConnection =>
+    _tcp_connection
+
+  fun ref _on_connected() =>
+    _tcp_connection.send(_request)
+
+  fun ref _on_received(data: Array[U8] iso): lori.ReadAction =>
+    _bytes_received = _bytes_received + data.size()
+    lori.KeepReading
+
+  fun ref _on_closed() =>
+    // The server completes these tests from its own `on_closed()`, which it
+    // only reaches after this client closes in response to the server's
+    // close. A connection that ends before any response arrived never gets
+    // there, so say that here rather than leaving the test to time out.
+    if _bytes_received == 0 then
+      _h.fail("Connection closed before any response arrived")
+      _h.complete(false)
+    end
+
+  fun ref _on_connection_failure(reason: lori.ConnectionFailureReason) =>
+    _h.fail("Client connection failed")
+    _h.complete(false)
+
+// ---------------------------------------------------------------------------
+// Chunk-counting server: streams a fixed number of chunks, then closes
+// ---------------------------------------------------------------------------
+
+class \nodoc\ val _TestChunkCountServerFactory is _TestConnectionFactory
+  let _h: TestHelper
+  let _chunks: USize
+
+  new val create(h: TestHelper, chunks: USize) =>
+    _h = h
+    _chunks = chunks
+
+  fun apply(
+    auth: lori.TCPServerAuth,
+    fd: U32,
+    config: ServerConfig,
+    ssl_ctx: (ssl_net.SSLContext val | None)
+  ): lori.TCPConnectionActor =>
+    _TestChunkCountServer(auth, fd, config, _h, _chunks)
+
+actor \nodoc\ _TestChunkCountServer is HTTPServerActor
+  var _http: HTTPServer = HTTPServer.none()
+  let _h: TestHelper
+  let _chunks: USize
+  embed _sent: Array[ChunkSendToken]
+  embed _delivered: Array[ChunkSendToken]
+
+  new create(
+    auth: lori.TCPServerAuth,
+    fd: U32,
+    config: ServerConfig,
+    h: TestHelper,
+    chunks: USize)
+  =>
+    _h = h
+    _chunks = chunks
+    _sent = Array[ChunkSendToken]
+    _delivered = Array[ChunkSendToken]
+    _http = HTTPServer(auth, fd, this, config)
+
+  fun ref _http_connection(): HTTPServer => _http
+
+  fun ref on_request_complete(request': Request val, responder: Responder) =>
+    responder.start_chunked_response(StatusOK)
+    var i: USize = 0
+    while i < _chunks do
+      match responder.send_chunk("chunk-" + i.string())
+      | let t: ChunkSendToken => _sent.push(t)
+      end
+      i = i + 1
+    end
+    responder.finish_response()
+
+  fun ref on_chunk_sent(token: ChunkSendToken) =>
+    _delivered.push(token)
+
+  fun ref on_closed() =>
+    _h.assert_eq[USize](_chunks, _sent.size(),
+      "send_chunk() should have accepted every chunk")
+    _h.assert_eq[USize](_sent.size(), _delivered.size(),
+      "every chunk send_chunk() accepted should get an on_chunk_sent()")
+    for (i, expected) in _sent.pairs() do
+      try
+        _h.assert_true(expected == _delivered(i)?,
+          "on_chunk_sent() token " + i.string() + " should be the token "
+            + "send_chunk() returned for that chunk")
+      else
+        _h.fail("missing on_chunk_sent() for chunk " + i.string())
+      end
+    end
+    _h.complete(true)
+
+// ---------------------------------------------------------------------------
+// on_closed timing server: flags that respond() returned before on_closed()
+// ---------------------------------------------------------------------------
+
+class \nodoc\ val _TestOnClosedTimingServerFactory is _TestConnectionFactory
+  let _h: TestHelper
+
+  new val create(h: TestHelper) =>
+    _h = h
+
+  fun apply(
+    auth: lori.TCPServerAuth,
+    fd: U32,
+    config: ServerConfig,
+    ssl_ctx: (ssl_net.SSLContext val | None)
+  ): lori.TCPConnectionActor =>
+    _TestOnClosedTimingServer(auth, fd, config, _h)
+
+actor \nodoc\ _TestOnClosedTimingServer is HTTPServerActor
+  var _http: HTTPServer = HTTPServer.none()
+  let _h: TestHelper
+  var _responded: Bool = false
+  var _closed_count: USize = 0
+
+  new create(
+    auth: lori.TCPServerAuth,
+    fd: U32,
+    config: ServerConfig,
+    h: TestHelper)
+  =>
+    _h = h
+    _http = HTTPServer(auth, fd, this, config)
+
+  fun ref _http_connection(): HTTPServer => _http
+
+  fun ref on_request_complete(request': Request val, responder: Responder) =>
+    let resp_body: String val = "Hello, World!"
+    responder.respond(
+      ResponseBuilder(StatusOK)
+        .add_header("content-type", "text/plain")
+        .add_header("Content-Length", resp_body.size().string())
+        .finish_headers()
+        .add_chunk(resp_body)
+        .build())
+    _responded = true
+
+  fun ref on_closed() =>
+    _closed_count = _closed_count + 1
+    _h.assert_true(_responded,
+      "on_closed() fired while respond() was still running")
+    _http.close()
+    _h.assert_eq[USize](1, _closed_count,
+      "close() from on_closed() should not deliver on_closed() again")
+    _h.complete(true)
+
+// ---------------------------------------------------------------------------
+// Pipelined-chunk server: streams on the non-head responder, then answers
+// the head so the queue cascades the buffered chunk out
+// ---------------------------------------------------------------------------
+
+class \nodoc\ val _TestPipelinedChunkServerFactory is _TestConnectionFactory
+  let _h: TestHelper
+
+  new val create(h: TestHelper) =>
+    _h = h
+
+  fun apply(
+    auth: lori.TCPServerAuth,
+    fd: U32,
+    config: ServerConfig,
+    ssl_ctx: (ssl_net.SSLContext val | None)
+  ): lori.TCPConnectionActor =>
+    _TestPipelinedChunkServer(auth, fd, config, _h)
+
+actor \nodoc\ _TestPipelinedChunkServer is HTTPServerActor
+  var _http: HTTPServer = HTTPServer.none()
+  let _h: TestHelper
+  var _head: (Responder | None) = None
+  var _tokens: USize = 0
+  var _callbacks: USize = 0
+
+  new create(
+    auth: lori.TCPServerAuth,
+    fd: U32,
+    config: ServerConfig,
+    h: TestHelper)
+  =>
+    _h = h
+    _http = HTTPServer(auth, fd, this, config)
+
+  fun ref _http_connection(): HTTPServer => _http
+
+  fun ref on_request_complete(request': Request val, responder: Responder) =>
+    match _head
+    | None =>
+      _head = responder
+    | let head: Responder =>
+      responder.start_chunked_response(StatusOK)
+      match responder.send_chunk("pipelined-chunk")
+      | let _: ChunkSendToken => _tokens = _tokens + 1
+      end
+      responder.finish_response()
+      _head = None
+      let resp_body: String val = "head"
+      head.respond(
+        ResponseBuilder(StatusOK)
+          .add_header("content-type", "text/plain")
+          .add_header("Content-Length", resp_body.size().string())
+          .finish_headers()
+          .add_chunk(resp_body)
+          .build())
+    end
+
+  fun ref on_chunk_sent(token: ChunkSendToken) =>
+    _callbacks = _callbacks + 1
+
+  fun ref on_closed() =>
+    _h.assert_eq[USize](1, _tokens,
+      "send_chunk() should have accepted the buffered chunk")
+    _h.assert_eq[USize](_tokens, _callbacks,
+      "every chunk send_chunk() accepted should get an on_chunk_sent()")
+    _h.complete(true)
+
+class \nodoc\ iso _TestTimerFiresWhileClosing is UnitTest
+  """
+  A timer set while the connection was active still fires after the server
+  starts closing. The client mutes itself after sending, so it never reads
+  the server's close and the server stays in its closing state; the timer
+  then fires there and the server completes from `on_timer()`.
+  """
+  fun name(): String => "server/timer fires while closing"
+
+  fun apply(h: TestHelper) =>
+    h.long_test(5_000_000_000)
+    let port = "45898"
+    let host = ifdef linux then "127.0.0.2" else "localhost" end
+    let config = ServerConfig(host, port)
+    let listener = _TestTrackingListener(h, port,
+      _TestClosingTimerServerFactory(h), config,
+      {(h': TestHelper, port': String) =>
+        let client = _TestMutingClient(h', port',
+          "GET / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n")
+        h'.dispose_when_done(client)
+      })
+    h.dispose_when_done(listener)
+
+class \nodoc\ val _TestClosingTimerServerFactory is _TestConnectionFactory
+  let _h: TestHelper
+
+  new val create(h: TestHelper) =>
+    _h = h
+
+  fun apply(
+    auth: lori.TCPServerAuth,
+    fd: U32,
+    config: ServerConfig,
+    ssl_ctx: (ssl_net.SSLContext val | None)
+  ): lori.TCPConnectionActor =>
+    _TestClosingTimerServer(auth, fd, config, _h)
+
+actor \nodoc\ _TestClosingTimerServer is HTTPServerActor
+  var _http: HTTPServer = HTTPServer.none()
+  let _h: TestHelper
+  var _armed: Bool = false
+
+  new create(
+    auth: lori.TCPServerAuth,
+    fd: U32,
+    config: ServerConfig,
+    h: TestHelper)
+  =>
+    _h = h
+    _http = HTTPServer(auth, fd, this, config)
+
+  fun ref _http_connection(): HTTPServer => _http
+
+  fun ref on_request_complete(request': Request val, responder: Responder) =>
+    // Arm before responding: responding is what starts the close, and a
+    // timer cannot be set once the connection is closing.
+    match lori.MakeTimerDuration(200)
+    | let d: lori.TimerDuration =>
+      match _http.set_timer(d)
+      | let t: lori.TimerToken => _armed = true
+      end
+    end
+    if not _armed then
+      _h.fail("could not set a timer on an active connection")
+      _h.complete(false)
+      return
+    end
+    let resp_body: String val = "Hello, World!"
+    responder.respond(
+      ResponseBuilder(StatusOK)
+        .add_header("content-type", "text/plain")
+        .add_header("Content-Length", resp_body.size().string())
+        .finish_headers()
+        .add_chunk(resp_body)
+        .build())
+
+  fun ref on_timer(token: lori.TimerToken) =>
+    _h.complete(true)
+
+actor \nodoc\ _TestMutingClient is
+  (lori.TCPConnectionActor & lori.ClientLifecycleEventReceiver)
+  """
+  Test client that sends a request and then mutes, so it never reads the
+  response or the server's close. That holds the server in its closing state
+  for as long as the test needs.
+  """
+  var _tcp_connection: lori.TCPConnection = lori.TCPConnection.none()
+  let _h: TestHelper
+  let _request: String val
+
+  new create(h: TestHelper, port: String, request: String val) =>
+    _h = h
+    _request = request
+    let host = ifdef linux then "127.0.0.2" else "localhost" end
+    _tcp_connection = lori.TCPConnection.client(
+      lori.TCPConnectAuth(_h.env.root), host, port, "", this, this)
+
+  fun ref _connection(): lori.TCPConnection =>
+    _tcp_connection
+
+  fun ref _on_connected() =>
+    _tcp_connection.send(_request)
+    _tcp_connection.mute()
+
+  fun ref _on_connection_failure(reason: lori.ConnectionFailureReason) =>
+    _h.fail("Client connection failed")
+    _h.complete(false)

--- a/stallion/chunk_send_token.pony
+++ b/stallion/chunk_send_token.pony
@@ -2,10 +2,11 @@ class val ChunkSendToken is Equatable[ChunkSendToken]
   """
   Identifies a `send_chunk()` operation.
 
-  Returned by `Responder.send_chunk()` on success and delivered to
-  `HTTPServerLifecycleEventReceiver.on_chunk_sent()` when the chunk data has
-  been fully handed to the OS. Tokens use structural equality based on
-  their ID, which is scoped per connection.
+  Returned by `Responder.send_chunk()` on success. The same token reaches
+  `HTTPServerLifecycleEventReceiver.on_chunk_sent()`. No callback fires until
+  the chunk's bytes reach the OS, and even then it can be lost — see that
+  callback for the case where it does not arrive. Tokens use structural
+  equality based on their ID, which is scoped per connection.
 
   Applications managing multiple connections should pair tokens with
   connection identity to avoid ambiguity.

--- a/stallion/http_server.pony
+++ b/stallion/http_server.pony
@@ -124,11 +124,14 @@ class HTTPServer is
     _state.on_closed(this)
 
   fun ref _on_start_failure(reason: lori.StartFailureReason) =>
+    // Set _Closed before delivering, for the reason _handle_closed does: an
+    // actor that calls close() from the callback re-enters
+    // _close_connection(), and the state guard makes that a no-op.
+    _state = _Closed
     match \exhaustive\ _lifecycle_event_receiver
     | let r: HTTPServerLifecycleEventReceiver ref => r.on_start_failure(reason)
     | None => _Unreachable()
     end
-    _state = _Closed
 
   fun ref _on_throttled() =>
     _state.on_throttled(this)
@@ -138,6 +141,9 @@ class HTTPServer is
 
   fun ref _on_sent(token: lori.SendToken) =>
     _state.on_sent(this, token)
+
+  fun ref _on_send_failed(token: lori.SendToken) =>
+    _state.on_send_failed(this, token)
 
   fun ref _on_idle_timeout() =>
     _state.on_idle_timeout(this)
@@ -275,7 +281,7 @@ class HTTPServer is
     match \exhaustive\ _config
     | let c: ServerConfig =>
       if _requests_pending > c.max_pending_responses then
-        _tcp_connection.send(_ErrorResponse.no_response())
+        _flush_data(_ErrorResponse.no_response())
         _close_connection()
         return
       end
@@ -321,7 +327,7 @@ class HTTPServer is
     // itself or internally here (Host/URI rejection in request_received), and
     // in the latter case the parser is otherwise unaware the request was
     // rejected and would keep parsing.
-    _tcp_connection.send(_ErrorResponse.for_error(err))
+    _flush_data(_ErrorResponse.for_error(err))
     match _parser
     | let p: _RequestParser => p.stop()
     end
@@ -339,15 +345,18 @@ class HTTPServer is
     """
     Send response data to the TCP connection.
 
-    Called when data for the head-of-line entry is ready to send.
     On successful send, pushes the HTTP-level token onto the FIFO so
     `_handle_sent` can correlate the lori `_on_sent` callback back to
-    the originating `send_chunk()` call. On send error, closes the
+    the originating `send_chunk()` call. On send error, starts closing the
     connection (which in turn closes the queue, making any remaining
     Responders inert).
     """
     match \exhaustive\ _tcp_connection.send(data)
     | let _: lori.SendToken =>
+      // Push only on success: an errored send adds no FIFO entry. send()
+      // synchronously fires the throttle callback, and on a send error the
+      // close callback, before it returns; the close path clears the FIFO,
+      // so this push can land on a FIFO that was just emptied.
       _pending_sent_tokens.push(token)
     | let _: lori.SendError =>
       _close_connection()
@@ -395,15 +404,24 @@ class HTTPServer is
     end
 
   fun ref _handle_closed() =>
-    """Notify the receiver that the connection has closed."""
+    """
+    Handle lori's report that the connection has closed.
+
+    Discards the chunk tokens still waiting on a send outcome — no further
+    `on_chunk_sent()` is delivered for this connection — and delivers
+    `on_closed()` to the receiver.
+    """
     match _parser | let p: _RequestParser => p.stop() end
     match _queue | let q: _ResponseQueue => q.close() end
     _pending_sent_tokens.clear()
+    // Set _Closed before delivering on_closed: an actor that calls close()
+    // from on_closed re-enters _close_connection(), and the state guard makes
+    // that a no-op.
+    _state = _Closed
     match \exhaustive\ _lifecycle_event_receiver
     | let r: HTTPServerLifecycleEventReceiver ref => r.on_closed()
     | None => _Unreachable()
     end
-    _state = _Closed
 
   fun ref _handle_throttled() =>
     """Apply backpressure: mute the TCP connection and notify the receiver."""
@@ -427,9 +445,9 @@ class HTTPServer is
     """
     Correlate a lori send completion back to an HTTP-level chunk token.
 
-    Pops the next entry from the FIFO. If it's a `ChunkSendToken`,
-    delivers `on_chunk_sent(token)` to the actor. If `None`, it was an
-    internal send (headers, terminal chunk, complete response) — skip it.
+    Pops the next entry from the FIFO. A `ChunkSendToken` reaches the actor
+    as `on_chunk_sent(token)`. A `None` entry was an internal send with
+    nothing to deliver.
     """
     try
       match _pending_sent_tokens.shift()?
@@ -441,6 +459,19 @@ class HTTPServer is
       end
     else
       _Unreachable()
+    end
+
+  fun ref _handle_send_failed(token: lori.SendToken) =>
+    """
+    Drop the FIFO entry for a send lori could not deliver.
+
+    Stallion reports delivery only, so a chunk whose bytes never reached
+    the OS produces no callback. No path through stallion reaches here with
+    an empty FIFO; the bare `try` is there so that a shift on an empty one
+    discards the notification instead of ending the process.
+    """
+    try
+      _pending_sent_tokens.shift()?
     end
 
   fun ref _handle_idle_timeout() =>
@@ -488,8 +519,9 @@ class HTTPServer is
 
     Use this when the actor needs to force-close the connection — for
     example, after rejecting a request early (413 Payload Too Large) via
-    the `Responder` delivered in `on_request()`. Safe to call at any time;
-    idempotent due to the `_Active` state guard.
+    the `Responder` delivered in `on_request()`. Safe to call at any time:
+    the first call starts the close, and a call made once the connection is
+    closing or closed does nothing.
     """
     _close_connection()
 
@@ -501,10 +533,11 @@ class HTTPServer is
     duration. Returns a `TimerToken` on success, or a `SetTimerError` on
     failure.
 
-    Unlike idle timeout, this timer has no I/O-reset behavior — it fires
-    unconditionally after the duration elapses, regardless of send/receive
-    activity. There is no automatic re-arming; call `set_timer()` again from
-    `on_timer()` for repetition.
+    Unlike idle timeout, this timer has no I/O-reset behavior — send and
+    receive activity do not change when it comes due. A timer set here still
+    fires if the connection starts closing before it comes due. There is no
+    automatic re-arming; call `set_timer()` again from `on_timer()` for
+    repetition.
 
     Only one timer can be active at a time. Setting a timer while one is
     already active returns `SetTimerAlreadyActive` — call `cancel_timer()`
@@ -528,26 +561,32 @@ class HTTPServer is
 
   fun ref _close_connection() =>
     """
-    Close the connection and clean up all resources.
+    Close the connection.
+
+    Under backpressure the close is a hard close that finishes inside
+    this call, so `_handle_closed` has already run by the time this
+    returns. A close at any other time leaves the connection open until
+    the peer closes its half, and `_handle_closed` runs when lori reports
+    the close.
 
     Safe to call from within queue callbacks (e.g., `_response_complete`
-    with `keep_alive=false`) — the `_Active` state guard prevents
-    double-close. After this, any Responders the actor still holds
-    become inert: their methods call through to the queue, which is
-    closed and no-ops everything.
+    with `keep_alive=false`): a second close is a no-op in every state
+    that is not `_Active`. After this, any Responders the actor still
+    holds become inert — their methods call through to the queue, which
+    is closed and no-ops everything.
     """
-    match _state
-    | let _: _Active =>
-      match _parser | let p: _RequestParser => p.stop() end
-      match _queue | let q: _ResponseQueue => q.close() end
-      _pending_sent_tokens.clear()
-      match \exhaustive\ _lifecycle_event_receiver
-      | let r: HTTPServerLifecycleEventReceiver ref => r.on_closed()
-      | None => _Unreachable()
-      end
-      // Set _Closed before close(): on a muted connection close() hard-closes
-      // synchronously and re-enters _on_closed; the _Closed state makes that
-      // re-entry a no-op, so on_closed fires exactly once.
-      _state = _Closed
-      _tcp_connection.close()
-    end
+    _state.close(this)
+
+  fun ref _start_close() =>
+    """
+    Stop taking work and hand the connection to lori.
+
+    Reached only from `_Active`, so this runs at most once per connection.
+    """
+    match _parser | let p: _RequestParser => p.stop() end
+    match _queue | let q: _ResponseQueue => q.close() end
+    // Set _Closing before close(): on a muted connection close() hard-closes
+    // synchronously and re-enters _on_closed; _Closing.on_closed delivers
+    // on_closed once and moves to _Closed.
+    _state = _Closing
+    _tcp_connection.close()

--- a/stallion/http_server_lifecycle_event_receiver.pony
+++ b/stallion/http_server_lifecycle_event_receiver.pony
@@ -55,11 +55,26 @@ trait ref HTTPServerLifecycleEventReceiver
 
   fun ref on_closed() =>
     """
-    Called when the connection closes.
+    Called once the connection is closed.
 
     Fires on client disconnect, server-initiated close, or any other
     reason. Not called if the connection fails before starting — see
     `on_start_failure()` for that case.
+
+    When the server closes first — through `HTTPServer.close()` or any
+    other close stallion starts — a close taken while the connection is
+    under backpressure (from `on_throttled()` until `on_unthrottled()`)
+    is a hard close: it shuts the connection down at once, drops
+    undelivered data, and fires this callback in the same turn. A close
+    taken at any other time leaves the connection open until the peer
+    closes its half, and this callback fires then. Stallion sets no
+    limit on how long that takes, so an actor that releases resources
+    here holds them until the peer closes.
+
+    To close without waiting on the peer, call `dispose()` on the actor:
+    `HTTPServerActor` is a `lori.TCPConnectionActor`, whose `dispose()`
+    hard-closes the connection and delivers `on_closed()` in the dispose
+    turn.
     """
     None
 
@@ -90,18 +105,27 @@ trait ref HTTPServerLifecycleEventReceiver
 
   fun ref on_chunk_sent(token: ChunkSendToken) =>
     """
-    Called when a chunk from `send_chunk()` has been handed to the OS.
+    Called for a chunk from `send_chunk()` whose bytes reached the OS.
 
     The `token` matches the `ChunkSendToken` returned by the
     `send_chunk()` call that produced the data. Fires asynchronously
     in a subsequent behavior turn — never during the `send_chunk()` call
-    itself. Only user chunks trigger this callback; internal sends
+    itself. Only user chunks produce this callback; internal sends
     (headers, terminal chunk, error responses) do not.
+
+    No callback fires until the chunk's bytes reach the OS, and even then it
+    can be lost: when the connection's close is reported first, any callback
+    queued behind that report never reaches the actor. One way that happens
+    is a delivery and the close landing in the same actor turn, where lori
+    reports the close synchronously and the delivery is queued behind it
+    (`ponylang/lori#345`).
 
     Use this for flow-controlled streaming: send a chunk, wait for the
     callback, then send the next chunk. Multiple chunks can be in flight
     simultaneously (windowed); use the tokens to track which have been
-    delivered.
+    delivered. Because a callback can go missing, an actor that sends the
+    next chunk only after the previous one's callback can stop making
+    progress.
     """
     None
 
@@ -117,14 +141,23 @@ trait ref HTTPServerLifecycleEventReceiver
     """
     Called when a one-shot timer created by `HTTPServer.set_timer()` fires.
 
-    The `token` matches the one returned by `set_timer()`. Fires once per
-    `set_timer()` call. The timer is consumed before the callback, so it is
-    safe to call `set_timer()` from within `on_timer()` to re-arm. No
-    automatic re-arming occurs.
+    The `token` matches the one returned by `set_timer()`. A `set_timer()`
+    call produces at most one callback. The timer is consumed before the
+    callback, so it is safe to call `set_timer()` from within `on_timer()` to
+    re-arm. No automatic re-arming occurs.
 
-    Unlike idle timeout, this timer has no I/O-reset behavior — it fires
-    unconditionally after the configured duration, regardless of send/receive
-    activity.
+    A timer that comes due after the connection has started closing still
+    fires. That is the point: a close the server starts is not complete until
+    the peer closes its half, so `on_closed()` may be a long way off, and
+    this callback is what your actor has to act on in the meantime. Calling
+    `dispose()` on the actor from here closes without waiting on the peer.
+
+    A new timer cannot be set once the connection is closing —
+    `HTTPServer.set_timer()` returns `SetTimerNotOpen` — so this is the last
+    callback of its kind for that connection.
+
+    Unlike idle timeout, this timer has no I/O-reset behavior — send and
+    receive activity do not change when it comes due.
     """
     None
 

--- a/stallion/responder.pony
+++ b/stallion/responder.pony
@@ -42,12 +42,15 @@ class ref Responder
     // HTTP/1.0 — fall back to a complete response
     responder.respond(fallback_response)
   | AlreadyResponded => None
+  | ConnectionClosed => None
   end
   ```
 
   Each `send_chunk()` returns a `ChunkSendToken` (or `None` if the call
-  was a no-op). A matching `on_chunk_sent(token)` callback fires when the
-  OS accepts the data, enabling flow-controlled streaming.
+  was a no-op). No callback fires until the chunk's bytes reach the OS, and
+  even then it can be lost — read
+  `HTTPServerLifecycleEventReceiver.on_chunk_sent()` before building
+  flow-controlled streaming on those callbacks.
 
   Responders are created internally by `HTTPServer`. Application
   code should not attempt to construct them directly.
@@ -98,11 +101,22 @@ class ref Responder
 
     Returns `StreamingStarted` on success, `ChunkedNotSupported` for HTTP/1.0
     requests (which do not support chunked transfer encoding — use `respond()`
-    with a `ResponseBuilder`-constructed response instead), or
-    `AlreadyResponded` when a response has already been started or completed.
+    with a `ResponseBuilder`-constructed response instead), `AlreadyResponded`
+    when a response has already been started or completed, or
+    `ConnectionClosed` when the connection is closed or closing.
+
+    On a connection that is closed or closing, the result is
+    `ConnectionClosed` even for an HTTP/1.0 request, because `respond()`, the
+    fallback for `ChunkedNotSupported`, does not work there either. After a
+    response has already been started or completed, the result is
+    `AlreadyResponded` whatever state the connection is in.
+    `ConnectionClosed` starts nothing: a second call returns
+    `ConnectionClosed` again, and a later `send_chunk()` returns `None`.
     """
     match _state
     | _ResponderNotResponded =>
+      if _queue.is_closed() then return ConnectionClosed end
+
       // HTTP/1.0 does not support chunked transfer encoding
       if _version is HTTP10 then return ChunkedNotSupported end
 
@@ -120,6 +134,13 @@ class ref Responder
       end
       let response = _ResponseSerializer(status, h, None, _version)
       _queue.send_data(_id, consume response)
+      // send_data can close the connection on its way out: a send error
+      // closes the queue before it returns. Nothing was started in that
+      // case, so report it and leave the Responder where it began.
+      if _queue.is_closed() then
+        _state = _ResponderNotResponded
+        return ConnectionClosed
+      end
       StreamingStarted
     else
       AlreadyResponded
@@ -132,16 +153,21 @@ class ref Responder
     The data is wrapped in chunked transfer encoding format. Empty data is
     silently ignored — use `finish_response()` to send the terminal chunk.
 
-    Returns `ChunkSendToken` when the chunk was queued — a matching
-    `on_chunk_sent()` callback will fire when the OS accepts the data.
-    Returns `None` when the call was a no-op (wrong state, empty data,
-    or HTTP/1.0 request where chunked encoding was rejected).
+    Returns `ChunkSendToken` when the chunk was queued. Returns `None` when
+    the call was a no-op (wrong state, empty data, a connection that is
+    closed or closing, or an HTTP/1.0 request where chunked encoding was
+    rejected).
+
+    A token is not a promise of a callback. No callback fires until the
+    chunk's bytes reach the OS, and even then it can be lost — see
+    `HTTPServerLifecycleEventReceiver.on_chunk_sent()`.
 
     Only valid after `start_chunked_response()`. Calls in other states are
     silently ignored.
     """
     match _state
     | _ResponderStreaming =>
+      if _queue.is_closed() then return None end
       let size: USize = match \exhaustive\ data
       | let s: String val => s.size()
       | let a: Array[U8] val => a.size()
@@ -150,6 +176,10 @@ class ref Responder
       let token = _queue.create_chunk_token()
       let chunk = _ChunkedEncoder.chunk(data)
       _queue.send_data(_id, consume chunk, token)
+      // send_data can close the connection on its way out: a send error
+      // closes the queue before it returns. The chunk went nowhere, so hand
+      // back no token rather than one that will never be reported.
+      if _queue.is_closed() then return None end
       token
     else
       None

--- a/stallion/server_config.pony
+++ b/stallion/server_config.pony
@@ -16,7 +16,9 @@ class val ServerConfig
 
   Host and port specify the listen address. Parser limits control the maximum
   size of request components. Idle timeout controls how long a keep-alive
-  connection can sit without activity before being closed.
+  connection can sit without activity before being closed; it applies only
+  while the connection is open, so once a close has started the idle timeout
+  no longer bounds the connection.
   `max_requests_per_connection` limits how many requests a single keep-alive
   connection can serve before the server closes it (analogous to nginx's
   `keepalive_requests`). `None` means unlimited. Use

--- a/stallion/stallion.pony
+++ b/stallion/stallion.pony
@@ -95,8 +95,17 @@ fun ref on_request_complete(request': stallion.Request val,
     // HTTP/1.0 — fall back to a complete response
     responder.respond(fallback_response)
   | stallion.AlreadyResponded => None
+  | stallion.ConnectionClosed => None
   end
 ```
+
+No callback fires until the chunk's bytes reach the OS, and even then it can
+be lost: when the connection's close is reported first, any callback queued
+behind that report never reaches the actor. One way that happens is a delivery
+and the close landing in the same actor turn, where lori reports the close
+synchronously and the delivery is queued behind it (`ponylang/lori#345`). An
+actor that sends the next chunk only after the previous one's callback can
+therefore stop making progress.
 
 For HTTPS, use `stallion.HTTPServer.ssl` instead of `stallion.HTTPServer`. Store
 an `SSLContext val` in the listener and pass it through in `_on_accept`:

--- a/stallion/start_chunked_response_result.pony
+++ b/stallion/start_chunked_response_result.pony
@@ -16,11 +16,23 @@ primitive ChunkedNotSupported is _StartChunkedResponseResult
   """
   fun string(): String iso^ => "ChunkedNotSupported".clone()
 
-type StartChunkedResponseResult is
-  ((StreamingStarted | AlreadyResponded | ChunkedNotSupported)
-  & _StartChunkedResponseResult)
+primitive ConnectionClosed is _StartChunkedResponseResult
   """
-  Result of calling `Responder.start_chunked_response()`: indicates whether
-  streaming was started, was rejected because HTTP/1.0 doesn't support chunked
-  transfer encoding, or was rejected because a response was already in progress.
+  The connection is closed or closing, so nothing more can be sent for this
+  request.
+
+  Nothing was started: a second `start_chunked_response()` on the same
+  `Responder` returns `ConnectionClosed` again, and a later `send_chunk()`
+  returns `None`.
+  """
+  fun string(): String iso^ => "ConnectionClosed".clone()
+
+type StartChunkedResponseResult is
+  ((StreamingStarted | AlreadyResponded | ChunkedNotSupported
+  | ConnectionClosed) & _StartChunkedResponseResult)
+  """
+  Result of `Responder.start_chunked_response()`: streaming started, or the
+  reason it did not — HTTP/1.0 does not support chunked transfer encoding, a
+  response was already started or completed, or the connection is closed or
+  closing.
   """


### PR DESCRIPTION
`Responder.send_chunk()` returns a `ChunkSendToken`, and the docs said a matching `on_chunk_sent()` would follow once the OS had the bytes. Send a chunk on a connection that then closes and the bytes go out, but no callback arrives. An actor built on the documented pattern — send a chunk, wait for the callback, send the next — stops there.

The connection state machine was one state short. It went to `_Closed` the moment a close started, while lori was still closing and still delivering send outcomes for data stallion had already handed it. `_Closed.on_sent` is a no-op, so every outcome arriving after that point was dropped. `_Closing` is the state `_Closed` was standing in for, and send outcomes are handled there.

Handling them meant two sends had to stop bypassing `_flush_data` first: the response for a client over `max_pending_responses`, and the response for a parse error. Neither pushed a token onto the FIFO that pairs a lori send outcome with the chunk that produced it. That cost nothing while the outcome was dropped in `_Closed`. Once it is routed instead, `_handle_sent` shifts an empty FIFO and calls `_Unreachable()`, which ends the process.

`on_closed()` fires later now because there is a state to be in while the close runs. For a close stallion starts, it fires when lori reports the connection closed rather than when the close starts, because a connection halfway through a graceful close is not closed. A peer-initiated close is unchanged. On a connection that is not under backpressure, closed means the peer has closed its half, a wait stallion sets no bound on, so an application that frees resources in `on_closed()` holds them until then. Under backpressure the close is a hard close and `on_closed()` fires in the turn the close started. `dispose()` on the server actor closes without waiting on the peer.

`Responder` stopped reporting success for work a closed or closing connection then drops. `send_chunk()` returns `None`, already its no-op return, and `start_chunked_response()` returns a new `ConnectionClosed`. That last one is source-breaking: `ConnectionClosed` is now part of the `StartChunkedResponseResult` union, so a `match \exhaustive\` on the union stops compiling until the case is added. A `match` with an `else` is unaffected.

The same hole, generalized: every state now handles every send outcome, `on_send_failed` included, which had no override before. Only `_Closed`'s implementation can run under today's lori.

A token is still not a promise of a callback. When lori reports the close before a chunk's send outcome, stallion has already discarded the pending tokens, so a chunk whose bytes reached the OS produces no callback. That ordering is `ponylang/lori#345`. The docstrings and the release notes say so now, where before they described a callback that always arrives.

A timer the actor set with `HTTPServer.set_timer()` is delivered while the connection is closing. That window lasts as long as the peer takes to close its half, and lori still fires the timer in it, so dropping it left an actor whose deadline was that timer waiting on a connection it could no longer hear from. `on_idle_timeout` stays a no-op there — that timer is stallion's own and its only action is to close.

`start_chunked_response()` and `send_chunk()` also check the connection after their own send, not just on entry. A send error closes the connection before `send_data` returns, and both used to report success for work that then went nowhere — the case the entry check exists to report.

`close` is an operation on the connection state machine rather than an inline guard on `_Active`, so a state added later has to answer it.

Closes #144
