### PR TITLE
Remove _ResponseQueue._closed; let operations report their own outcome

### DIFF
--- a/stallion/_response_queue.pony
+++ b/stallion/_response_queue.pony
@@ -1,3 +1,8 @@
+type _QueueResult is (_QueueAccepted | _QueueEntryGone)
+
+primitive _QueueAccepted
+primitive _QueueEntryGone
+
 class ref _QueueEntry
   """
   Per-request buffered response data.
@@ -25,16 +30,22 @@ class ref _ResponseQueue
   callback (unless throttled). For non-head entries, data is buffered until
   the entry becomes the head.
 
+  The queue carries no connection-lifecycle state. `close()` is pure
+  teardown: it clears entries, and subsequent operations report
+  `_QueueEntryGone` because the entry array is empty. The connection state
+  machine (`HTTPServer._state`) is the sole authority on whether the
+  connection is alive.
+
   **Re-entrancy contract**: both `close()` and `throttle()` may be called
   from within `_flush_data`. `_flush_data` calls `TCPConnection.send()`,
   which synchronously fires `_on_throttled` (on a partial write) — that
   re-enters as `throttle()` — or, on a send error, closes the connection,
   which re-enters as `close()`. `_response_complete` may likewise re-enter
   as `close()` (e.g., keep-alive=false). `_pump_head` is the single place
-  head data is flushed: it re-checks both `_closed` and `_throttled` after
-  every `_flush_data` and in its outer loop, so a re-throttle leaves the
-  unsent chunks buffered for the next `unthrottle()` and a close stops the
-  cascade safely.
+  head data is flushed: it re-checks `_entries.size()` and `_throttled`
+  after every `_flush_data` and in its outer loop, so a re-throttle leaves
+  the unsent chunks buffered for the next `unthrottle()` and a close (which
+  clears entries) stops the cascade safely.
   """
   let _notify: _ResponseQueueNotify ref
   var _head_id: U64 = 0
@@ -42,7 +53,6 @@ class ref _ResponseQueue
   var _next_chunk_token_id: U64 = 0
   embed _entries: Array[_QueueEntry]
   var _throttled: Bool = false
-  var _closed: Bool = false
 
   new create(notify: _ResponseQueueNotify ref) =>
     """
@@ -77,10 +87,21 @@ class ref _ResponseQueue
     _entries.push(_QueueEntry(keep_alive))
     id
 
+  fun has_entry(id: U64): Bool =>
+    """
+    Check whether the entry for a request ID still exists.
+
+    Returns `true` when the entry is present in the queue, `false` when it
+    has been cleared by `close()`. Pure read — no side effects.
+    """
+    let index = (id - _head_id).usize()
+    index < _entries.size()
+
   fun ref send_data(
     id: U64,
     data: ByteSeq,
     token: (ChunkSendToken | None) = None)
+    : _QueueResult
   =>
     """
     Submit response data for a request.
@@ -89,22 +110,33 @@ class ref _ResponseQueue
     data is sent immediately via `_flush_data`. Otherwise, data is buffered
     in the entry for later flushing. The optional `token` travels alongside
     the data — `ChunkSendToken` for user chunks, `None` for internal sends.
+
+    Returns `_QueueAccepted` when the data was buffered or sent, or
+    `_QueueEntryGone` when the entry no longer exists (the queue was torn
+    down by `close()`).
     """
-    if _closed then return end
     let index = (id - _head_id).usize()
     try
       let entry = _entries(index)?
       if (id == _head_id) and (not _throttled) then
         _notify._flush_data(data, token)
+        // Re-entrant close from _flush_data may have cleared entries.
+        if _entries.size() == 0 then return _QueueEntryGone end
       else
         entry.data.push(data)
         entry.tokens.push(token)
       end
+      _QueueAccepted
     else
-      _Unreachable()
+      if _entries.size() == 0 then
+        _QueueEntryGone
+      else
+        _Unreachable()
+        _QueueEntryGone
+      end
     end
 
-  fun ref finish(id: U64) =>
+  fun ref finish(id: U64): _QueueResult =>
     """
     Mark a request's response as complete.
 
@@ -115,8 +147,11 @@ class ref _ResponseQueue
     deferred: it stays at the head and advances on the next `unthrottle()`,
     so its data is never dropped. A non-head entry is flushed when it
     becomes the head.
+
+    Returns `_QueueAccepted` when the entry was marked finished, or
+    `_QueueEntryGone` when the entry no longer exists (the queue was torn
+    down by `close()`).
     """
-    if _closed then return end
     let index = (id - _head_id).usize()
     try
       let entry = _entries(index)?
@@ -124,8 +159,14 @@ class ref _ResponseQueue
       if id == _head_id then
         _pump_head()
       end
+      _QueueAccepted
     else
-      _Unreachable()
+      if _entries.size() == 0 then
+        _QueueEntryGone
+      else
+        _Unreachable()
+        _QueueEntryGone
+      end
     end
 
   fun ref throttle() =>
@@ -139,24 +180,20 @@ class ref _ResponseQueue
     Release backpressure — flush any buffered data for the head entry.
     """
     _throttled = false
