### PR TITLE
Fix pony-lint findings for ponyc 0.69.0

### DIFF
--- a/.github/workflows/breakage-against-ponyc-latest.yml
+++ b/.github/workflows/breakage-against-ponyc-latest.yml
@@ -9,6 +9,27 @@ permissions:
   packages: read
 
 jobs:
+  pony-lint:
+    name: Lint against ponyc main
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/ponylang/shared-docker-ci-standard-builder-with-libressl-4.2.1:nightly
+    steps:
+      - uses: actions/checkout@v6.0.2
+      - name: Lint
+        run: make lint
+      - name: Send alert on failure
+        if: ${{ failure() }}
+        uses: zulip/github-actions-zulip/send-message@bd8ec52de371d139ae8313661b7d8318c19266aa
+        with:
+          api-key: ${{ secrets.ZULIP_SCHEDULED_JOB_FAILURE_API_KEY }}
+          email: ${{ secrets.ZULIP_SCHEDULED_JOB_FAILURE_EMAIL }}
+          organization-url: 'https://ponylang.zulipchat.com/'
+          to: notifications
+          type: stream
+          topic: ${{ github.repository }} scheduled job failure
+          content: ${{ github.server_url}}/${{ github.repository }}/actions/runs/${{ github.run_id }} failed.
+
   vs-ponyc-latest:
     name: Test against ponyc main
     runs-on: ubuntu-latest

--- a/.github/workflows/pony-lint.yml
+++ b/.github/workflows/pony-lint.yml
@@ -17,7 +17,7 @@ jobs:
     name: Lint Pony source
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/ponylang/shared-docker-ci-standard-builder:release
+      image: ghcr.io/ponylang/shared-docker-ci-standard-builder:nightly
     steps:
       - uses: actions/checkout@v6.0.2
       - name: Lint

--- a/stallion/_chunk_header.pony
+++ b/stallion/_chunk_header.pony
@@ -64,8 +64,8 @@ primitive _ChunkHeader
     if s.size() == 0 then return false end
     match \exhaustive\ try s.find("=")?.usize() else None end
     | let eq: USize =>
-      _Token.valid(_OWS.trim(s.trim(0, eq)))
-        and _valid_ext_val(_OWS.trim(s.trim(eq + 1)))
+      _Token.valid(_OWS.trim(s.trim(0, eq))) and
+        _valid_ext_val(_OWS.trim(s.trim(eq + 1)))
     | None =>
       _Token.valid(s)
     end
@@ -104,18 +104,18 @@ primitive _ChunkHeader
     false
 
   fun _is_hexdig(b: U8): Bool =>
-    ((b >= '0') and (b <= '9'))
-      or ((b >= 'a') and (b <= 'f'))
-      or ((b >= 'A') and (b <= 'F'))
+    ((b >= '0') and (b <= '9')) or
+      ((b >= 'a') and (b <= 'f')) or
+      ((b >= 'A') and (b <= 'F'))
 
   fun _qdtext(c: U8): Bool =>
     """
     HTAB / SP / %x21 / %x23-5B / %x5D-7E / obs-text.
     """
-    (c == 0x09) or (c == 0x20) or (c == 0x21)
-      or ((c >= 0x23) and (c <= 0x5B))
-      or ((c >= 0x5D) and (c <= 0x7E))
-      or (c >= 0x80)
+    (c == 0x09) or (c == 0x20) or (c == 0x21) or
+      ((c >= 0x23) and (c <= 0x5B)) or
+      ((c >= 0x5D) and (c <= 0x7E)) or
+      (c >= 0x80)
 
   fun _quoted_pair_octet(c: U8): Bool =>
     """

--- a/stallion/_error_response.pony
+++ b/stallion/_error_response.pony
@@ -13,20 +13,20 @@ primitive _ErrorResponse
     """
     match err
     | TooLarge =>
