### PR TITLE
Update to lori 0.18.0 and ssl 4.0.0

### DIFF
--- a/.release-notes/next-release.md
+++ b/.release-notes/next-release.md
@@ -80,11 +80,11 @@ end
 
 Stallion now requires ponyc 0.67.0 or later on every platform. The previous minimum was 0.64.0, and 0.66.0 on Windows; 0.64.0 through 0.66.x are no longer supported. The write hang under load is closed by a socket call that ponyc added in 0.67.0.
 
-## Move to ponylang/ssl 3.0.0
+## Move to ponylang/ssl 4.0.0
 
-Stallion now requires ponylang/ssl 3.0.0, where it required 2.0.1. Stallion's own API is unchanged by the move: you build an `SSLContext val` and hand it to `HTTPServer.ssl` exactly as before.
+Stallion now requires ponylang/ssl 4.0.0, where it required 2.0.1. Stallion's own API is unchanged by the move: you build an `SSLContext val` and hand it to `HTTPServer.ssl` exactly as before.
 
-Your own code can break if it picks up the new version. If your application does not declare ssl itself, it gets 3.0.0 through stallion, and your own `use "ssl/net"` or `use "ssl/crypto"` code is built against it. If your application does declare ssl, your declaration is the one that applies.
+Your own code can break if it picks up the new version. If your application does not declare ssl itself, it gets 4.0.0 through stallion, and your own `use "ssl/net"` or `use "ssl/crypto"` code is built against it. If your application does declare ssl, your declaration is the one that applies.
 
 The twelve protocol-version primitives now spell their acronyms in full. They are the values passed to `SSLContext.set_min_proto_version` and `set_max_proto_version`, so if you pin a TLS version on the context you hand to `HTTPServer.ssl`, that call no longer compiles until you rename it:
 
@@ -96,7 +96,7 @@ ctx.set_min_proto_version(Tls1u2Version())?
 ctx.set_min_proto_version(TLS1u2Version())?
 ```
 
-`SSLContext.alpn_set_resolver` also changed: it takes an `ALPNProtocolResolver val` where it took a `box`. Constructing a `Digest`, `Digest.final`, and `HmacSha256` are all partial and need a `?`. `SSLState` gained an `SSLDisposed` member, which breaks an exhaustive match on `SSL.state()`. And a reference typed `HashFn tag` no longer compiles, so type it `val` or `box`. See the ponylang/ssl 3.0.0 release notes for more on each.
+`SSLContext.alpn_set_resolver` also changed: it takes an `ALPNProtocolResolver val` where it took a `box`. Constructing a `Digest`, `Digest.final`, and `HmacSha256` are all partial and need a `?`. `SSLState` gained an `SSLDisposed` member, which breaks an exhaustive match on `SSL.state()`. And a reference typed `HashFn tag` no longer compiles, so type it `val` or `box`. See the ponylang/ssl 3.0.0 and 4.0.0 release notes for more on each.
 
 ## Change when on_closed() fires
 
@@ -141,4 +141,26 @@ An actor called back at `on_chunk_sent()` while the connection is closing gets `
 ## Fix a number of SSL bugs
 
 Fixed multiple bugs affecting SSL support, including handshake failures being reported as authentication failures, data being silently dropped on large writes and when encryption fails, and connections being closed by unrelated SSL failures elsewhere.