-    if _closed then return end
     _pump_head()
 
   fun ref close() =>
     """
-    Discard all pending entries. All subsequent operations become no-ops.
+    Discard all pending entries.
+
+    Pure teardown — clears the entry array. Subsequent `send_data` and
+    `finish` calls report `_QueueEntryGone` because the entries are gone.
 
     Safe to call from within `_response_complete` or `_flush_data`
-    callbacks — the `_closed` flag stops cascading flushes.
+    callbacks — the empty entries array stops cascading flushes in
+    `_pump_head`.
     """
-    _closed = true
     _entries.clear()
-
-  fun is_closed(): Bool =>
-    """
-    Whether the queue is closed. A closed queue discards all work.
-    """
-    _closed
 
   fun pending(): USize =>
     """
@@ -190,7 +227,8 @@ class ref _ResponseQueue
 
     THE single place head data is flushed. Stops early on:
 
-    - close (`_closed`) — the connection is gone, nothing more to send;
+    - entries gone (`_entries.size() == 0`) — `close()` cleared the array,
+      nothing more to send;
     - re-throttle (`_throttled`) — `TCPConnection.send()`, called inside
       `_flush_data`, synchronously fires `_on_throttled` on a partial write
       / EWOULDBLOCK, which re-enters as `throttle()` and re-sets `_throttled`
@@ -201,21 +239,17 @@ class ref _ResponseQueue
     or close. `_advance_head` is only reached here, only when the buffer is
     empty and we are not throttled.
     """
-    while (not _closed) and (not _throttled) and (_entries.size() > 0) do
+    while (not _throttled) and (_entries.size() > 0) do
       try
         let entry = _entries(0)?
-        // Flush buffered data (data and tokens in lockstep) until drained,
-        // closed, or re-throttled.
         while entry.data.size() > 0 do
           try
             _notify._flush_data(entry.data.shift()?, entry.tokens.shift()?)
           else
             _Unreachable()
           end
-          if _closed or _throttled then return end
+          if (_entries.size() == 0) or _throttled then return end
         end
-        // Buffer drained. Advance if finished; otherwise wait for more
-        // send_data/finish on this head.
         if entry.finished then
           _advance_head()
         else

--- a/stallion/_test.pony
+++ b/stallion/_test.pony
@@ -208,7 +208,8 @@ actor \nodoc\ Main is TestList
     test(_TestQueueTokenNoneForInternalSends)
     test(_TestQueueTokenThrottle)
     test(_TestQueueTokenClose)
-    test(_TestQueueIsClosed)
+    test(_TestQueueHasEntry)
+    test(_TestQueueCloseDiscardsEntries)
 
     // Pipelining and streaming integration tests
     test(_TestPipelineCorrectness)

--- a/stallion/_test_response_queue.pony
+++ b/stallion/_test_response_queue.pony
@@ -1063,17 +1063,46 @@ primitive \nodoc\ _PermutationGenerator
           consume result
         })
 
-class \nodoc\ iso _TestQueueIsClosed is UnitTest
+class \nodoc\ iso _TestQueueHasEntry is UnitTest
   """
-  Verify is_closed() reports false on a fresh queue and true after close().
+  Verify has_entry returns true for a registered ID and false after close().
   """
-  fun name(): String => "response-queue/is_closed"
+  fun name(): String => "response-queue/has-entry"
 
   fun apply(h: TestHelper) =>
     let queue = _ResponseQueue(_TestQueueNotify)
+    let id = queue.register(true)
 
-    h.assert_false(queue.is_closed(), "a fresh queue is not closed")
+    h.assert_true(queue.has_entry(id), "registered ID has an entry")
+    h.assert_false(queue.has_entry(id + 10), "unregistered ID has no entry")
 
     queue.close()
 
-    h.assert_true(queue.is_closed(), "a queue is closed after close()")
+    h.assert_false(queue.has_entry(id), "no entry after close")
+
+class \nodoc\ iso _TestQueueCloseDiscardsEntries is UnitTest
+  """
+  Verify that close() clears all entries: send_data and finish report
+  `_QueueEntryGone` afterward.
+  """
+  fun name(): String => "response-queue/close-discards-entries"
+
+  fun apply(h: TestHelper) =>
+    let queue = _ResponseQueue(_TestQueueNotify)
+    let id = queue.register(true)
+
+    h.assert_is[_QueueResult](
+      _QueueAccepted,
+      queue.send_data(id, "data"),
+      "send_data accepts before close")
+
+    queue.close()
+
+    h.assert_is[_QueueResult](
+      _QueueEntryGone,
+      queue.send_data(id, "data"),
+      "send_data reports entry gone after close")
+    h.assert_is[_QueueResult](
+      _QueueEntryGone,
+      queue.finish(id),
+      "finish reports entry gone after close")