-      "HTTP/1.1 431 Request Header Fields Too Large\r\n"
-        + "Connection: close\r\nContent-Length: 0\r\n\r\n"
+      "HTTP/1.1 431 Request Header Fields Too Large\r\n" +
+        "Connection: close\r\nContent-Length: 0\r\n\r\n"
     | BodyTooLarge =>
-      "HTTP/1.1 413 Payload Too Large\r\n"
-        + "Connection: close\r\nContent-Length: 0\r\n\r\n"
+      "HTTP/1.1 413 Payload Too Large\r\n" +
+        "Connection: close\r\nContent-Length: 0\r\n\r\n"
     | InvalidVersion =>
-      "HTTP/1.1 505 HTTP Version Not Supported\r\n"
-        + "Connection: close\r\nContent-Length: 0\r\n\r\n"
+      "HTTP/1.1 505 HTTP Version Not Supported\r\n" +
+        "Connection: close\r\nContent-Length: 0\r\n\r\n"
     | UnsupportedTransferEncoding | UnknownMethod =>
-      "HTTP/1.1 501 Not Implemented\r\n"
-        + "Connection: close\r\nContent-Length: 0\r\n\r\n"
+      "HTTP/1.1 501 Not Implemented\r\n" +
+        "Connection: close\r\nContent-Length: 0\r\n\r\n"
     else
-      "HTTP/1.1 400 Bad Request\r\n"
-        + "Connection: close\r\nContent-Length: 0\r\n\r\n"
+      "HTTP/1.1 400 Bad Request\r\n" +
+        "Connection: close\r\nContent-Length: 0\r\n\r\n"
     end
 
   fun no_response(): String val =>
@@ -35,5 +35,5 @@ primitive _ErrorResponse
 
     This is a server error (500) — the connection closes after sending.
     """
-    "HTTP/1.1 500 Internal Server Error\r\n"
-      + "Connection: close\r\nContent-Length: 0\r\n\r\n"
+    "HTTP/1.1 500 Internal Server Error\r\n" +
+      "Connection: close\r\nContent-Length: 0\r\n\r\n"

--- a/stallion/_host_value.pony
+++ b/stallion/_host_value.pony
@@ -188,10 +188,10 @@ primitive _HostValue
     // Lenient: only HEXDIG, ':', and '.' (for IPv4-mapped forms).
     for c in content.values() do
       if not (
-        ((c >= '0') and (c <= '9'))
-          or ((c >= 'A') and (c <= 'F'))
-          or ((c >= 'a') and (c <= 'f'))
-          or (c == ':') or (c == '.'))
+        ((c >= '0') and (c <= '9')) or
+          ((c >= 'A') and (c <= 'F')) or
+          ((c >= 'a') and (c <= 'f')) or
+          (c == ':') or (c == '.'))
       then
         return false
       end
@@ -263,17 +263,17 @@ primitive _HostValue
     true
 
   fun _is_hexdig(c: U8): Bool =>
-    ((c >= '0') and (c <= '9'))
-      or ((c >= 'A') and (c <= 'F'))
-      or ((c >= 'a') and (c <= 'f'))
+    ((c >= '0') and (c <= '9')) or
+      ((c >= 'A') and (c <= 'F')) or
+      ((c >= 'a') and (c <= 'f'))
 
   fun _is_unreserved(c: U8): Bool =>
-    ((c >= 'A') and (c <= 'Z'))
-      or ((c >= 'a') and (c <= 'z'))
-      or ((c >= '0') and (c <= '9'))
-      or (c == '-') or (c == '.') or (c == '_') or (c == '~')
+    ((c >= 'A') and (c <= 'Z')) or
+      ((c >= 'a') and (c <= 'z')) or
+      ((c >= '0') and (c <= '9')) or
+      (c == '-') or (c == '.') or (c == '_') or (c == '~')
 
   fun _is_sub_delim(c: U8): Bool =>
-    (c == '!') or (c == '$') or (c == '&') or (c == '\'')
-      or (c == '(') or (c == ')') or (c == '*') or (c == '+')
-      or (c == ',') or (c == ';') or (c == '=')
+    (c == '!') or (c == '$') or (c == '&') or (c == '\'') or
+      (c == '(') or (c == ')') or (c == '*') or (c == '+') or
+      (c == ',') or (c == ';') or (c == '=')

--- a/stallion/_mort.pony
+++ b/stallion/_mort.pony
@@ -10,9 +10,9 @@ primitive _IllegalState
   fun apply(loc: SourceLoc = __loc) =>
     @fprintf(
       @pony_os_stderr(),
-      ("An illegal state was encountered in %s at line %s\n"
-        + "Please open an issue at "
-        + "https://github.com/ponylang/stallion/issues")
+      ("An illegal state was encountered in %s at line %s\n" +
+        "Please open an issue at " +
+        "https://github.com/ponylang/stallion/issues")
         .cstring(),
       loc.file().cstring(),
       loc.line().string().cstring())
@@ -26,9 +26,9 @@ primitive _Unreachable
   fun apply(loc: SourceLoc = __loc) =>
     @fprintf(
       @pony_os_stderr(),
-      ("The unreachable was reached in %s at line %s\n"
-        + "Please open an issue at "
-        + "https://github.com/ponylang/stallion/issues")
+      ("The unreachable was reached in %s at line %s\n" +
+        "Please open an issue at " +
+        "https://github.com/ponylang/stallion/issues")
         .cstring(),
       loc.file().cstring(),
       loc.line().string().cstring())

--- a/stallion/_parser_state.pony
+++ b/stallion/_parser_state.pony
@@ -129,8 +129,8 @@ class _ExpectHeaders is _ParserState
     elseif f.name == "transfer-encoding" then
       _has_transfer_encoding = true
       _te_well_formed =
-        _TransferEncoding.append_codings(f.value, _te_codings)
-          and _te_well_formed
+        _TransferEncoding.append_codings(f.value, _te_codings) and
+          _te_well_formed
     end
     None
 

--- a/stallion/_request_line.pony
+++ b/stallion/_request_line.pony
@@ -77,9 +77,9 @@ primitive _RequestLine
     """
     if s.size() != 8 then return None end
     try
