### PR TITLE
Require ponyc 0.69.1 or later

### DIFF
--- a/.release-notes/require-ponyc-0.69.1.md
+++ b/.release-notes/require-ponyc-0.69.1.md
@@ -1,0 +1,3 @@
+## Require ponyc 0.69.1 or later
+
+stallion now requires ponyc 0.69.1 or later, up from 0.67.0. Building stallion with an earlier ponyc fails to compile.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ stallion is beta quality software that will change frequently. Expect breaking c
 
 ## Installation
 
-* Requires ponyc 0.67.0 or later.
+* Requires ponyc 0.69.1 or later.
 * Install [corral](https://github.com/ponylang/corral)
 * `corral add github.com/ponylang/stallion.git --version 0.9.0`
 * `corral fetch` to fetch your dependencies

--- a/corral.json
+++ b/corral.json
@@ -13,7 +13,7 @@
   "deps": [
     {
       "locator": "github.com/ponylang/lori.git",
-      "version": "0.18.1"
+      "version": "0.19.0"
     },
     {
       "locator": "github.com/ponylang/ssl.git",

--- a/stallion/_test_server_ssl.pony
+++ b/stallion/_test_server_ssl.pony
@@ -554,6 +554,9 @@ actor \nodoc\ _TestPlainTCPClient is
 
   fun ref _connection(): lori.TCPConnection => _tcp_connection
 
+  fun ref _on_connection_failure(reason: lori.ConnectionFailureReason) =>
+    None
+
   fun ref _on_connected() =>
     _tcp_connection.send("NOT AN SSL HANDSHAKE\r\n")
 


### PR DESCRIPTION
Updates the lori dependency to 0.19.0 and bumps stallion's minimum ponyc to 0.69.1 to match.

lori 0.19.0 removed the default body for the `_on_connection_failure` client callback. stallion's production code already handled server start failure; only one test double needed the no-op callback added, matching lori's previous default. Behavior is unchanged.