--- a/stallion/http_server.pony
+++ b/stallion/http_server.pony
@@ -410,9 +410,6 @@ class HTTPServer is
     `on_chunk_sent()` is delivered for this connection — and delivers
     `on_closed()` to the receiver.
     """
-    match _parser
-    | let p: _RequestParser => p.stop()
-    end
     match _queue
     | let q: _ResponseQueue => q.close()
     end
@@ -587,8 +584,8 @@ class HTTPServer is
     Safe to call from within queue callbacks (e.g., `_response_complete`
     with `keep_alive=false`): a second close is a no-op in every state
     that is not `_Active`. After this, any Responders the actor still
-    holds become inert — their methods call through to the queue, which
-    is closed and no-ops everything.
+    holds become inert — their methods submit to a queue whose entries
+    are gone and get `_QueueEntryGone` back.
     """
     _state.close(this)
 
@@ -598,9 +595,6 @@ class HTTPServer is
 
     Reached only from `_Active`, so this runs at most once per connection.
     """
-    match _parser
-    | let p: _RequestParser => p.stop()
-    end
     match _queue
     | let q: _ResponseQueue => q.close()
     end

--- a/stallion/responder.pony
+++ b/stallion/responder.pony
@@ -84,9 +84,11 @@ class ref Responder
     """
     match _state
     | _ResponderNotResponded =>
-      _state = _ResponderComplete
-      _queue.send_data(_id, raw)
-      _queue.finish(_id)
+      match _queue.send_data(_id, raw)
+      | _QueueAccepted =>
+        _state = _ResponderComplete
+        _queue.finish(_id)
+      end
     end
 
   fun ref start_chunked_response(
@@ -117,9 +119,7 @@ class ref Responder
     """
     match _state
     | _ResponderNotResponded =>
-      if _queue.is_closed() then return ConnectionClosed end
-
-      // HTTP/1.0 does not support chunked transfer encoding
+      if not _queue.has_entry(_id) then return ConnectionClosed end
       if _version is HTTP10 then return ChunkedNotSupported end
 
       _state = _ResponderStreaming
@@ -136,15 +136,12 @@ class ref Responder
           new_h
         end
       let response = _ResponseSerializer(status, h, None, _version)
-      _queue.send_data(_id, consume response)
-      // send_data can close the connection on its way out: a send error
-      // closes the queue before it returns. Nothing was started in that
-      // case, so report it and leave the Responder where it began.
-      if _queue.is_closed() then
+      match \exhaustive\ _queue.send_data(_id, consume response)
+      | _QueueAccepted => StreamingStarted
+      | _QueueEntryGone =>
         _state = _ResponderNotResponded
-        return ConnectionClosed
+        ConnectionClosed
       end
-      StreamingStarted
     else
       AlreadyResponded
     end
@@ -170,7 +167,6 @@ class ref Responder
     """
     match _state
     | _ResponderStreaming =>
-      if _queue.is_closed() then return None end
       let size: USize =
         match \exhaustive\ data
         | let s: String val => s.size()
@@ -179,12 +175,10 @@ class ref Responder
       if size == 0 then return None end
       let token = _queue.create_chunk_token()
       let chunk = _ChunkedEncoder.chunk(data)
-      _queue.send_data(_id, consume chunk, token)
-      // send_data can close the connection on its way out: a send error
-      // closes the queue before it returns. The chunk went nowhere, so hand
-      // back no token rather than one that will never be reported.
-      if _queue.is_closed() then return None end
-      token
+      match \exhaustive\ _queue.send_data(_id, consume chunk, token)
+      | _QueueAccepted => token
+      | _QueueEntryGone => None
+      end
     else
       None
     end
@@ -198,7 +192,9 @@ class ref Responder
     """
     match _state
     | _ResponderStreaming =>
-      _state = _ResponderComplete
-      _queue.send_data(_id, _ChunkedEncoder.final_chunk())
-      _queue.finish(_id)
+      match _queue.send_data(_id, _ChunkedEncoder.final_chunk())
+      | _QueueAccepted =>
+        _state = _ResponderComplete
+        _queue.finish(_id)
+      end
     end


### PR DESCRIPTION
The queue carried a `_closed` flag that duplicated the connection state machine's authority on whether the connection was alive. Callers pre-checked `is_closed()` before every operation, and the queue guarded `send_data`, `finish`, and `unthrottle` on entry.

`send_data` and `finish` now return `_QueueResult` — `_QueueAccepted` or `_QueueEntryGone`. All four Responder methods that call the queue (`start_chunked_response`, `send_chunk`, `respond`, `finish_response`) match on the result: the first two propagate the outcome to the caller, the second two skip state transition and the `finish()` call when the entry is gone.

`close()` is pure teardown: it clears entries. The empty array is the structural signal that stops cascading flushes in `_pump_head` and causes subsequent operations to report `_QueueEntryGone`. A failed `_entries(index)?` with entries still present is a bogus ID — `_Unreachable()`, same as before.

The `p.stop()` calls in `_handle_closed` and `_start_close` were a second redundant copy of the same "stop accepting work" fact. After either transition, the state machine blocks data from reaching the parser, making the parser's `_failed` flag redundant on those paths. `p.stop()` remains in `parse_error`, where it short-circuits a parse loop during a handler rejection.