-      if (s(0)? == 'H') and (s(1)? == 'T') and (s(2)? == 'T')
-        and (s(3)? == 'P') and (s(4)? == '/') and (s(5)? == '1')
-        and (s(6)? == '.')
+      if (s(0)? == 'H') and (s(1)? == 'T') and (s(2)? == 'T') and
+        (s(3)? == 'P') and (s(4)? == '/') and (s(5)? == '1') and
+        (s(6)? == '.')
       then
         match s(7)?
         | '1' => HTTP11

--- a/stallion/_test_chunked_encoder.pony
+++ b/stallion/_test_chunked_encoder.pony
@@ -33,8 +33,8 @@ class \nodoc\ iso _PropertyChunkedEncoderFormat
     var found = false
     while crlf_pos < (encoded_val.size() - 1) do
       try
-        if (encoded_val(crlf_pos)? == '\r')
-          and (encoded_val(crlf_pos + 1)? == '\n')
+        if (encoded_val(crlf_pos)? == '\r') and
+          (encoded_val(crlf_pos + 1)? == '\n')
         then
           found = true
           break

--- a/stallion/_test_connection_factory.pony
+++ b/stallion/_test_connection_factory.pony
@@ -147,8 +147,8 @@ actor \nodoc\ _TestHTTPClient is
 
     // Verify status line contains expected status
     if not response.contains(_expected_status) then
-      _h.fail("Expected status '" + _expected_status
-        + "' not found in response:\n" + response)
+      _h.fail("Expected status '" + _expected_status +
+        "' not found in response:\n" + response)
       _h.complete(false)
       return
     end
@@ -157,8 +157,8 @@ actor \nodoc\ _TestHTTPClient is
     match _expected_body
     | let body: String val =>
       if not response.contains(body) then