+
+## Fix additional SSL connection bugs
+
+Fixed additional bugs in SSL connection handling that could cause handshake failures to be misreported, data to be silently dropped during encrypted writes, and one connection's SSL failure to close a different connection.
+
+## Change when on_chunk_sent fires
+
+`on_chunk_sent()` can now fire during the `send_chunk()` call that produced the chunk, when the bytes drain to the operating system immediately. It used to fire only in a later actor turn.
+
+Code that sets state after `send_chunk()` and reads it in `on_chunk_sent()` has a latent ordering bug that this change exposes. Move the state setup before the `send_chunk()` call:
+
+```pony
+// Before — on_chunk_sent could read stale state
+responder.send_chunk("chunk 1")
+_responder = responder
+_chunks_sent = 1
+
+// After — state is ready before the callback can fire
+_responder = responder
+_chunks_sent = 1
+responder.send_chunk("chunk 1")
+```
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file. This projec
 - Fix a possible write hang under load ([PR #140](https://github.com/ponylang/stallion/pull/140))
 - Fix on_chunk_sent not firing when the connection closes ([PR #146](https://github.com/ponylang/stallion/pull/146))
 - Fix a number of SSL bugs ([PR #157](https://github.com/ponylang/stallion/pull/157))
+- Fix additional SSL connection bugs ([PR #159](https://github.com/ponylang/stallion/pull/159))
 
 ### Added
 
@@ -22,8 +23,9 @@ All notable changes to this project will be documented in this file. This projec
 
 - Remove HTTPServer.yield_read() ([PR #140](https://github.com/ponylang/stallion/pull/140))
 - Require ponyc 0.67.0 or later ([PR #140](https://github.com/ponylang/stallion/pull/140))
-- Move to ponylang/ssl 3.0.0 ([PR #140](https://github.com/ponylang/stallion/pull/140))
+- Move to ponylang/ssl 4.0.0 ([PR #140](https://github.com/ponylang/stallion/pull/140))
 - Change when on_closed() fires ([PR #146](https://github.com/ponylang/stallion/pull/146))
+- Change when on_chunk_sent fires ([PR #159](https://github.com/ponylang/stallion/pull/159))
 - Report a closed connection from Responder ([PR #146](https://github.com/ponylang/stallion/pull/146))
 
 ## [0.8.0] - 2026-06-30

--- a/corral.json
+++ b/corral.json
@@ -13,11 +13,11 @@
   "deps": [
     {
       "locator": "github.com/ponylang/lori.git",
-      "version": "0.17.0"
+      "version": "0.18.0"
     },
     {
       "locator": "github.com/ponylang/ssl.git",
-      "version": "3.0.1"
+      "version": "4.0.0"
     },
     {
       "locator": "github.com/ponylang/uri.git",

--- a/stallion/_test_server.pony
+++ b/stallion/_test_server.pony
@@ -1641,9 +1641,9 @@ actor \nodoc\ _TestChunkSentServer is HTTPServerActor
       h
     end
     responder.start_chunked_response(StatusOK, headers)
-    responder.send_chunk("cs-chunk-1")
     _responder = responder
     _chunks_sent = 1
+    responder.send_chunk("cs-chunk-1")
 
   fun ref on_chunk_sent(token: ChunkSendToken) =>
     match _responder

--- a/stallion/http_server.pony
+++ b/stallion/http_server.pony
@@ -43,6 +43,7 @@ class HTTPServer is
   var _requests_completed: USize = 0
   var _parser: (_RequestParser | None) = None
   embed _pending_sent_tokens: Array[(ChunkSendToken | None)]
+  var _next_chunk_token: (ChunkSendToken | None) = None
 
   new none() =>
     """
@@ -144,6 +145,11 @@ class HTTPServer is
 
   fun ref _on_send_failed(token: lori.SendToken) =>
     _state.on_send_failed(this, token)
+
+  fun ref _on_send_accepted(token: lori.SendToken,
+    data: (ByteSeq | ByteSeqIter))
+  =>
+    _pending_sent_tokens.push(_next_chunk_token)
 
   fun ref _on_idle_timeout() =>
     _state.on_idle_timeout(this)
@@ -345,19 +351,14 @@ class HTTPServer is
     """
     Send response data to the TCP connection.
 
-    On successful send, pushes the HTTP-level token onto the FIFO so
-    `_handle_sent` can correlate the lori `_on_sent` callback back to
-    the originating `send_chunk()` call. On send error, starts closing the
-    connection (which in turn closes the queue, making any remaining
-    Responders inert).
+    Stages the HTTP-level token in `_next_chunk_token` before calling
+    `send()`, because `_on_send_accepted` fires from inside `send()` and
+    pushes it onto the FIFO before `_on_sent` can pop it. On send error,
+    starts closing the connection.
     """
+    _next_chunk_token = token
     match \exhaustive\ _tcp_connection.send(data)
-    | let _: lori.SendToken =>
-      // Push only on success: an errored send adds no FIFO entry. send()
-      // synchronously fires the throttle callback, and on a send error the
-      // close callback, before it returns; the close path clears the FIFO,
-      // so this push can land on a FIFO that was just emptied.
-      _pending_sent_tokens.push(token)
+    | lori.SendAccepted => None
     | let _: lori.SendError =>
       _close_connection()
     end

--- a/stallion/http_server_lifecycle_event_receiver.pony
+++ b/stallion/http_server_lifecycle_event_receiver.pony
@@ -108,10 +108,11 @@ trait ref HTTPServerLifecycleEventReceiver
     Called for a chunk from `send_chunk()` whose bytes reached the OS.
 
     The `token` matches the `ChunkSendToken` returned by the
-    `send_chunk()` call that produced the data. Fires asynchronously
-    in a subsequent behavior turn — never during the `send_chunk()` call
-    itself. Only user chunks produce this callback; internal sends
-    (headers, terminal chunk, error responses) do not.
+    `send_chunk()` call that produced the data. Can fire during the
+    `send_chunk()` call itself when the bytes drain immediately, so any
+    state that `on_chunk_sent` reads must be set before calling
+    `send_chunk()`. Only user chunks produce this callback; internal
+    sends (headers, terminal chunk, error responses) do not.
 
     No callback fires until the chunk's bytes reach the OS, and even then it
     can be lost: when the connection's close is reported first, any callback


### PR DESCRIPTION
Updates lori from 0.17.0 to 0.18.0 and ssl from 3.0.1 to 4.0.0.

lori 0.18.0 makes `_on_sent` a direct (synchronous) call instead of a deferred behavior. `on_chunk_sent` can now fire during `send_chunk()` when bytes drain immediately, exposing a latent ordering bug in the test server that set state after `send_chunk()`. Fixed the test and updated the `on_chunk_sent` docstring to document the new timing contract.

The ssl version bump in next-release.md goes from 3.0.0 to 4.0.0 to match what will actually ship.

Multi-type PR (Fixed + Changed) — CHANGELOG and next-release.md updated manually, no changelog label.