-        _h.fail("Expected body '" + body
-          + "' not found in response:\n" + response)
+        _h.fail("Expected body '" + body +
+          "' not found in response:\n" + response)
         _h.complete(false)
         return
       end
@@ -202,8 +202,8 @@ actor \nodoc\ _TestHTTPClientExpectClose is
       if response.contains(_expected_status) then
         _response_ok = true
       else
-        _h.fail("Expected status '" + _expected_status
-          + "' not found in response:\n" + response)
+        _h.fail("Expected status '" + _expected_status +
+          "' not found in response:\n" + response)
         _h.complete(false)
       end
     end

--- a/stallion/_test_request_framing.pony
+++ b/stallion/_test_request_framing.pony
@@ -79,8 +79,8 @@ class \nodoc\ val _Signature
     body = notify.collected_body_string()
 
   fun eq(other: _Signature): Bool =>
-    (requests == other.requests) and (completed == other.completed)
-      and (errors == other.errors) and (body == other.body)
+    (requests == other.requests) and (completed == other.completed) and
+      (errors == other.errors) and (body == other.body)
 
   fun show(): String =>
     "requests=" + requests.string() + " completed=" + completed.string() +

--- a/stallion/_test_server_close_ordering.pony
+++ b/stallion/_test_server_close_ordering.pony
@@ -296,8 +296,8 @@ actor \nodoc\ _TestChunkCountServer is HTTPServerActor
       try
         _h.assert_true(
           expected == _delivered(i)?,
-          "on_chunk_sent() token " + i.string() + " should be the token "
-            + "send_chunk() returned for that chunk")
+          "on_chunk_sent() token " + i.string() + " should be the token " +
+            "send_chunk() returned for that chunk")
       else
         _h.fail("missing on_chunk_sent() for chunk " + i.string())
       end

--- a/stallion/_test_server_conformance.pony
+++ b/stallion/_test_server_conformance.pony
@@ -122,8 +122,8 @@ class \nodoc\ iso _TestServerDuplicateHostWithBody is UnitTest
           _TestHTTPClient(
           h',
           port',
-          "POST / HTTP/1.1\r\nHost: a\r\nHost: b\r\n"
-            + "Content-Length: 3\r\n\r\nabc",
+          "POST / HTTP/1.1\r\nHost: a\r\nHost: b\r\n" +
+            "Content-Length: 3\r\n\r\nabc",
           "400 Bad Request",
           None)
         h'.dispose_when_done(client)
@@ -471,8 +471,8 @@ class \nodoc\ iso _TestServerAbsoluteFormPortMatch is UnitTest
           _TestHTTPClient(
           h',
           port',
-          "GET http://example.com:8080/ HTTP/1.1\r\n"
-            + "Host: example.com:8080\r\n\r\n",
+          "GET http://example.com:8080/ HTTP/1.1\r\n" +
+            "Host: example.com:8080\r\n\r\n",
           "200 OK",
           None)
         h'.dispose_when_done(client)
@@ -499,8 +499,8 @@ class \nodoc\ iso _TestServerAbsoluteFormPortMismatch is UnitTest
           _TestHTTPClient(
           h',
           port',
-          "GET http://example.com:8080/ HTTP/1.1\r\n"
-            + "Host: example.com:9090\r\n\r\n",
+          "GET http://example.com:8080/ HTTP/1.1\r\n" +
+            "Host: example.com:9090\r\n\r\n",
           "400 Bad Request",
           None)
         h'.dispose_when_done(client)
@@ -641,8 +641,8 @@ class \nodoc\ iso _TestServerConnectUserinfo is UnitTest
           _TestHTTPClient(
           h',
           port',
-          "CONNECT user@example.com:443 HTTP/1.1\r\n"
-            + "Host: example.com:443\r\n\r\n",
+          "CONNECT user@example.com:443 HTTP/1.1\r\n" +
+            "Host: example.com:443\r\n\r\n",
           "400 Bad Request",
           None)
         h'.dispose_when_done(client)

--- a/stallion/_test_server_pipeline.pony
+++ b/stallion/_test_server_pipeline.pony
@@ -271,9 +271,9 @@ actor \nodoc\ _TestPipelineClient is
         if (pos0 < pos1) and (pos1 < pos2) then
           _h.complete(true)
         else
-          _h.fail("Responses arrived out of order: pos0="
-            + pos0.string() + " pos1=" + pos1.string()
-            + " pos2=" + pos2.string())
+          _h.fail("Responses arrived out of order: pos0=" +
+            pos0.string() + " pos1=" + pos1.string() +
+            " pos2=" + pos2.string())
           _h.complete(false)
         end
       else
@@ -374,8 +374,8 @@ actor \nodoc\ _TestStreamClient is
     if r.contains("0\r\n\r\n") then
       _completed = true
       // Verify Transfer-Encoding: chunked header (case-insensitive check)
-      if not (r.contains("Transfer-Encoding: chunked")
-        or r.contains("transfer-encoding: chunked"))
+      if not (r.contains("Transfer-Encoding: chunked") or
+        r.contains("transfer-encoding: chunked"))
       then
         _h.fail(
           "Missing Transfer-Encoding: chunked header in:\n" + r)
@@ -383,8 +383,8 @@ actor \nodoc\ _TestStreamClient is
         return lori.KeepReading
       end
       // Verify chunk data is present
-      if not (r.contains("chunk1") and r.contains("chunk2")
-        and r.contains("chunk3"))
+      if not (r.contains("chunk1") and r.contains("chunk2") and
+        r.contains("chunk3"))
       then
         _h.fail("Missing chunk data in:\n" + r)
         _h.complete(false)
@@ -398,8 +398,8 @@ actor \nodoc\ _TestStreamClient is
     // A close after the test's outcome is decided is not a failure.
     if not _completed then
       _h.fail(
-        "Connection closed before the chunked response completed:\n"
-          + _response)
+        "Connection closed before the chunked response completed:\n" +
+          _response)
       _h.complete(false)
     end
 
@@ -653,8 +653,8 @@ actor \nodoc\ _TestChunkSentClient is
     // Check for terminal chunk
     if r.contains("0\r\n\r\n") then
       _completed = true
-      if not (r.contains("Transfer-Encoding: chunked")
-        or r.contains("transfer-encoding: chunked"))
+      if not (r.contains("Transfer-Encoding: chunked") or
+        r.contains("transfer-encoding: chunked"))
       then
         _h.fail(
           "Missing Transfer-Encoding: chunked header in:\n" + r)
@@ -662,8 +662,8 @@ actor \nodoc\ _TestChunkSentClient is
         return lori.KeepReading
       end
       // Verify all 3 chunks arrived
-      if not (r.contains("cs-chunk-1") and r.contains("cs-chunk-2")
-        and r.contains("cs-chunk-3"))
+      if not (r.contains("cs-chunk-1") and r.contains("cs-chunk-2") and
+        r.contains("cs-chunk-3"))
       then
         _h.fail("Missing chunk data in:\n" + r)
         _h.complete(false)
@@ -677,8 +677,8 @@ actor \nodoc\ _TestChunkSentClient is
     // A close after the test's outcome is decided is not a failure.
     if not _completed then
       _h.fail(
-        "Connection closed before the chunked response completed:\n"
-          + _response)
+        "Connection closed before the chunked response completed:\n" +
+          _response)
       _h.complete(false)
     end
 

--- a/stallion/_test_server_ssl.pony
+++ b/stallion/_test_server_ssl.pony
@@ -264,8 +264,8 @@ actor \nodoc\ _TestSSLHTTPClient is
     let response: String val = _response.clone()
 
     if not response.contains(_expected_status) then
-      _h.fail("Expected status '" + _expected_status
-        + "' not found in response:\n" + response)
+      _h.fail("Expected status '" + _expected_status +
+        "' not found in response:\n" + response)
       _h.complete(false)
       return
     end
@@ -273,8 +273,8 @@ actor \nodoc\ _TestSSLHTTPClient is
     match _expected_body
     | let body: String val =>
       if not response.contains(body) then
-        _h.fail("Expected body '" + body
-          + "' not found in response:\n" + response)
+        _h.fail("Expected body '" + body +
+          "' not found in response:\n" + response)
         _h.complete(false)
         return
       end
@@ -319,8 +319,8 @@ actor \nodoc\ _TestSSLHTTPClientExpectClose is
       if response.contains(_expected_status) then
         _response_ok = true
       else
-        _h.fail("Expected status '" + _expected_status
-          + "' not found in response:\n" + response)
+        _h.fail("Expected status '" + _expected_status +
+          "' not found in response:\n" + response)
         _h.complete(false)
       end
     end
@@ -431,16 +431,16 @@ actor \nodoc\ _TestSSLStreamClient is
     let r: String val = _response.clone()
     if r.contains("0\r\n\r\n") then
       _completed = true
-      if not (r.contains("Transfer-Encoding: chunked")
-        or r.contains("transfer-encoding: chunked"))
+      if not (r.contains("Transfer-Encoding: chunked") or
+        r.contains("transfer-encoding: chunked"))
       then
         _h.fail(
           "Missing Transfer-Encoding: chunked header in:\n" + r)
         _h.complete(false)
         return lori.KeepReading
       end
-      if not (r.contains("chunk1") and r.contains("chunk2")
-        and r.contains("chunk3"))
+      if not (r.contains("chunk1") and r.contains("chunk2") and
+        r.contains("chunk3"))
       then
         _h.fail("Missing chunk data in:\n" + r)
         _h.complete(false)
@@ -454,8 +454,8 @@ actor \nodoc\ _TestSSLStreamClient is
     // A close after the test's outcome is decided is not a failure.
     if not _completed then
       _h.fail(
-        "Connection closed before the chunked response completed:\n"
-          + _response)
+        "Connection closed before the chunked response completed:\n" +
+          _response)
       _h.complete(false)
     end
 

--- a/stallion/_test_server_timer.pony
+++ b/stallion/_test_server_timer.pony
@@ -197,9 +197,9 @@ class \nodoc\ iso _PropertyKeepAliveDecision
             let normalized = s.clone()
             normalized.strip(" \t")
             let nlower = normalized.lower()
-            (s, (not s.contains(","))
-              and (nlower != "close")
-              and (nlower != "keep-alive"))})
+            (s, (not s.contains(",")) and
+              (nlower != "close") and
+              (nlower != "keep-alive"))})
         .map[(String val | None)](
           {(s: String val): (String val | None) => s })
 

--- a/stallion/_test_set_cookie.pony
+++ b/stallion/_test_set_cookie.pony
@@ -152,8 +152,8 @@ class \nodoc\ iso _TestSetCookieKnownGood is UnitTest
       h.fail("__Host- with Domain: expected CookiePrefixViolation")
     | let e: CookiePrefixViolation => None // expected
     | let e: SetCookieBuildError =>
-      h.fail("__Host- with Domain: expected CookiePrefixViolation, got "
-        + e.string())
+      h.fail("__Host- with Domain: expected CookiePrefixViolation, got " +
+        e.string())
     end
 
     // Invalid: __Host- without Path="/"
@@ -164,8 +164,8 @@ class \nodoc\ iso _TestSetCookieKnownGood is UnitTest
       h.fail("__Host- with Path=/app: expected CookiePrefixViolation")
     | let e: CookiePrefixViolation => None
     | let e: SetCookieBuildError =>
-      h.fail("__Host- with Path=/app: expected CookiePrefixViolation, got "
-        + e.string())
+      h.fail("__Host- with Path=/app: expected CookiePrefixViolation, got " +
+        e.string())
     end
 
     // Invalid: __Host- without Secure
@@ -177,8 +177,8 @@ class \nodoc\ iso _TestSetCookieKnownGood is UnitTest
       h.fail("__Host- without Secure: expected CookiePrefixViolation")
     | let e: CookiePrefixViolation => None
     | let e: SetCookieBuildError =>
-      h.fail("__Host- without Secure: expected CookiePrefixViolation, got "
-        + e.string())
+      h.fail("__Host- without Secure: expected CookiePrefixViolation, got " +
+        e.string())
     end
 
     // Invalid: __Host- without any Path set (defaults to None)
@@ -187,8 +187,8 @@ class \nodoc\ iso _TestSetCookieKnownGood is UnitTest
       h.fail("__Host- no path: expected CookiePrefixViolation")
     | let e: CookiePrefixViolation => None
     | let e: SetCookieBuildError =>
-      h.fail("__Host- no path: expected CookiePrefixViolation, got "
-        + e.string())
+      h.fail("__Host- no path: expected CookiePrefixViolation, got " +
+        e.string())
     end
 
   fun _test_secure_prefix(h: TestHelper) =>
@@ -211,8 +211,8 @@ class \nodoc\ iso _TestSetCookieKnownGood is UnitTest
       h.fail("__Secure- without Secure: expected CookiePrefixViolation")
     | let e: CookiePrefixViolation => None
     | let e: SetCookieBuildError =>
-      h.fail("__Secure- without Secure: expected CookiePrefixViolation, got "
-        + e.string())
+      h.fail("__Secure- without Secure: expected CookiePrefixViolation, got " +
+        e.string())
     end
 
   fun _test_omit_same_site(h: TestHelper) =>
@@ -267,8 +267,8 @@ class \nodoc\ iso _TestSetCookieErrors is UnitTest
     | let _: InvalidCookiePath => None // expected
     | let sc: SetCookie val => h.fail("invalid path CRLF: expected error")
     | let e: SetCookieBuildError =>
-      h.fail("invalid path CRLF: expected InvalidCookiePath, got "
-        + e.string())
+      h.fail("invalid path CRLF: expected InvalidCookiePath, got " +
+        e.string())
     end
 
     // Invalid domain (semicolon injection)
@@ -278,8 +278,8 @@ class \nodoc\ iso _TestSetCookieErrors is UnitTest
     | let _: InvalidCookieDomain => None // expected
     | let sc: SetCookie val => h.fail("invalid domain: expected error")
     | let e: SetCookieBuildError =>
-      h.fail("invalid domain: expected InvalidCookieDomain, got "
-        + e.string())
+      h.fail("invalid domain: expected InvalidCookieDomain, got " +
+        e.string())
     end
 
     // Invalid domain (control character)
@@ -289,8 +289,8 @@ class \nodoc\ iso _TestSetCookieErrors is UnitTest
     | let _: InvalidCookieDomain => None // expected
     | let sc: SetCookie val => h.fail("invalid domain CTL: expected error")
     | let e: SetCookieBuildError =>
-      h.fail("invalid domain CTL: expected InvalidCookieDomain, got "
-        + e.string())
+      h.fail("invalid domain CTL: expected InvalidCookieDomain, got " +
+        e.string())
     end
 
     // SameSite=None without Secure
@@ -302,8 +302,8 @@ class \nodoc\ iso _TestSetCookieErrors is UnitTest
     | let sc: SetCookie val =>
       h.fail("SameSite=None no Secure: expected error")
     | let e: SetCookieBuildError =>
-      h.fail("SameSite=None no Secure: expected SameSiteRequiresSecure, got "
-        + e.string())
+      h.fail("SameSite=None no Secure: expected SameSiteRequiresSecure, got " +
+        e.string())
     end
 
 class \nodoc\ iso _PropertySetCookieValidBuild


### PR DESCRIPTION
Fix pony-lint operator-spacing errors surfaced by ponyc 0.69.0 rules. Public API unchanged; no release note or CHANGELOG entry.